### PR TITLE
Fix #395

### DIFF
--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -162,7 +162,7 @@ class Language
      */
     public function setActiveFromUri($uri)
     {
-        $regex = '/(^\/(' . $this->getAvailable() . ')).*/';
+        $regex = '/(^\/(' . $this->getAvailable() . '))(?:\/.*|$)/i';
 
         // if languages set
         if ($this->enabled()) {


### PR DESCRIPTION
This PR fixes #395 (Problem with default language and slugs that is starting with language name), which anchors the regex such that the language from the uri is only stripped, when a slash is following with the path to the page or the uri ends there.