### PR TITLE
makes cli commands available on windows machines from site root

### DIFF
--- a/gpm.bat
+++ b/gpm.bat
@@ -1,0 +1,11 @@
+@echo off
+
+@setlocal
+
+set GPM_PATH=bin/
+
+if "%PHP_COMMAND%" == "" set PHP_COMMAND=php.exe
+
+"%PHP_COMMAND%" "%GPM_PATH%gpm" %*
+
+@endlocal

--- a/grav.bat
+++ b/grav.bat
@@ -1,0 +1,11 @@
+@echo off
+
+@setlocal
+
+set GRAV_PATH=bin/
+
+if "%PHP_COMMAND%" == "" set PHP_COMMAND=php.exe
+
+"%PHP_COMMAND%" "%GRAV_PATH%grav" %*
+
+@endlocal


### PR DESCRIPTION
I wanted to test the command line package manager and updates locally but the bin/gpm commands won't work on windows command line.

The 2 bat files let you run gpm and grav commands from the root of the site using a windows command prompt by dropping the path from the command

```
>cd /root/of/site
C:\root\of\site>gpm version
You are running Grav v0.9.6
```
