### PR TITLE
Fix to merge nested page options with default plugin configurations

### DIFF
--- a/system/src/Grav/Common/Plugin.php
+++ b/system/src/Grav/Common/Plugin.php
@@ -141,7 +141,7 @@ class Plugin implements EventSubscriberInterface
 
         // Get default plugin configurations and retrieve page header configuration
         if (isset($page->header()->$class_name)) {
-            $header =  array_merge($defaults, $page->header()->$class_name);
+            $header =  array_replace_recursive($defaults, $page->header()->$class_name);
         } else {
             $header = $defaults;
         }


### PR DESCRIPTION
Dear Andy,

today I encoutered a minor bug in the **Plugin** class, that nested page overwrite default plugin configurations although some are not set. For example consider we have the follwing configuration in our YAML file (see e.g. my DropCaps plugin):

```
titling:
  enabled: false              # Toggle to (de-)activate titling of text
  first_line: true            # Highlight first line of paragraph
  breakpoints: ".,:;!?'\"-"   # Specify which characters will end titling
```

We then want to enable `titling` in a page via

```
titling:
  enabled: true
```

When using `$config = $this->mergeConfig($page)` we finally would expect to get

```
titling:
  enabled: true     # <-- Changed via page header
  first_line: true
  breakpoints: ".,:;!?'\"-" 
```

but at the moment we get

```
titling:
  enabled: true
```

My PR will fix this to get the desired result from above. It would be nice to have this behavior in core.