### PR TITLE
Modified `$page->summary()` to allow custom summary assignments

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -361,7 +361,7 @@ class Page
             $var = 300;
         }
 
-        return Utils::truncateHTML($content, $size);
+        return Utils::truncateHTML($content, $var);
     }
 
     /**

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -307,11 +307,10 @@ class Page
     /**
      * Get the summary.
      *
-     * @param  int|string  $var  Summary or max summary size.
-     *
+     * @param  int    $size Max summary size.
      * @return string
      */
-    public function summary($var = null)
+    public function summary($size = null)
     {
         /** @var Config $config */
         $config = self::getGrav()['config']->get('site.summary');
@@ -322,12 +321,6 @@ class Page
         // Return summary based on settings in site config file
         if (!$config['enabled']) {
             return $content;
-        }
-
-        // Set summary
-        if (is_string($var)) {
-            $this->summary = $var;
-            $var = null;
         }
 
         // Set up variables to process summary from page or from custom summary
@@ -349,19 +342,29 @@ class Page
         }
 
         // Get summary size from site config's file
-        if (is_null($var)) {
-            $var = $config['size'];
+        if (is_null($size)) {
+            $size = $config['size'];
         }
 
         // If the size is zero, return the entire page content
-        if ($var === 0) {
+        if ($size === 0) {
             return $content;
         // Return calculated summary based on defaults
-        } elseif (!is_numeric($var) || ($var < 0)) {
-            $var = 300;
+        } elseif (!is_numeric($size) || ($size < 0)) {
+            $size = 300;
         }
 
-        return Utils::truncateHTML($content, $var);
+        return Utils::truncateHTML($content, $size);
+    }
+
+    /**
+     * Sets the summary of the page
+     *
+     * @param string $var Summary
+     */
+    public function setSummary($summary)
+    {
+        $this->summary = $summary;
     }
 
     /**

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -61,6 +61,7 @@ class Page
     protected $header;
     protected $frontmatter;
     protected $content;
+    protected $summary;
     protected $raw_content;
     protected $pagination;
     protected $media;
@@ -164,6 +165,7 @@ class Page
             $this->id($this->modified().md5($this->filePath()));
             $this->header = null;
             $this->content = null;
+            $this->summary = null;
         }
         return $file ? $file->raw() : '';
     }
@@ -305,15 +307,14 @@ class Page
     /**
      * Get the summary.
      *
-     * @param int $size  Max summary size.
+     * @param  int|string  $var  Summary or max summary size.
+     *
      * @return string
      */
-    public function summary($size = null)
+    public function summary($var = null)
     {
         /** @var Config $config */
         $config = self::getGrav()['config']->get('site.summary');
-        $content = $this->content();
-
         if (isset($this->header->summary)) {
             $config = array_merge($config, $this->header->summary);
         }
@@ -323,9 +324,19 @@ class Page
             return $content;
         }
 
-        // Get summary size from site config's file
-        if (is_null($size)) {
-            $size = $config['size'];
+        // Set summary
+        if (is_string($var)) {
+            $this->summary = $var;
+            $var = null;
+        }
+
+        // Set up variables to process summary from page or from custom summary
+        if ($this->summary === null) {
+            $content = $this->content();
+            $summary_size = $this->summary_size;
+        } else {
+            $content = $this->summary;
+            $summary_size = mb_strlen($this->summary);
         }
 
         // Return calculated summary based on summary divider's position
@@ -333,16 +344,21 @@ class Page
         // Return entire page content on wrong/ unknown format
         if (!in_array($format, array('short', 'long'))) {
             return $content;
-        } elseif (($format === 'short') && isset($this->summary_size)) {
-            return substr($content, 0, $this->summary_size);
+        } elseif (($format === 'short') && isset($summary_size)) {
+            return mb_substr($content, 0, $summary_size);
+        }
+
+        // Get summary size from site config's file
+        if (is_null($var)) {
+            $var = $config['size'];
         }
 
         // If the size is zero, return the entire page content
-        if ($size === 0) {
+        if ($var === 0) {
             return $content;
         // Return calculated summary based on defaults
-        } elseif (!is_numeric($size) || ($size < 0)) {
-            $size = 300;
+        } elseif (!is_numeric($var) || ($var < 0)) {
+            $var = 300;
         }
 
         return Utils::truncateHTML($content, $size);


### PR DESCRIPTION
This is a PR to allow custom summary texts for pages. The PR is fully-backward compatible, but now accepts integers (for limiting the length of a summary) and strings (to set the summary), e.g.

```php
// Sets the summary
$page->summary('My superawesome summary');

// Gets the summary with custom size (here: with length 15)
$page->summary(15);

// Or return summary with default settings
$page->summary();
```

Further, even if one sets a custom summary, it will respect the settings made in the [`system/config/site.yaml`](https://github.com/getgrav/grav/blob/develop/system/config/site.yaml#L15) file.