### PR TITLE
Change nativeName for Russian language

### DIFF
--- a/system/src/Grav/Common/Language/LanguageCodes.php
+++ b/system/src/Grav/Common/Language/LanguageCodes.php
@@ -537,7 +537,7 @@ class LanguageCodes
         ],
         "ru" => [
             "name"       => "Russian",
-            "nativeName" => "русский язык"
+            "nativeName" => "Русский"
         ],
         "sa" => [
             "name"       => "Sanskrit",


### PR DESCRIPTION
Now nativeName for Russian is "Русский", not "русский язык".