### PR TITLE
Added a translation for "Invalid input in " text

### DIFF
--- a/system/src/Grav/Common/Data/Validation.php
+++ b/system/src/Grav/Common/Data/Validation.php
@@ -38,7 +38,7 @@ class Validation
         $type = (string) isset($field['validate']['type']) ? $field['validate']['type'] : $field['type'];
         $method = 'type'.strtr($type, '-', '_');
         $name = ucfirst(isset($field['label']) ? $field['label'] : $field['name']);
-        $message = (string) isset($field['validate']['message']) ? $field['validate']['message'] : 'Invalid input in "' . $language->translate($name) . '""';
+        $message = (string) isset($field['validate']['message']) ? $field['validate']['message'] : $language->translate('FORM.INVALID_INPUT', null, true) . ' "' . $language->translate($name) . '"';
 
         if (method_exists(__CLASS__, $method)) {
             $success = self::$method($value, $validate, $field);


### PR DESCRIPTION
The English phrase "Invalid input in " was hardcoded at line 40. I created a new translation 'FORM.INVALID_INPUT' and placed it in /system/languages/en.yaml. It will need to be translated into other languages by others.