### PR TITLE
Allow override of directory constants

### DIFF
--- a/system/defines.php
+++ b/system/defines.php
@@ -6,19 +6,17 @@ define('GRAV_VERSION', '0.9.45');
 define('DS', '/');
 
 // Directories and Paths
-if (!defined('GRAV_ROOT')) {
-    define('GRAV_ROOT', str_replace(DIRECTORY_SEPARATOR, DS, getcwd()));
-}
-define('ROOT_DIR', GRAV_ROOT . '/');
-define('USER_PATH', 'user/');
-define('USER_DIR', ROOT_DIR . USER_PATH);
-define('SYSTEM_DIR', ROOT_DIR .'system/');
-define('ASSETS_DIR', ROOT_DIR . 'assets/');
-define('CACHE_DIR', ROOT_DIR . 'cache/');
-define('IMAGES_DIR', ROOT_DIR . 'images/');
-define('LOG_DIR', ROOT_DIR .'logs/');
-define('ACCOUNTS_DIR', USER_DIR .'accounts/');
-define('PAGES_DIR', USER_DIR .'pages/');
+defined('GRAV_ROOT') || define('GRAV_ROOT', str_replace(DIRECTORY_SEPARATOR, DS, getcwd()));
+defined('ROOT_DIR') || define('ROOT_DIR', GRAV_ROOT . '/');
+defined('USER_PATH') || define('USER_PATH', 'user/');
+defined('USER_DIR') || define('USER_DIR', ROOT_DIR . USER_PATH);
+defined('SYSTEM_DIR') || define('SYSTEM_DIR', ROOT_DIR .'system/');
+defined('ASSETS_DIR') || define('ASSETS_DIR', ROOT_DIR . 'assets/');
+defined('CACHE_DIR') || define('CACHE_DIR', ROOT_DIR . 'cache/');
+defined('IMAGES_DIR') || define('IMAGES_DIR', ROOT_DIR . 'images/');
+defined('LOG_DIR') || define('LOG_DIR', ROOT_DIR .'logs/');
+defined('ACCOUNTS_DIR') || define('ACCOUNTS_DIR', USER_DIR .'accounts/');
+defined('PAGES_DIR') || define('PAGES_DIR', USER_DIR .'pages/');
 
 // DEPRECATED: Do not use!
 define('DATA_DIR', USER_DIR .'data/');
@@ -29,11 +27,11 @@ define('VENDOR_DIR', ROOT_DIR .'vendor/');
 // END DEPRECATED
 
 // Some extensions
-define('CONTENT_EXT', '.md');
-define('TEMPLATE_EXT', '.html.twig');
-define('TWIG_EXT', '.twig');
-define('PLUGIN_EXT', '.php');
-define('YAML_EXT', '.yaml');
+defined('CONTENT_EXT') || define('CONTENT_EXT', '.md');
+defined('TEMPLATE_EXT') || define('TEMPLATE_EXT', '.html.twig');
+defined('TWIG_EXT') || define('TWIG_EXT', '.twig');
+defined('PLUGIN_EXT') || define('PLUGIN_EXT', '.php');
+defined('YAML_EXT') || define('YAML_EXT', '.yaml');
 
 // Content types
 define('RAW_CONTENT', 1);


### PR DESCRIPTION
This change allows to override and change some of the directory names from a customized index.php entry script:

Example:
In index.php before registering the autoloader one now can re-define the name and location of the cache or image directory like this:

    define('ROOT_DIR', __DIR__ . '/');
    define('CACHE_DIR', ROOT_DIR . 'site-cache/');
    define('IMAGES_DIR', ROOT_DIR . 'img/');
