### PR TITLE
Clear previously applied operations when doing a reset on image files to avoid calling filters twice

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageFile.php
+++ b/system/src/Grav/Common/Page/Medium/ImageFile.php
@@ -10,6 +10,14 @@ class ImageFile extends \Gregwar\Image\Image
     use GravTrait;
 
     /**
+     * Clear previously applied operations
+     */
+    public function clearOperations()
+    {
+        $this->operations = [];
+    }
+
+    /**
      * This is the same as the Gregwar Image class except this one fires a Grav Event on creation of new cached file
      *
      * @param string $type    the image type

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -260,6 +260,7 @@ class ImageMedium extends Medium
 
         if ($this->image) {
             $this->image();
+            $this->image->clearOperations(); // Clear previously applied operations
             $this->filter();
         }
 


### PR DESCRIPTION
Image default filters are called twice if `system.images.cache_all` is turned on and a _meta.yaml_ file exists, for example the default filter `enableProgressive` would is called twice in that case.

With `system.images.cache_all` enabled, on a page with a single image file the default filters are called once which would be correct.

Once a meta.yaml file is added to the folder (can be just an empty file) the default filters are run twice. This can be verified by logging the execution of the applyOperations() method
and also by dumping the Image object:  the operations array contains two elements.

This compromises performance for sites with lots of images and/or more complex filter operations
when the image cache is re-build.

This PR adds a clearOperations method and it is called when doing a reset() on images to avoid duplication of image operations.