### PR TITLE
Escape graph root in page medium to work with special characters.

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -135,7 +135,7 @@ class ImageMedium extends Medium
      */
     public function url($reset = true)
     {
-        $output = preg_replace('|^' . GRAV_ROOT . '|', '', $this->saveImage());
+        $output = preg_replace('|^' . preg_quote(GRAV_ROOT) . '|', '', $this->saveImage());
 
         if ($reset) {
             $this->reset();

--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -137,7 +137,7 @@ class Medium extends Data implements RenderableInterface
      */
     public function url($reset = true)
     {
-        $output = preg_replace('|^' . GRAV_ROOT . '|', '', $this->get('filepath'));
+        $output = preg_replace('|^' . preg_quote(GRAV_ROOT) . '|', '', $this->get('filepath'));
 
         if ($reset) {
             $this->reset();


### PR DESCRIPTION
The current implementation of the `url` function for page medium does not work when the grav root path contains regular expression characters (e.g. `+`).

This PR fixes this by escaping the grav root with `preg_quote`.