### PR TITLE
Use global composer install when available

### DIFF
--- a/bin/gpm
+++ b/bin/gpm
@@ -6,10 +6,13 @@ if (version_compare($ver = PHP_VERSION, $req = '5.4.0', '<')) {
     exit(sprintf("You are running PHP %s, but Grav needs at least PHP %s to run.\n", $ver, $req));
 }
 
+use Grav\Common\Composer;
+
 if (!file_exists(__DIR__ . '/../vendor')){
     // Before we can even start, we need to run composer first
+    $composer = Composer::getComposerLocation();
     echo "Preparing to install vendor dependencies...\n\n";
-    echo system('php bin/composer.phar --working-dir="'.__DIR__.'/../" --no-interaction --no-dev --prefer-dist -o install');
+    echo system('php '.$composer.' --working-dir="'.__DIR__.'/../" --no-interaction --no-dev --prefer-dist -o install');
     echo "\n\n";
 }
 

--- a/bin/grav
+++ b/bin/grav
@@ -6,10 +6,13 @@ if (version_compare($ver = PHP_VERSION, $req = '5.4.0', '<')) {
     exit(sprintf("You are running PHP %s, but Grav needs at least PHP %s to run.\n", $ver, $req));
 }
 
+use Grav\Common\Composer;
+
 if (!file_exists(__DIR__ . '/../vendor')){
     // Before we can even start, we need to run composer first
+    $composer = Composer::getComposerLocation();
     echo "Preparing to install vendor dependencies...\n\n";
-    echo system('php bin/composer.phar --working-dir="'.__DIR__.'/../" --no-interaction --no-dev --prefer-dist -o install');
+    echo system('php '.$composer.' --working-dir="'.__DIR__.'/../" --no-interaction --no-dev --prefer-dist -o install');
     echo "\n\n";
 }
 

--- a/system/src/Grav/Common/Composer.php
+++ b/system/src/Grav/Common/Composer.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Grav\Common;
+
+/**
+ * Offers composer helper methods.
+ *
+ * @author  eschmar
+ * @license MIT
+ */
+class Composer
+{
+    /**
+     * Returns the location of composer.
+     *
+     * @return string
+     */
+    public static function getComposerLocation()
+    {
+        // check for global composer install
+        $path = shell_exec("which composer");
+
+        // fall back to grav bundled composer
+        if (!$path || !preg_match('/(composer|composer\.phar)$/', $path)) {
+            $path =  "bin/composer.phar";
+        }
+
+        return $path;
+    }
+}

--- a/system/src/Grav/Console/ConsoleTrait.php
+++ b/system/src/Grav/Console/ConsoleTrait.php
@@ -2,6 +2,7 @@
 namespace Grav\Console;
 
 use Grav\Common\GravTrait;
+use Grav\Common\Composer;
 use Grav\Console\Cli\ClearCacheCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -85,11 +86,7 @@ trait ConsoleTrait
 
     public function composerUpdate($path, $action = 'install')
     {
-        $composer = shell_exec("which composer");
-        if (!$composer || !preg_match('/(composer|composer\.phar)$/', $composer)) {
-            $composer =  "bin/composer.phar";
-        }
-
+        $composer = Composer::getComposerLocation();
         return system('php '.$composer.' --working-dir="'.$path.'" --no-interaction --no-dev --prefer-dist -o '. $action);
     }
 

--- a/system/src/Grav/Console/ConsoleTrait.php
+++ b/system/src/Grav/Console/ConsoleTrait.php
@@ -85,7 +85,12 @@ trait ConsoleTrait
 
     public function composerUpdate($path, $action = 'install')
     {
-        return system('php bin/composer.phar --working-dir="'.$path.'" --no-interaction --no-dev --prefer-dist -o '. $action);
+        $composer = shell_exec("which composer");
+        if (!$composer || !preg_match('/(composer|composer\.phar)$/', $composer)) {
+            $composer =  "bin/composer.phar";
+        }
+
+        return system('php '.$composer.' --working-dir="'.$path.'" --no-interaction --no-dev --prefer-dist -o '. $action);
     }
 
     /**


### PR DESCRIPTION
To avoid the manual placement of composer into ``bin/``, this pull request proposes a centralised check for the availability of a global composer installation (and fallback to ``bin/composer.phar``).