### PR TITLE
Update composer.json to not use GitHub API for rockettheme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "repositories": [
         {
             "type": "vcs",
+            "no-api": true,
             "url": "https://github.com/rockettheme/toolbox"
         }
     ],


### PR DESCRIPTION
I kept running into the following error when installing composer packages (as a part of  `bin/grav install`). It came down to my computer hitting the GitHub API rate limit for rockettheme. This changes rockettheme to not user the API and just download the repo directly.

`
Loading composer repositories with package information
Failed to clone the git@github.com:rockettheme/toolbox.git repository, try running in interactive mode so that you can enter your GitHub credentials


                                                                                                                                                     
  [RuntimeException]                                                                                                                                 
  Failed to execute git clone --mirror 'git@github.com:rockettheme/toolbox.git' '/root/.composer/cache/vcs/git-github.com-rockettheme-toolbox.git/'  
                                                                                                                                                     
                                                                                                                                                     
                                                                                                                                                     


install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [--ignore-platform-reqs] [packages1] ... [packagesN]


Failed to clone the git@github.com:rockettheme/toolbox.git repository, try running in interactive mode so that you can enter your GitHub credentials
`