### PR TITLE
FE: Add ability to set-up custom repositories

### DIFF
--- a/system/src/Grav/Common/GPM/Remote/Grav.php
+++ b/system/src/Grav/Common/GPM/Remote/Grav.php
@@ -23,7 +23,7 @@ class Grav extends AbstractPackageCollection
 
         $this->fetch($refresh, $callback);
 
-        $this->data = json_decode($this->raw, true);
+        $this->data = json_decode(end($this->raw), true);
         $this->version = isset($this->data['version']) ? $this->data['version'] : '-';
         $this->date = isset($this->data['date']) ? $this->data['date'] : '-';
 


### PR DESCRIPTION
This PR adds the ability to setup custom repositories in a `user/config/repositories.yaml` file with the structure

```yaml
plugins:
  - http://..../plugins.json

themes:
  - http://..../themes.json
```

For security reasons Grav repositories are loaded always at last, thus no "shadowing" of packages is possible.

Although at the moment there is definitely no use for it, this PR is for the future and hence not needed to be documented yet. The reason is that this PR enables one to provide their own repositories, which is useful to integrate private plugin repositories transparently in the Grav update process.

P.S.: Of course I already have a plugin for that ;-).