### PR TITLE
Fix issue with date format for PHP 5.1.0+

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -58,7 +58,7 @@ form:
                     default: "jS M Y"
                     options:
                         "F jS \\a\\t g:ia": Date1
-                        "l jS of F g:i A": Date2
+                        "l jS \\of F g:i A": Date2
                         "D, m M Y G:i:s": Date3
                         "d-m-y G:i": Date4
                         "jS M Y": Date5
@@ -71,7 +71,7 @@ form:
                     help: PLUGIN_ADMIN.LONG_DATE_FORMAT_HELP
                     options:
                         "F jS \\a\\t g:ia": Date1
-                        "l jS of F g:i A": Date2
+                        "l jS \\of F g:i A": Date2
                         "D, m M Y G:i:s": Date3
                         "d-m-y G:i": Date4
                         "jS M Y": Date5


### PR DESCRIPTION
As of PHP 5.1.0 the character 'o' represents the ISO-8601 year number in a date format. Therefore the 'o' needs to be escaped to avoid being converted to a year in the admin > configuration > system > long/short date format pulldown menu.

I should note that this fixes the issue for English, but you might want to consider moving the date format options into a language string in order to provide better multi-language support.