### PR TITLE
Proper handling of list fields

### DIFF
--- a/system/src/Grav/Common/Data/Blueprint.php
+++ b/system/src/Grav/Common/Data/Blueprint.php
@@ -335,33 +335,23 @@ class Blueprint implements \ArrayAccess, ExportInterface
 				// Recursively get all the nested fields.
 				$newParams = array_intersect_key($this->filter, $field);
 				$this->parseFormFields($field['fields'], $newParams, $prefix, $current[$key]['fields']);
-			} else if( $field['type'] === 'list') {
-				// Lists have different structure for fields (one level deeper)
-                // This means we need to loop through the list to get to the actual field
-                // The property and rule setting need to be set on the list field
-                // and NOT on the children, which is why we need to duplicate some of
-                // the code below :(
-
-				$this->rules[$prefix . $key] = &$field;
-				$this->addProperty($prefix . $key);
-
-				foreach($field['fields'] as $subName => &$subField) {
-					$this->parseFormField($subField);
-				}
-
-				if (isset($field['validate']['rule']) && $field['type'] !== 'ignore') {
-					$field['validate'] += $this->getRule($field['validate']['rule']);
-				}
 			} else if ($field['type'] !== 'ignore') {
                 $this->rules[$prefix . $key] = &$field;
-				$this->addProperty($prefix . $key);
-
-				$this->parseFormField($field);
-
-				if (isset($field['validate']['rule']) && $field['type'] !== 'ignore') {
-					$field['validate'] += $this->getRule($field['validate']['rule']);
-				}
-			}
+                $this->addProperty($prefix . $key);
+            
+                if ($field['type'] === 'list') {
+                    // we loop through list to get the actual field
+                    foreach($field['fields'] as $subName => &$subField) {
+                        $this->parseFormField($subField);
+                    }
+                } else {
+                    $this->parseFormField($field);
+                }
+            
+                if (isset($field['validate']['rule']) && $field['type'] !== 'ignore') {
+                    $field['validate'] += $this->getRule($field['validate']['rule']);
+                }
+            }
 		}
 	}
 	/**

--- a/system/src/Grav/Common/Data/Blueprint.php
+++ b/system/src/Grav/Common/Data/Blueprint.php
@@ -346,7 +346,7 @@ class Blueprint implements \ArrayAccess, ExportInterface
 				$this->addProperty($prefix . $key);
 
 				foreach($field['fields'] as $subName => &$subField) {
-					$this->parseFormField($subField, $prefix, $key, false);
+					$this->parseFormField($subField);
 				}
 
 				if (isset($field['validate']['rule']) && $field['type'] !== 'ignore') {
@@ -356,7 +356,7 @@ class Blueprint implements \ArrayAccess, ExportInterface
                 $this->rules[$prefix . $key] = &$field;
 				$this->addProperty($prefix . $key);
 
-				$this->parseFormField($field, $prefix, $key, true);
+				$this->parseFormField($field);
 
 				if (isset($field['validate']['rule']) && $field['type'] !== 'ignore') {
 					$field['validate'] += $this->getRule($field['validate']['rule']);

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -423,7 +423,6 @@ abstract class Utils
         return in_array($value, [true, 1, '1', 'yes', 'on', 'true'], true);
     }
 
-
     /**
      * Generates a nonce string to be hashed. Called by self::getNonce()
      *
@@ -451,7 +450,7 @@ abstract class Utils
             $i++;
         }
 
-        return ( $i . '|' . $action . '|' . $username . '|' . $token );
+        return ( $i . '|' . $action . '|' . $username . '|' . $token . '|' . self::getGrav()['config']->get('security.salt'));
     }
 
     /**
@@ -469,19 +468,6 @@ abstract class Utils
     }
 
     /**
-     * Get hash of given string
-     *
-     * @param string $data string to hash
-     *
-     * @return string hashed value of $data, cut to 10 characters
-     */
-    public static function hash($data)
-    {
-        $hash = password_hash($data, PASSWORD_DEFAULT);
-        return $hash;
-    }
-
-    /**
      * Creates a hashed nonce tied to the passed action. Tied to the current user and time. The nonce for a given
      * action is the same for 12 hours.
      *
@@ -496,9 +482,8 @@ abstract class Utils
         if (isset(static::$nonces[$action])) {
             return static::$nonces[$action];
         }
-        $nonce = self::hash(self::generateNonceString($action, $plusOneTick));
-
-        static::$nonces[$action] = str_replace('/', 'SLASH', $nonce);
+        $nonce = md5(self::generateNonceString($action, $plusOneTick));
+        static::$nonces[$action] = $nonce;
 
         return static::$nonces[$action];
     }
@@ -513,21 +498,18 @@ abstract class Utils
      */
     public static function verifyNonce($nonce, $action)
     {
-        $nonce = str_replace('SLASH', '/', $nonce);
-
         //Nonce generated 0-12 hours ago
-        if (password_verify(self::generateNonceString($action), $nonce)) {
+        if ($nonce == self::getNonce($action)) {
             return true;
         }
 
         //Nonce generated 12-24 hours ago
         $plusOneTick = true;
-        if (password_verify(self::generateNonceString($action, $plusOneTick), $nonce)) {
+        if ($nonce == self::getNonce($action, $plusOneTick)) {
             return true;
         }
 
         //Invalid nonce
         return false;
     }
-
 }


### PR DESCRIPTION
Moved field handling to a separate function and added logic to correctly process nested lists. 

Code diff looks way more complex than it actually is. Copied everything that originally was under `else if ($field['type'] !== 'ignore') {` into a new function, so that it can be called from multiple places.

Fixes https://github.com/getgrav/grav-plugin-admin/issues/273