### PR TITLE
fix for PHP warning "is_file(): open_basedir restriction in effect", round 2

### DIFF
--- a/system/src/Grav/Common/Config.php
+++ b/system/src/Grav/Common/Config.php
@@ -231,13 +231,12 @@ class Config extends Data
 
         /** @var \DirectoryIterator $plugin */
         foreach ($iterator as $plugin) {
-            $name = $plugin->getBasename();
-            $dir = $plugin->getPathname() ;
-            $file = $dir . DS . $name . YAML_EXT;
+            if ($iterator->isFile() || $iterator->isDot()) continue;
 
-            if (!(is_dir($dir) && is_file($file))) {
-                continue;
-            }
+            $name = $plugin->getBasename();
+            $file = $plugin->getPathname() . DS . $name . YAML_EXT;
+
+            if (!file_exists($file)) continue;
 
             $modified = filemtime($file);
             $plugins["plugins/{$name}"] = $modified;


### PR DESCRIPTION
This reverts commit d234b8e2128356a5d7c76e7d7048c21a26bd49c2 in PR #47 and returns back the is_dir() check.

I was working with too many hosts simultaneously and checked the file_exists() method on a host that worked perfectly even before the fix and as I updated the files on the problematic host the problems returned and the warning message changed to:

``` plain
PHP Warning: file_exists(): open_basedir restriction in effect. File(/home/users/.../web/user/plugins/.gitkeep/.gitkeep.yaml) is not within the allowed path(s): (/home/users/.../:/usr/share/pear/) in .../web/system/src/Grav/Common/Config.php:237
```

I'm sorry for this and have triple-checked that this code really finally fixes the issue.
