### PR TITLE
Fixed twig url function to return empty if not found

### DIFF
--- a/system/src/Grav/Common/TwigExtension.php
+++ b/system/src/Grav/Common/TwigExtension.php
@@ -343,7 +343,7 @@ class TwigExtension extends \Twig_Extension
         /** @var Uri $uri */
         $uri = $this->grav['uri'];
 
-        return $uri->rootUrl($domain) .'/'. $locator->findResource($input, false);
+        return ($locator->findResource($input, false)) ? $uri->rootUrl($domain) .'/'. $locator->findResource($input, false) : '';
     }
 
     /**


### PR DESCRIPTION
- If not found the stream with locator return empty instead the root url.