### PR TITLE
add specific links to 'adding functionality' intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Check out the [install procedures](http://learn.getgrav.org/basics/installation)
 
 # Adding Functionality
 
-You can download manually from the [Downloads page on http://getgrav.org](http://getgrav.org/downloads), but the preferred solution is to use the [Grav Package Manager](http://learn.getgrav.org/advanced/grav-gpm) or `GPM`:
+You can download [plugins](http://getgrav.org/downloads/plugins) or [themes](http://getgrav.org/downloads/themes) manually from the appropriate tab on the [Downloads page on http://getgrav.org](http://getgrav.org/downloads), but the preferred solution is to use the [Grav Package Manager](http://learn.getgrav.org/advanced/grav-gpm) or `GPM`:
 
 ```
 $ bin/gpm index


### PR DESCRIPTION
add links directly to the tabs for plugins and themes on getgrav.org. The first time I loaded the main downloads page I didn't see the plugins/themes tabs because I immediately started scrolling down. It might be worth adding to the bottom of that main page a quick line to the tune of "Looking for plugins or themes? Click here or here."