### PR TITLE
fix for PHP warning "is_file(): open_basedir restriction in effect"

### DIFF
--- a/system/src/Grav/Common/Config.php
+++ b/system/src/Grav/Common/Config.php
@@ -232,10 +232,9 @@ class Config extends Data
         /** @var \DirectoryIterator $plugin */
         foreach ($iterator as $plugin) {
             $name = $plugin->getBasename();
-            $dir = $plugin->getPathname() ;
-            $file = $dir . DS . $name . YAML_EXT;
+            $file = $plugin->getPathname() . DS . $name . YAML_EXT;
 
-            if (!(is_dir($dir) && is_file($file))) {
+            if (!file_exists($file)) {
                 continue;
             }
 


### PR DESCRIPTION
Tracy constantly reported this error on my host:

``` plain
PHP Warning: is_file(): open_basedir restriction in effect. File(/home/users/.../user/plugins/.gitkeep/.gitkeep.yaml) is not within the allowed path(s): (/home/users/.../:/usr/share/pear/) in .../web/system/src/Grav/Common/Config.php:237
```

it has probably something to do with executing is_file() for a file in a non-existing dir
