### PR TITLE
Allow setting of redirect http response code through config.system.pa…

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -131,8 +131,14 @@ class Grav extends Container
                     }
                 }
                 // Default route test and redirect
-                if ($c['config']->get('system.pages.redirect_default_route') && $page->route() != $path) {
-                    $c->redirectLangSafe($page->route());
+                $redirect_default_route = $c['config']->get('system.pages.redirect_default_route');
+                if ($redirect_default_route && $page->route() != $path) {
+                    // redirect_default_route can be either just true or set to the http response code value, 301 or 303
+                    if (is_int($redirect_default_route)) {
+                        $c->redirectLangSafe($page->route(), $redirect_default_route);
+                    }
+                    else
+                        $c->redirectLangSafe($page->route());
                 }
             }
 
@@ -305,7 +311,7 @@ class Grav extends Container
         if (!$this['uri']->isExternal($route) && $language->enabled() && $language->isIncludeDefaultLanguage()) {
             return $this->redirect($language->getLanguage() . $route, $code);
         } else {
-            return $this->redirect($route);
+            return $this->redirect($route, $code);
         }
     }
 


### PR DESCRIPTION
If `redirect_default_route` is set to true, the redirects are using 303 HTTP response codes.

For SEO purposes it may be beneficial to issue 301 repsonse codes for route alias redirects.

The `redirect_default_route` can now be also set to a numeric value reflecting the desired response code. example:
```
pages:
  redirect_default_route: 301
```

This makes routes defined using the `route: alias` header use 301 as http response code.
