### PR TITLE
Fix #248 (Plugin language interference) and fixed summary

### DIFF
--- a/system/src/Grav/Common/Config/Config.php
+++ b/system/src/Grav/Common/Config/Config.php
@@ -371,9 +371,7 @@ class Config extends Data
                 foreach ((array) $languageFiles['user/plugins'] as $plugin => $item) {
                     $lang_file = CompiledYamlFile::instance($item['file']);
                     $content = $lang_file->content();
-                    foreach ((array) $content as $lang => $value) {
-                        $this->languages->join($lang, $value, '/');
-                    }
+                    $this->languages->mergeRecursive($content);
                 }
             }
 

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -332,7 +332,7 @@ class Page
 
         // Return summary based on settings in site config file
         if (!$config['enabled']) {
-            return $content;
+            return $this->content();
         }
 
         // Set up variables to process summary from page or from custom summary


### PR DESCRIPTION
This PR references https://github.com/getgrav/grav/issues/248. I further added a bugfix when calling `$page->summary` with system option `summary.enabled: false`.

