### PR TITLE
Feature/Allow the use of custom datetime fields for collection filtering

### DIFF
--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -216,14 +216,14 @@ class Collection extends Iterator
      * Dates can be passed in as text that strtotime() can process
      * http://php.net/manual/en/function.strtotime.php
      *
-     * @param      $field
      * @param      $startDate
      * @param bool $endDate
+     * @param      $field
      *
      * @return $this
      * @throws \Exception
      */
-    public function dateRange($field = false, $startDate, $endDate = false)
+    public function dateRange($startDate, $endDate = false, $field = false)
     {
         $start = strtotime($startDate);
         $end = $endDate ? strtotime($endDate) : strtotime("now +1000 years");

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -211,17 +211,19 @@ class Collection extends Iterator
     }
 
     /**
-     * Returns the items between a set of date ranges where second value is optional
+     * Returns the items between a set of date ranges of either the page date field (default) or
+     * an arbitrary datetime page field where end date is optional
      * Dates can be passed in as text that strtotime() can process
      * http://php.net/manual/en/function.strtotime.php
      *
+     * @param      $field
      * @param      $startDate
      * @param bool $endDate
      *
      * @return $this
      * @throws \Exception
      */
-    public function dateRange($startDate, $endDate = false)
+    public function dateRange($field = false, $startDate, $endDate = false)
     {
         $start = strtotime($startDate);
         $end = $endDate ? strtotime($endDate) : strtotime("now +1000 years");
@@ -230,7 +232,10 @@ class Collection extends Iterator
 
         foreach ($this->items as $path => $slug) {
             $page = $this->pages->get($path);
-            if ($page->date() > $start && $page->date() < $end) {
+
+            $date = $field ? strtotime($page->value($field)) : $page->date();
+
+            if ($date > $start && $date < $end) {
                 $date_range[$path] = $slug;
             }
         }

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1841,10 +1841,10 @@ class Page
         // TODO: END OF MOVE
 
         if (isset($params['dateRange'])) {
-            $field = isset($params['dateRange']['field']) ? $params['dateRange']['field'] : false;
             $start = isset($params['dateRange']['start']) ? $params['dateRange']['start'] : 0;
             $end = isset($params['dateRange']['end']) ? $params['dateRange']['end'] : false;
-            $collection->dateRange($field, $start, $end);
+            $field = isset($params['dateRange']['field']) ? $params['dateRange']['field'] : false;
+            $collection->dateRange($start, $end, $field);
         }
 
         if (isset($params['order'])) {

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1841,9 +1841,10 @@ class Page
         // TODO: END OF MOVE
 
         if (isset($params['dateRange'])) {
+            $field = isset($params['dateRange']['field']) ? $params['dateRange']['field'] : false;
             $start = isset($params['dateRange']['start']) ? $params['dateRange']['start'] : 0;
             $end = isset($params['dateRange']['end']) ? $params['dateRange']['end'] : false;
-            $collection->dateRange($start, $end);
+            $collection->dateRange($field, $start, $end);
         }
 
         if (isset($params['order'])) {


### PR DESCRIPTION
Issue: #274 

This feature allows the user to specify a custom field to use in the dateRange filter of a collection page. While the same thing is most likely possible to using the Publish and Unpublish Date fields on each child page, this removes the chance of errors and extra fields to fill out.

Use case: Display a list of "event" page types that only shows upcoming events.

Yaml usage:
```yaml
content:
    items: @self.children
    dateRange:
        start: today
        field: header.event.time               // can use anything $page->value() will take
```