### PR TITLE
Add default apache resource for index.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -51,6 +51,7 @@ RewriteRule ^(system|user|vendor)/(.*)\.(txt|md|html|yaml|php|twig|sh|bat)$ erro
 
 </IfModule>
 
-# Begin - Prevent Browsing
+# Begin - Prevent Browsing and Set Default Resources
 Options -Indexes
-# End - Prevent Browsing
+DirectoryIndex index.php index.html index.htm
+# End - Prevent Browsing and Set Default Resources


### PR DESCRIPTION
I'm sure my setup is pretty unusual, but as I was trying out Grav for the first time I was greeted by a Apache 403 Forbidden error whenever I tried to view the home page.

Turns out that I don't have the `DirectoryIndex` directive set, and it's easy enough to include in the .htaccess file. Looks like other CMSs, like Drupal, include it, so here it is if you want it.