### PR TITLE
Added merge config and disable function in "Plugin.php"

### DIFF
--- a/system/src/Grav/Common/Plugin.php
+++ b/system/src/Grav/Common/Plugin.php
@@ -1,6 +1,9 @@
 <?php
 namespace Grav\Common;
 
+use Grav\Common\Inflector;
+use Grav\Common\Data\Data;
+use Grav\Common\Page\Page;
 use Grav\Common\Config\Config;
 use RocketTheme\Toolbox\Event\EventDispatcher;
 use RocketTheme\Toolbox\Event\EventSubscriberInterface;
@@ -83,5 +86,75 @@ class Plugin implements EventSubscriberInterface
                 }
             }
         }
+    }
+
+    /**
+     * @param array $events
+     */
+    protected function disable(array $events)
+    {
+        /** @var EventDispatcher $dispatcher */
+        $dispatcher = $this->grav['events'];
+
+        foreach ($events as $eventName => $params) {
+            if (is_string($params)) {
+                $dispatcher->removeListener($eventName, array($this, $params));
+            } elseif (is_string($params[0])) {
+                $dispatcher->removeListener($eventName, array($this, $params[0]));
+            } else {
+                foreach ($params as $listener) {
+                    $dispatcher->removeListener($eventName, array($this, $listener[0]));
+                }
+            }
+        }
+    }
+
+    /**
+     * Merge global and page configurations.
+     *
+     * @param  Page   $page The page to merge the configurations with the
+     *                      plugin settings.
+     */
+    protected function mergeConfig(Page $page)
+    {
+        static $className;
+
+        if ( is_null($className) ) {
+            // Load configuration based on class name
+            $reflector = new \ReflectionClass($this);
+
+            // Remove namespace and trailing "Plugin" word
+            $name = $reflector->getShortName();
+            $name = substr($name, 0, -strlen('Plugin'));
+
+            // Guess configuration path from class name
+            $class_formats = array(
+                strtolower($name),                # all lowercased
+                Inflector::underscorize($name),   # underscored
+            );
+
+            $defaults = array();
+            // Try to load configuration
+            foreach ( $class_formats as $name ) {
+                if ( !is_null($this->config->get('plugins.' . $name, NULL)) ) {
+                    $className = $name;
+                    break;
+                }
+            }
+        }
+
+        // Get default plugin configurations and retrieve page header configuration
+        $plugin = (array) $this->config->get('plugins.' . $className, array());
+        $header = (array) $page->header();
+
+        // Create new config data class
+        $config = new Data();
+
+        // Join configuration options
+        $config->setDefaults($header);
+        $config->joinDefaults($className, $plugin);
+
+        // Return configurations as a new data config class
+        return $config;
     }
 }


### PR DESCRIPTION
While developing plugins I missed some really important functions again and again:

- There should be definetely a `disable` function doing right the opposite as 'enable'.
- I really like the idea of having global plugin configurations and page specific configurations. But since merging them together when needed is always a mess, I propose to add a `mergeConfig` function to the core functions. It will automatically load the plugins configurations merge them with the page header, returning back a new config data object. Usage in the plugin would be e.g.
```php
$config = $this->mergeConfig($page);
$option = $config->get('plugin_name.option');
```