### PR TITLE
onTwigPageVariables event handler gets Page object passed as Event parameter

### DIFF
--- a/system/src/Grav/Common/Twig/Twig.php
+++ b/system/src/Grav/Common/Twig/Twig.php
@@ -7,6 +7,7 @@ use Grav\Common\Page\Page;
 use Grav\Common\Inflector;
 use Grav\Common\Utils;
 use RocketTheme\Toolbox\ResourceLocator\UniformResourceLocator;
+use RocketTheme\Toolbox\Event\Event;
 
 /**
  * The Twig object handles all the Twig template rendering for Grav. It's a singleton object
@@ -201,7 +202,7 @@ class Twig
         $content = $content !== null ? $content : $item->content();
 
         // override the twig header vars for local resolution
-        $this->grav->fireEvent('onTwigPageVariables');
+        $this->grav->fireEvent('onTwigPageVariables',  new Event(['page' => $item]));
         $twig_vars = $this->twig_vars;
 
         $twig_vars['page'] = $item;


### PR DESCRIPTION
This patch passes the Page object down to the onTwigPageVariables event handler of a plugin so it can determine and manipulate the page headers of the corresponding page object. It is otherwise not possible to access page headers of modular pages because `$this->grav['page']` will point always to the main page not the modular subpage.

Refer to discussion here: http://getgrav.org/forum#!/getgrav/plugin-development:ontwigpagevariables-event-h::unread