### PR TITLE
Fix #240

### DIFF
--- a/system/src/Grav/Common/Twig/Twig.php
+++ b/system/src/Grav/Common/Twig/Twig.php
@@ -301,13 +301,14 @@ class Twig
         $this->grav->fireEvent('onTwigSiteVariables');
         $pages = $this->grav['pages'];
         $page = $this->grav['page'];
+        $content = $page->content();
 
         $twig_vars = $this->twig_vars;
 
         $twig_vars['pages'] = $pages->root();
         $twig_vars['page'] = $page;
         $twig_vars['header'] = $page->header();
-        $twig_vars['content'] = $page->content();
+        $twig_vars['content'] = $content;
         $ext = '.' . ($format ? $format : 'html') . TWIG_EXT;
 
         // determine if params are set, if so disable twig cache


### PR DESCRIPTION
$page->content() fires the onPageContentRaw event. A plugin handler for this event might want to update the twig variable with additional information during twig rendering.

However, $twig_vars takes a copy of $Twig->twig_vars and therefore never sees any later changes in $Twig->twig_vars.

By moving the method call $page->content() earlier, potential twig variable changes from a plugin get now inside this local variable copy.