### PR TITLE
Prevent error if no collections present

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -186,7 +186,7 @@ class Assets
         $this->base_url = $base_url . '/';
 
         // Register any preconfigured collections
-        foreach ($config->get('system.assets.collections') as $name => $collection) {
+        foreach ($config->get('system.assets.collections', []) as $name => $collection) {
             $this->registerCollection($name, (array)$collection);
         }
     }


### PR DESCRIPTION
If there are no collections you can get a "Invalid argument supplied for foreach()" without an empty default.