### PR TITLE
Fix: error 500 IIS

### DIFF
--- a/web.config
+++ b/web.config
@@ -3,6 +3,7 @@
     <system.webServer>
         <defaultDocument>
             <files>
+                <remove value="index.php" />
                 <add value="index.php" />
             </files>
         </defaultDocument>


### PR DESCRIPTION
When you have already set index.php as default, you get a error 500. 
So first you need to remove it then add it again. This is solving the error 500.
