### PR TITLE
Changed Twig Link Regex which fixes #149 [Markdown Doesn't Handle [words](#)

### DIFF
--- a/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
+++ b/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
@@ -19,7 +19,7 @@ trait ParsedownGravTrait
     protected $pages_dir;
     protected $special_chars;
 
-    protected $twig_link_regex = '/\!*\[(?:.*)\]\(([{{|{%|{#].*[#}|%}|}}])\)/';
+    protected $twig_link_regex = '/\!*\[(?:.*)\]\((\{([\{%#])\s*(.*?)\s*(?:\2|\})\})\)/';
 
     /**
      * Initialiazation function to setup key variables needed by the MarkdownGravLinkTrait

--- a/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
+++ b/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
@@ -227,7 +227,7 @@ trait ParsedownGravTrait
             $url = parse_url(htmlspecialchars_decode($excerpt['element']['attributes']['href']));
 
             // if there is no scheme, the file is local
-            if (!isset($url['scheme'])) {
+            if (!isset($url['scheme']) and (count($url) > 0)) {
                 // convert the URl is required
                 $excerpt['element']['attributes']['href'] = $this->convertUrl(Uri::buildUrl($url));
             }


### PR DESCRIPTION
Hi @rhukster,

here is the PR of bugfix for issue https://github.com/getgrav/grav/issues/149 .