### PR TITLE
Added support for default routes with a trailing slash

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -114,7 +114,7 @@ class Grav extends Container
             /** @var Uri $uri */
             $uri = $c['uri'];
 
-            $path = rtrim($uri->path(), '/');
+            $path = $uri->path(); // Don't trim to support trailing slash default routes
             $path = $path ?: '/';
 
             $page = $pages->dispatch($path);
@@ -296,7 +296,10 @@ class Grav extends Container
         if ($uri->isExternal($route)) {
             $url = $route;
         } else {
-            $url = rtrim($uri->rootUrl(), '/') .'/'. trim($route, '/');
+            if ($this['config']->get('system.pages.redirect_trailing_slash', true))
+                $url = rtrim($uri->rootUrl(), '/') .'/'. trim($route, '/'); // Remove trailing slash
+            else
+                $url = rtrim($uri->rootUrl(), '/') .'/'. ltrim($route, '/'); // Support trailing slash default routes
         }
 
         header("Location: {$url}", true, $code);

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -272,6 +272,10 @@ class Pages
     {
         // Fetch page if there's a defined route to it.
         $page = isset($this->routes[$url]) ? $this->get($this->routes[$url]) : null;
+        // Try without trailing slash
+        if (!$page && Utils::endsWith($url, '/')) {
+            $page = isset($this->routes[rtrim($url, '/')]) ? $this->get($this->routes[rtrim($url, '/')]) : null;
+        }
 
         // Are we in the admin? this is important!
         $not_admin = !isset($this->grav['admin']);


### PR DESCRIPTION
This PR enables Grav to specify URLs with a trailing slash for a page, by means of a default route with a trailing slash.  Such a feature shall help migrating legacy sites to Grav while maintaining existing and well established URLs which may have trailing slashes.

Refer to https://github.com/getgrav/grav/issues/404

Example 
```
---
routes:
  default: /support/
---
```
A request to this page will NOT redirect to `/support` and resolve as `/support/`
This feature works with `redirect_default_route` either on or off and if  `redirect_default_route` is on a request to `/support` redirects to `/support/` otherwise the page is served as is.

`redirect_trailing_slash` must be set to false for this use case for obvious reasons as this would conflict.

