### PR TITLE
Add a few more common RCS to ignore folders

### DIFF
--- a/system/src/Grav/Common/Backup/ZipBackup.php
+++ b/system/src/Grav/Common/Backup/ZipBackup.php
@@ -24,6 +24,8 @@ class ZipBackup
 
     protected static $ignoreFolders = [
         '.git',
+        '.svn',
+        '.hg',
         '.idea'
     ];
 


### PR DESCRIPTION
The back-up  function is a great feature and to allow Mercurial users to revision control their page files some more ignore directories like `.hg` were added.