### PR TITLE
Added summary option

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -308,25 +308,31 @@ class Page
             return $content;
         }
 
+        // Get summary size from site config's file
+        if (is_null($size)) {
+            $size = $config->get('site.summary.size', null);
+        }
+
         // Return calculated summary based on summary divider's position
-        if (!$size && isset($this->summary_size)) {
+        $format = $config->get('site.summary.format', 'short');
+        // Return entire page content on wrong/ unknown format
+        if (!in_array($format, array('short', 'long'))) {
+            return $content;
+        } elseif (($format === 'short') && isset($this->summary_size)) {
             return substr($content, 0, $this->summary_size);
         }
 
-        // Return calculated summary based on setting in site config file
-        if (is_null($size) && $config->get('site.summary.size')) {
-            $size = $config->get('site.summary.size');
+        // If the size is zero, return the entire page content
+        if ($size === 0) {
+            return $content;
         }
-
         // Return calculated summary based on defaults
-        if (!is_numeric($size) || ($size < 0)) {
+        elseif (!is_numeric($size) || ($size < 0)) {
             $size = 300;
         }
 
         return Utils::truncateHTML($content, $size);
     }
-
-
 
     /**
      * Gets and Sets the content based on content portion of the .md file


### PR DESCRIPTION
Dear Andy,

according to the forum post "Blog always shows ‘Continue Reading’" I considered now all use cases and propose to add an additional option to toggle between looking for and ignoring summary delimiters. Together with the other summary options, we finally can adjust it for all our needs:

```
summary:
  enabled: true | false       # enable or disable summary of page
  format: short | long        # if set to long a summary delimiter
                              # will be ignored; if set to short all
                              # content before the  summary delimiter
                              # will be shown until
  size: number                # positive number (set to zero to show 
                              # entire page content)
```
In short the use cases are:

1. `summary.enabled: false` -- Switch off page summary (the summary is the same as the page content)
2. `summary.enabled: true`:
	1. `summary.size: 0` -- No truncation of content happens except a summary delimiter can be found.
	2. `summary.size: num` -- Content greater than length **num** will be truncated. If a summary delimiter can be found, then the content will be truncated according to the summary delimiter.
	3. `summary.format: long` -- Any summary delimiter of the content will be ignored.
		1. `summary.size: 0` -- Summary equals the entire page content.
		2. `summary.size: num` -- The content will be truncated after **num** chars, independent of summary delimiter position.
	4. `summary.format: short` -- Detect and truncate content according to summary delimiter position.
		1. `summary.size: 0` -- If no summary delimiter was found, the summary equals the page content, otherwise the content will be truncated according to summary delimiter position.
		2. `summary.size: num` -- Always truncate the content after **num** chars. If a summary delimiter was found, then truncate content according to summary delimiter position.

Please review my suggestions. Maybe you also have ideas to tighten the code and perform some optimizations! :-)
