### PR TITLE
Load language files according to stream configurations

### DIFF
--- a/system/src/Grav/Common/Config/Config.php
+++ b/system/src/Grav/Common/Config/Config.php
@@ -366,14 +366,16 @@ class Config extends Data
 
             // Load languages.
             $this->languages = new Languages;
-
-            if (isset($languageFiles['user/plugins'])) {
-                foreach ((array) $languageFiles['user/plugins'] as $plugin => $item) {
-                    $lang_file = CompiledYamlFile::instance($item['file']);
-                    $content = $lang_file->content();
-                    $this->languages->mergeRecursive($content);
+            $pluginPaths = str_ireplace(GRAV_ROOT . '/', '', array_reverse($plugins));
+            foreach ($pluginPaths as $path) {
+                if (isset($languageFiles[$path])) {
+                    foreach ((array) $languageFiles[$path] as $plugin => $item) {
+                        $lang_file = CompiledYamlFile::instance($item['file']);
+                        $content = $lang_file->content();
+                        $this->languages->mergeRecursive($content);
+                    }
+                    unset($languageFiles[$path]);
                 }
-                unset($languageFiles['user/plugins']);
             }
 
             foreach ($languageFiles as $location) {

--- a/system/src/Grav/Common/Plugins.php
+++ b/system/src/Grav/Common/Plugins.php
@@ -94,18 +94,21 @@ class Plugins extends Iterator
     {
         $list = array();
         $locator = Grav::instance()['locator'];
-        $iterator = new \DirectoryIterator($locator->findResource('plugins://', false));
 
-        /** @var \DirectoryIterator $directory */
-        foreach ($iterator as $directory) {
-            if (!$directory->isDir() || $directory->isDot()) {
-                continue;
+        $plugins = (array) $locator->findResources('plugins://', false);
+        foreach ($plugins as $path) {
+            $iterator = new \DirectoryIterator($path);
+
+            /** @var \DirectoryIterator $directory */
+            foreach ($iterator as $directory) {
+                if (!$directory->isDir() || $directory->isDot()) {
+                    continue;
+                }
+
+                $type = $directory->getBasename();
+                $list[$type] = self::get($type);
             }
-
-            $type = $directory->getBasename();
-            $list[$type] = self::get($type);
         }
-
         ksort($list);
 
         return $list;

--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -60,18 +60,21 @@ class Themes extends Iterator
     {
         $list = array();
         $locator = Grav::instance()['locator'];
-        $iterator = new \DirectoryIterator($locator->findResource('themes://', false));
 
-        /** @var \DirectoryIterator $directory */
-        foreach ($iterator as $directory) {
-            if (!$directory->isDir() || $directory->isDot()) {
-                continue;
+        $themes = (array) $locator->findResources('themes://', false);
+        foreach ($themes as $path) {
+            $iterator = new \DirectoryIterator($path);
+
+            /** @var \DirectoryIterator $directory */
+            foreach ($iterator as $directory) {
+                if (!$directory->isDir() || $directory->isDot()) {
+                    continue;
+                }
+
+                $type = $directory->getBasename();
+                $list[$type] = self::get($type);
             }
-
-            $type = $directory->getBasename();
-            $list[$type] = self::get($type);
         }
-
         ksort($list);
 
         return $list;
@@ -96,9 +99,8 @@ class Themes extends Iterator
 
         // Find thumbnail.
         $thumb = "themes://{$name}/thumbnail.jpg";
-
-        if (file_exists($thumb)) {
-            $blueprint->set('thumbnail', $this->grav['base_url'] . "/user/themes/{$name}/thumbnail.jpg");
+        if ($path = $this->grav['locator']->findResource($thumb, false)) {
+            $blueprint->set('thumbnail', $this->grav['base_url'] . '/' . $path);
         }
 
         // Load default configuration.


### PR DESCRIPTION
This PR addresses a minor issue when dealing with custom multisite configurations using e.g. a `setup.php` and one changes the plugin folder location other than `user/plugins`. In this case the plugin language files aren't loaded correctly into the system. This PR fixes this.

**Update:** Ok, just added some other minor issues concerning loading of plugins and themes from different directories.