### PR TITLE
Fixes #432 (Theme autoloading doesn't seem to work)

### DIFF
--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -284,11 +284,11 @@ class Themes extends Iterator
             $class = substr($class, strlen($prefix));
 
             // Replace namespace tokens to directory separators
-            $path = ltrim(preg_replace('#\\\|_(?!.+\\\)#', '/', $class), '/');
+            $path = strtolower(ltrim(preg_replace('#\\\|_(?!.+\\\)#', '/', $class), '/'));
             $file = $locator->findResource("themes://{$path}/{$path}.php");
 
             // Load class
-            if (stream_resolve_include_path($file)) {
+            if (file_exists($file)) {
               return include_once($file);
             }
         }


### PR DESCRIPTION
This PR fixes #432 and improves autoloading speed using `file_exsits($file)` instead of `stream_resolve_include_path($file)` for a file check.