### PR TITLE
fix for last modified time detection of page

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -523,6 +523,11 @@ class Pages
 
         /** @var \DirectoryIterator $file */
         foreach ($iterator as $file) {
+
+            if ($file->isDot()) {
+                continue;
+            }
+
             $name = $file->getFilename();
             $modified = $file->getMTime();
 
@@ -535,7 +540,7 @@ class Pages
                     $this->grav->fireEvent('onPageProcessed', new Event(['page' => $page]));
                 }
 
-            } elseif ($file->isDir() && !$file->isDot()) {
+            } elseif ($file->isDir()) {
 
                 if (!$page->path()) {
                     $page->path($file->getPath());

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -529,17 +529,23 @@ class Pages
             }
 
             $name = $file->getFilename();
-            $modified = $file->getMTime();
 
-            if ($file->isFile() && Utils::endsWith($name, CONTENT_EXT)) {
+            if ($file->isFile()) {
 
-                $page->init($file);
-                $content_exists = true;
-
-                if ($config->get('system.pages.events.page')) {
-                    $this->grav->fireEvent('onPageProcessed', new Event(['page' => $page]));
+                // Update the last modified if it's newer than already found
+                if ($file->getBasename() !== '.DS_Store' && ($modified = $file->getMTime()) > $last_modified) {
+                    $last_modified = $modified;
                 }
 
+                if (Utils::endsWith($name, CONTENT_EXT)) {
+
+                    $page->init($file);
+                    $content_exists = true;
+
+                    if ($config->get('system.pages.events.page')) {
+                        $this->grav->fireEvent('onPageProcessed', new Event(['page' => $page]));
+                    }
+                }
             } elseif ($file->isDir()) {
 
                 if (!$page->path()) {
@@ -558,11 +564,6 @@ class Pages
                 if ($config->get('system.pages.events.page')) {
                     $this->grav->fireEvent('onFolderProcessed', new Event(['page' => $page]));
                 }
-            }
-
-            // Update the last modified if it's newer than already found
-            if ($modified > $last_modified) {
-                $last_modified = $modified;
             }
         }
 


### PR DESCRIPTION
Prevent a page from taken it's parent into account when detecting modified time.