### PR TITLE
Don't create <style> or <script> tags for empty inline CSS or inline JS

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -413,7 +413,7 @@ class Assets
         }
 
         $key = md5($asset);
-        if (is_string($asset) && !array_key_exists($key, $this->inline_css)) {
+        if ($asset && is_string($asset) && !array_key_exists($key, $this->inline_css)) {
             $this->inline_css[$key] = $data;
         }
 
@@ -460,7 +460,7 @@ class Assets
         }
 
         $key = md5($asset);
-        if (is_string($asset) && !array_key_exists($key, $this->inline_js)) {
+        if ($asset && is_string($asset) && !array_key_exists($key, $this->inline_js)) {
             $this->inline_js[$key] = $data;
         }
 


### PR DESCRIPTION
Just a little patch which prevents the generation of empty `<style>` or `<script>` tags in case the added inline JS or CSS was an empty string.

This saves to wrap addInlineJs calls into an if clause checking if the string is defined/empty or not on Twig level.