### PR TITLE
Fixed hardcoded string "Security"

### DIFF
--- a/system/blueprints/user/account.yaml
+++ b/system/blueprints/user/account.yaml
@@ -55,7 +55,7 @@ form:
                     help: PLUGIN_ADMIN.LANGUAGE_HELP
 
                 security:
-                    title: Security
+                    title: PLUGIN_ADMIN.SECURITY
                     type: section
                     security: admin.super
 


### PR DESCRIPTION
Added the PLUGIN_ADMIN.SECURITY constant instead. Will add this to the admin language files too.