### PR TITLE
Fix error from grav-plugin-admin issue # 80

### DIFF
--- a/system/src/Grav/Common/GPM/Installer.php
+++ b/system/src/Grav/Common/GPM/Installer.php
@@ -72,7 +72,7 @@ class Installer
 
         $zip = new \ZipArchive();
         $archive = $zip->open($package);
-        $tmp = CACHE_DIR . DS . 'tmp/Grav-' . uniqid();
+        $tmp = CACHE_DIR . 'tmp/Grav-' . uniqid();
 
         if ($archive !== true) {
             self::$error = self::ZIP_OPEN_ERROR;


### PR DESCRIPTION
This change fixes an issue connected with https://github.com/getgrav/grav-plugin-admin/issues/80 that occurred when installing plugins removing the duplicate slash in the beginning due to https://github.com/getgrav/grav/blob/develop/system/defines.php#L17 .