### PR TITLE
Fix composer location method

### DIFF
--- a/system/src/Grav/Common/Composer.php
+++ b/system/src/Grav/Common/Composer.php
@@ -17,8 +17,12 @@ class Composer
      */
     public static function getComposerLocation()
     {
+        if (!function_exists('shell_exec')) {
+            return "bin/composer.phar";
+        }
+
         // check for global composer install
-        $path = trim(shell_exec("which composer"));
+        $path = trim(shell_exec("command -v composer"));
 
         // fall back to grav bundled composer
         if (!$path || !preg_match('/(composer|composer\.phar)$/', $path)) {

--- a/system/src/Grav/Common/Composer.php
+++ b/system/src/Grav/Common/Composer.php
@@ -18,7 +18,7 @@ class Composer
     public static function getComposerLocation()
     {
         // check for global composer install
-        $path = shell_exec("which composer");
+        $path = trim(shell_exec("which composer"));
 
         // fall back to grav bundled composer
         if (!$path || !preg_match('/(composer|composer\.phar)$/', $path)) {

--- a/system/src/Grav/Common/Composer.php
+++ b/system/src/Grav/Common/Composer.php
@@ -10,6 +10,9 @@ namespace Grav\Common;
  */
 class Composer
 {
+    /** @const Default composer location */
+    const DEFAULT_PATH = "bin/composer.phar";
+
     /**
      * Returns the location of composer.
      *
@@ -18,7 +21,7 @@ class Composer
     public static function getComposerLocation()
     {
         if (!function_exists('shell_exec')) {
-            return "bin/composer.phar";
+            return self::DEFAULT_PATH;
         }
 
         // check for global composer install
@@ -26,7 +29,7 @@ class Composer
 
         // fall back to grav bundled composer
         if (!$path || !preg_match('/(composer|composer\.phar)$/', $path)) {
-            $path =  "bin/composer.phar";
+            $path =  self::DEFAULT_PATH;
         }
 
         return $path;

--- a/system/src/Grav/Common/Composer.php
+++ b/system/src/Grav/Common/Composer.php
@@ -29,7 +29,7 @@ class Composer
 
         // fall back to grav bundled composer
         if (!$path || !preg_match('/(composer|composer\.phar)$/', $path)) {
-            $path =  self::DEFAULT_PATH;
+            $path = self::DEFAULT_PATH;
         }
 
         return $path;


### PR DESCRIPTION
My previous pull request #191 unfortunately had a small bug - the ``shell_exec`` call returned a string with an ending line break, thus breaking the command. Sorry for the trouble.