### PR TITLE
Use PCRE_UTF8 so unicode strings don't break up.

### DIFF
--- a/system/src/Grav/Common/Helpers/Truncator.php
+++ b/system/src/Grav/Common/Helpers/Truncator.php
@@ -131,7 +131,7 @@ class Truncator {
             $inner .= $txt;
             if ($remaining < 0) {
                 if (static::ellipsable($node)) {
-                    $inner = preg_replace('/(?:[\s\pP]+|(?:&(?:[a-z]+|#[0-9]+);?))*$/', '', $inner).$opts['ellipsis'];
+                    $inner = preg_replace('/(?:[\s\pP]+|(?:&(?:[a-z]+|#[0-9]+);?))*$/u', '', $inner).$opts['ellipsis'];
                     $opts['ellipsis'] = '';
                     $opts['was_truncated'] = true;
                 }


### PR DESCRIPTION
The `Truncator`-class fails when the truncated text contains unicode characters with a nice exception:

    "DOMDocumentFragment::appendXML(): Entity: line 1: parser error : Input is not proper UTF-8, indicate encoding ! Bytes: 0xC3 0xE2 0x80 0xA6"

By using the `PCRE_UTF8` modifier `u` everything is UTF8 and all is fine.