### PR TITLE
Make $container available in setup.php

### DIFF
--- a/system/src/Grav/Common/Config/Setup.php
+++ b/system/src/Grav/Common/Config/Setup.php
@@ -113,8 +113,13 @@ class Setup extends Data
         ],
     ];
 
-    public function __construct($environment = 'localhost')
+    public function __construct($container)
     {
+        $environment = $container['uri']->environment();
+        if (!$environment) {
+            $environment = 'localhost';
+        }
+
         // Pre-load setup.php which contains our initial configuration.
         // Configuration may contain dynamic parts, which is why we need to always load it.
         $file = GRAV_ROOT . '/setup.php';

--- a/system/src/Grav/Common/Service/ConfigServiceProvider.php
+++ b/system/src/Grav/Common/Service/ConfigServiceProvider.php
@@ -40,7 +40,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
 
     public static function setup(Container $container)
     {
-        return new Setup($container['uri']->environment());
+        return new Setup($container);
     }
 
     public static function blueprints(Container $container)


### PR DESCRIPTION
@mahagr made this PR to fix a problem introduced in this commit: https://github.com/getgrav/grav/commit/dd2ddfeb409baafc0bf7fed2a5c1f74b2bf8cae2 

The multisite subfolder example http://learn.getgrav.org/advanced/multisite-setup#quickstart-for-beginners was failing because $container was no longer available. Made a PR so you can review and tell me if this is an OK change or you want to revisit it.