### PR TITLE
Add `onBuildPagesInitialized` event for memory & time consuming plugins

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -491,6 +491,12 @@ class Pages
             list($this->instances, $this->routes, $this->children, $taxonomy_map, $this->sort) = $cache->fetch($page_cache_id);
             if (!$this->instances) {
                 $this->grav['debugger']->addMessage('Page cache missed, rebuilding pages..');
+
+                // Fire event for memory and time consuming plugins...
+                if ($config->get('system.pages.events.page')) {
+                    $this->grav->fireEvent('onBuildPagesInitialized');
+                }
+
                 $this->recurse($pagesDir);
                 $this->buildRoutes();
 
@@ -505,6 +511,11 @@ class Pages
                 $taxonomy->taxonomy($taxonomy_map);
             }
         } else {
+            // Fire event for memory and time consuming plugins...
+            if ($config->get('system.pages.events.page')) {
+                $this->grav->fireEvent('onBuildPagesInitialized');
+            }
+
             $this->recurse($pagesDir);
             $this->buildRoutes();
         }


### PR DESCRIPTION
Hi @rhukster,

regarding our yesterday's chat, I prefer to add a new event `onBuildPagesInitialized` into core, to allow memory and time consuming plugins to be initialized only when it is really needed (e.g. a page has changed and therefore `onPageContentRaw` or `onPageContentProcessed` is triggered). Thus, when there are no changes the plugin isn't even initalized! This makes Grav (in my opinion) very powerful, since otherwise all plugins (even the time consuming ones) have to be initialized in the `onPluginsInitialized` event.

Ok, caching could be speed up the process. But not everything could be chached, i.e. when one can register additional classes and imho it would be the best, if even the caching (load and process data) should only happen, when there is actually some uncached pages. This saves memory and Grav delivers sites faster.