### PR TITLE
Added 'enabled' option for summary and fixed query support in assets

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -193,13 +193,21 @@ class Assets
         } elseif (isset($this->collections[$asset])) {
             $this->add($this->collections[$asset], $priority, $pipeline);
         } else {
+            // Get extension
+            $extension = pathinfo($asset, PATHINFO_EXTENSION);
+
+            // Strip query from pathinfo extension
+            $query_pos = strpos($extension, '?');
+            if ($query_pos !== FALSE) {
+                $extension = substr($extension, 0, $query_pos);
+            }
+
             // JavaScript or CSS
-            $info = pathinfo($asset);
-            if (isset($info['extension'])) {
-                $ext = strtolower($info['extension']);
-                if ($ext === 'css') {
+            if (strlen($extension) > 0) {
+                $extension = strtolower($extension);
+                if ($extension === 'css') {
                     $this->addCss($asset, $priority, $pipeline);
-                } elseif ($ext === 'js') {
+                } elseif ($extension === 'js') {
                     $this->addJs($asset, $priority, $pipeline);
                 }
             }

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -288,7 +288,14 @@ class Page
      */
     public function summary($size = null)
     {
+        /** @var Config $config */
+        $config = self::$grav['config'];
         $content = $this->content();
+
+        // Return summary based on settings in site config file
+        if (!$config->get('site.summary.enabled', TRUE)) {
+            return $content;
+        }
 
         // Return calculated summary based on summary divider's position
         if (!$size && isset($this->summary_size)) {
@@ -296,14 +303,12 @@ class Page
         }
 
         // Return calculated summary based on setting in site config file
-        /** @var Config $config */
-        $config = self::$grav['config'];
-        if (!$size && $config->get('site.summary.size')) {
+        if (is_null($size) && $config->get('site.summary.size')) {
             $size = $config->get('site.summary.size');
         }
 
         // Return calculated summary based on defaults
-        if (!$size) {
+        if (!is_numeric($size) || ($size < 0)) {
             $size = 300;
         }
 


### PR DESCRIPTION
Dear Andy,

according to the recent forum post about adjusting summary lengths in Grav, I realized that there is no easy switch to easily enable or disable truncationation of summary contents. I think it is better to let the user decide, whether he or she wants a short version of his/her articles shown on frontpage or not.

Further I noticed, that using
```
$this->grav['assets']->add('https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML');
```
does not add the javascript as expected. That is a bug due to pathinfo which doesn't strip out the query of the asset.