### PR TITLE
Support for width/height and style attributes to media and image files

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -360,6 +360,48 @@ class ImageMedium extends Medium
     }
 
     /**
+     * Allows to set the width attribute from Markdown or Twig
+     * Examples: ![Example](myimg.png?width=200&height=400)
+     *           ![Example](myimg.png?resize=100,200&width=100&height=200)
+     *           ![Example](myimg.png?width=auto&height=auto)
+     *           ![Example](myimg.png?width&height)
+     *           {{ page.media['myimg.png'].width().height().html }}
+     *           {{ page.media['myimg.png'].resize(100,200).width(100).height(200).html }}
+     *
+     * @param mixed $value A value or 'auto' or empty to use the width of the image
+     * @return $this
+     */
+    public function width($value = 'auto')
+    {
+        if (!$value || $value == 'auto')
+            $this->attributes['width'] = $this->get('width');
+        else
+            $this->attributes['width'] = $value;
+        return $this;
+    }
+
+    /**
+     * Allows to set the height attribute from Markdown or Twig
+     * Examples: ![Example](myimg.png?width=200&height=400)
+     *           ![Example](myimg.png?resize=100,200&width=100&height=200)
+     *           ![Example](myimg.png?width=auto&height=auto)
+     *           ![Example](myimg.png?width&height)
+     *           {{ page.media['myimg.png'].width().height().html }}
+     *           {{ page.media['myimg.png'].resize(100,200).width(100).height(200).html }}
+     *
+     * @param mixed $value A value or 'auto' or empty to use the height of the image
+     * @return $this
+     */
+    public function height($value = 'auto')
+    {
+        if (!$value || $value == 'auto')
+            $this->attributes['height'] = $this->get('height');
+        else
+            $this->attributes['height'] = $value;
+        return $this;
+    }
+
+    /**
      * Forward the call to the image processing method.
      *
      * @param string $method

--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -209,9 +209,13 @@ class Medium extends Data implements RenderableInterface
 
         $style = '';
         foreach ($this->styleAttributes as $key => $value) {
-            $style .= $key . ': ' . $value . ';';
+            if (is_numeric($key)) // Special case for inline style attributes, refer to style() method
+                $style .= $value;
+            else
+                $style .= $key . ': ' . $value . ';';
         }
-        $attributes['style'] = $style;
+        if ($style)
+            $attributes['style'] = $style;
 
         if (empty($attributes['title'])) {
             if (!empty($title)) {
@@ -389,6 +393,20 @@ class Medium extends Data implements RenderableInterface
     }
 
     /**
+     * Allows to add an inline style attribute from Markdown or Twig
+     * Example: ![Example](myimg.png?style=float:left)
+     *
+     * @param string $style
+     * @return $this
+     */
+    public function style($style)
+    {
+        error_log($style);
+        $this->styleAttributes[] = rtrim($style, ';') . ';';
+        return $this;
+    }
+
+    /**
      * Allow any action to be called on this medium from twig or markdown
      *
      * @param string $method
@@ -440,4 +458,5 @@ class Medium extends Data implements RenderableInterface
 
         return $this->_thumbnail;
     }
+
 }

--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -401,7 +401,6 @@ class Medium extends Data implements RenderableInterface
      */
     public function style($style)
     {
-        error_log($style);
         $this->styleAttributes[] = rtrim($style, ';') . ';';
         return $this;
     }


### PR DESCRIPTION
This commit adds the possibility to add inline style attributes to Medium objects and width and height attributes to ImageMedium objects. Usage is like shown below:

```
![Example](myimg.png?style=float:left)
![Example](myimg.png?width=200&height=400)
![Example](myimg.png?resize=100,200&width=100&height=200)  # match the resized dimensions
![Example](myimg.png?width=auto&height=auto) # use image's native dimensions
![Example](myimg.png?width&height)    # same as above, just more brief
{{ page.media['myimg.png'].width().height().html }}   # use image's native dimensions
{{ page.media['myimg.png'].resize(100,200).width(100).height(200).html }}

```
