### PR TITLE
Added a translation for "Validation failed:" text

### DIFF
--- a/system/src/Grav/Common/Data/Blueprint.php
+++ b/system/src/Grav/Common/Data/Blueprint.php
@@ -72,12 +72,15 @@ class Blueprint
     {
         // Initialize data
         $this->fields();
+        
+        // Get language class
+        $language = self::getGrav()['language'];
 
         try {
             $this->validateArray($data, $this->nested);
         } catch (\RuntimeException $e) {
-            $language = self::getGrav()['language'];
-            throw new \RuntimeException(sprintf('<b>Validation failed:</b> %s', $language->translate($e->getMessage())));
+            $message = sprintf($language->translate('FORM.VALIDATION_FAIL', null, true) . ' %s', $e->getMessage());
+            throw new \RuntimeException($message);
         }
     }
 

--- a/system/src/Grav/Common/Data/Blueprint.php
+++ b/system/src/Grav/Common/Data/Blueprint.php
@@ -72,13 +72,11 @@ class Blueprint
     {
         // Initialize data
         $this->fields();
-        
-        // Get language class
-        $language = self::getGrav()['language'];
 
         try {
             $this->validateArray($data, $this->nested);
         } catch (\RuntimeException $e) {
+            $language = self::getGrav()['language'];
             $message = sprintf($language->translate('FORM.VALIDATION_FAIL', null, true) . ' %s', $e->getMessage());
             throw new \RuntimeException($message);
         }


### PR DESCRIPTION
The English term "Validation failed:" was hard coded on line 83. Instead, I created a translation and placed this at /system/languages/en.yaml. It will need to be translated into other languages by others.