### PR TITLE
Feature/theme inheritance

### DIFF
--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -226,7 +226,11 @@ class Themes extends Iterator
         $config->joinDefaults("themes.{$name}", $themeConfig);
 
         if ($this->config->get('system.languages.translations', true)) {
-            $languages = CompiledYamlFile::instance("themes://{$name}/languages". YAML_EXT)->content();
+            $languages = [];
+            $schemes = array_reverse($config->get("themes.{$name}.streams.schemes.theme.prefixes.", []));
+            foreach ($schemes as $scheme) {
+                $languages = array_replace_recursive($languages, CompiledYamlFile::instance("$scheme/languages". YAML_EXT)->content());
+            }
             if ($languages) {
                 $config->getLanguages()->mergeRecursive($languages);
             }

--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -27,6 +27,9 @@ class Themes extends Iterator
     {
         $this->grav = $grav;
         $this->config = $grav['config'];
+
+        // Register instance as autoloader for theme inheritance
+        spl_autoload_register([$this, 'autoloadTheme']);
     }
 
     public function init()
@@ -235,5 +238,36 @@ class Themes extends Iterator
                 $config->getLanguages()->mergeRecursive($languages);
             }
         }
+    }
+
+    /**
+     * Autoload theme classes for inheritance
+     *
+     * @param  string $class Class name
+     *
+     * @return mixed  false  FALSE if unable to load $class; Class name if
+     *                       $class is successfully loaded
+     */
+    protected function autoloadTheme($class)
+    {
+        /** @var UniformResourceLocator $locator */
+        $locator = $this->grav['locator'];
+
+        $prefix = "Grav\\Theme";
+        if (false !== strpos($class, $prefix)) {
+            // Remove prefix from class
+            $class = substr($class, strlen($prefix));
+
+            // Replace namespace tokens to directory separators
+            $path = ltrim(preg_replace('#\\\|_(?!.+\\\)#', '/', $class), '/');
+            $file = $locator->findResource("themes://{$path}/{$path}.php");
+
+            // Load class
+            if (stream_resolve_include_path($file)) {
+              return include_once($file);
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR fixes an unreferenced bug, when dealing with language files in child themes; if you don’t provide a language file, it now falls back properly to the parent theme language file or replaces/adds some keys from the parent theme language file if present.

Further this PR finally addresses #154 and finalize somehow the way themes are inherited. With this PR it is now possible to derive the child theme by extending the parent theme class e.g.

```php
namespace Grav\Theme;

class Mytheme extends Antimatter
{
  // Some new methods, properties etc.
}
```

This is accomplished by prociding a (simple and fast) autoloader mechanism for theme instantiation, which only gets active if a theme under the namespace `Grav\Theme` is constructed. 