### PR TITLE
Fix issue when `translations_fallback` is turned off, the translations are always relative to the default language even if the active language is != default

### DIFF
--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -352,7 +352,7 @@ class Language
                     if ($this->config->get('system.languages.translations_fallback', true)) {
                         $languages = $this->getFallbackLanguages();
                     } else {
-                        $languages = (array)$this->getDefault();
+                        $languages = (array)$this->getLanguage();
                     }
                 }
             } else {


### PR DESCRIPTION
To recreate: open the multilang skeleton, just set translations_fallback: false in system.yaml and go to deutsch/any other, lang strings are still in english