### PR TITLE
Responsive image

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -188,12 +188,23 @@ class ImageMedium extends Medium
         return implode(', ', $srcset);
     }
 
+    /**
+     * Generate derivatives
+     *
+     * @param  int $min_width
+     * @param  int $max_width
+     * @param  int $step
+     * @return $this
+     */
     public function derivatives($min_width, $max_width, $step = 200) {
       $width = $min_width;
+
+      // Do not upscale images.
       if ($max_width > $this->get('width')) {
         $max_width = $this->get('width');
       }
-      while($width <= $max_width) {
+
+      while ($width <= $max_width) {
         $ratio = $width / $this->get('width');
         $derivative = MediumFactory::scaledFromMedium($this, 1, $ratio);
         if (is_array($derivative)) {
@@ -204,6 +215,11 @@ class ImageMedium extends Medium
       return $this;
     }
 
+    /**
+     * Add a derivative
+     *
+     * @param  ImageMedium $image
+     */
     public function addDerivative(ImageMedium $image) {
       $this->derivatives[$image->url()] = $image->get('width');
     }

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -57,6 +57,11 @@ class ImageMedium extends Medium
     ];
 
     /**
+     * @var array
+     */
+    protected $derivatives = [];
+
+    /**
      * Construct.
      *
      * @param array $items
@@ -157,20 +162,50 @@ class ImageMedium extends Medium
      */
     public function srcset($reset = true)
     {
-        if (empty($this->alternatives)) {
+        if (empty($this->alternatives) && empty($this->derivatives)) {
             if ($reset) {
                 $this->reset();
             }
             return '';
         }
 
-        $srcset = [ $this->url($reset) . ' ' . $this->get('width') . 'w' ];
+        if (!empty($this->derivatives)) {
+          asort($this->derivatives);
 
-        foreach ($this->alternatives as $ratio => $medium) {
-            $srcset[] = $medium->url($reset) . ' ' . $medium->get('width') . 'w';
+          foreach ($this->derivatives as $url => $width) {
+              $srcset[] = $url . ' ' . $width . 'w';
+          }
+
+          $srcset[] = $this->url($reset) . ' ' . $this->get('width') . 'w';
+        }
+        else {
+          $srcset = [ $this->url($reset) . ' ' . $this->get('width') . 'w' ];
+          foreach ($this->alternatives as $ratio => $medium) {
+              $srcset[] = $medium->url($reset) . ' ' . $medium->get('width') . 'w';
+          }
         }
 
         return implode(', ', $srcset);
+    }
+
+    public function derivatives($min_width, $max_width, $step = 200) {
+      $width = $min_width;
+      if ($max_width > $this->get('width')) {
+        $max_width = $this->get('width');
+      }
+      while($width <= $max_width) {
+        $ratio = $width / $this->get('width');
+        $derivative = MediumFactory::scaledFromMedium($this, 1, $ratio);
+        if (is_array($derivative)) {
+          $this->addDerivative($derivative['file']);
+        }
+        $width += $step;
+      }
+      return $this;
+    }
+
+    public function addDerivative(ImageMedium $image) {
+      $this->derivatives[$image->url()] = $image->get('width');
     }
 
     /**


### PR DESCRIPTION
This patch adds more support for responsive images, allowing you to do the following:

```
  page.media.images|first.derivatives(320, 960, 100).sizes('(max-width: 26em) 100vw, 50vw').html()
```

This will output an image tag with srcset for all widths starting from 320px to 960px in steps of 100px, the image will never upscale. The example uses an image with an intrinsic width of 650px.

```
<img sizes="(max-width: 26em) 100vw, 50vw" style="" src="/images/a/2/d/c/0/a2dc029adaa6460cfae159f06e676439138fac17-its-havenvervoer-breed1.jpeg" srcset="/images/6/a/a/f/d/6aafde2cb0b8bca92368200556db5c48be7318b5-its-havenvervoer-breed1.jpeg 320w, /images/f/5/8/c/7/f58c75299a67eff397d1ef62731ed55e1df9ee9a-its-havenvervoer-breed1.jpeg 420w, /images/9/0/1/7/c/9017c3a9fcbe0e2f2894f377ff9460ba78d34b0d-its-havenvervoer-breed1.jpeg 520w, /images/c/e/d/4/6/ced46633f00d10c91b72dd38b3a82c39a03bb181-its-havenvervoer-breed1.jpeg 620w, /images/a/2/d/c/0/a2dc029adaa6460cfae159f06e676439138fac17-its-havenvervoer-breed1.jpeg 650w">
```

In the code you'll see we just remember a list of url and width, this has been done to avoid memory problems while using lots of steps.