### PR TITLE
Solve an issue with apostrophes in the taxonomy name

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1839,7 +1839,7 @@ class Page
                     }
                     foreach ($items as $item) {
                         if (empty($page->taxonomy[$taxonomy])
-                            || !in_array($item, $page->taxonomy[$taxonomy])) {
+                            || !in_array(htmlspecialchars_decode($item, ENT_QUOTES), $page->taxonomy[$taxonomy])) {
                             $collection->remove();
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/getgrav/grav-plugin-admin/issues/123

When a tag contains an apostrophe it's encoded and it cannot not match the page taxonomy items unless decoded.