### PR TITLE
Use rawurldecode and rawurlencode instead of urldecode/urlencode

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -484,7 +484,7 @@ class Grav extends Container
         if ($page) {
             $media = $page->media()->all();
 
-            $parsed_url = parse_url(urldecode($uri->basename()));
+            $parsed_url = parse_url(rawurldecode($uri->basename()));
 
             $media_file = $parsed_url['path'];
 

--- a/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
+++ b/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
@@ -194,7 +194,7 @@ trait ParsedownGravTrait
 
                 // get the local path to page media if possible
                 if ($path_parts['dirname'] == $this->page->url(false, false, false)) {
-                    $url['path'] = urldecode($path_parts['basename']);
+                    $url['path'] = rawurldecode($path_parts['basename']);
                     // get the media objects for this page
                     $media = $this->page->media();
                 } else {
@@ -204,7 +204,7 @@ trait ParsedownGravTrait
                     $ext_page = $this->pages->dispatch($page_route, true);
                     if ($ext_page) {
                         $media = $ext_page->media();
-                        $url['path'] = urldecode($path_parts['basename']);
+                        $url['path'] = rawurldecode($path_parts['basename']);
                     }
                 }
 
@@ -226,7 +226,7 @@ trait ParsedownGravTrait
 
                     // loop through actions for the image and call them
                     foreach ($actions as $action) {
-                        $medium = call_user_func_array(array($medium, $action['method']), explode(',', urldecode($action['params'])));
+                        $medium = call_user_func_array(array($medium, $action['method']), explode(',', rawurldecode($action['params'])));
                     }
 
                     if (isset($url['fragment'])) {

--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -449,7 +449,7 @@ class Medium extends Data implements RenderableInterface
     {
         $qs = $method;
         if (count($args) > 1 || (count($args) == 1 && !empty($args[0]))) {
-            $qs .= '=' . implode(',', array_map(function ($a) { return urlencode($a); }, $args));
+            $qs .= '=' . implode(',', array_map(function ($a) { return rawurlencode($a); }, $args));
         }
 
         if (!empty($qs)) {

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -170,7 +170,7 @@ class Uri
                 if (strpos($bit, $delimiter) !== false) {
                     $param = explode($delimiter, $bit);
                     if (count($param) == 2) {
-                        $plain_var = filter_var(urldecode($param[1]), FILTER_SANITIZE_STRING);
+                        $plain_var = filter_var(rawurldecode($param[1]), FILTER_SANITIZE_STRING);
                         $this->params[$param[0]] = $plain_var;
                     }
                 } else {
@@ -206,7 +206,7 @@ class Uri
      */
     public function route($absolute = false, $domain = false)
     {
-        return urldecode(($absolute ? $this->rootUrl($domain) : '') . '/' . implode('/', $this->paths));
+        return rawurldecode(($absolute ? $this->rootUrl($domain) : '') . '/' . implode('/', $this->paths));
     }
 
     /**
@@ -268,7 +268,7 @@ class Uri
     public function param($id)
     {
         if (isset($this->params[$id])) {
-            return urldecode($this->params[$id]);
+            return rawurldecode($this->params[$id]);
         } else {
             return false;
         }
@@ -545,8 +545,8 @@ class Uri
 
             if (file_exists($full_path)) {
                 // do nothing
-            } elseif (file_exists(urldecode($full_path))) {
-                $full_path = urldecode($full_path);
+            } elseif (file_exists(rawurldecode($full_path))) {
+                $full_path = rawurldecode($full_path);
             } else {
                 return $normalized_url;
             }


### PR DESCRIPTION
Proposed fix for #541.

After reading http://stackoverflow.com/a/6998242 rawurldecode (and
rawurlencode) is better over urldecode/urlencode: "rawurlencode is the
way to go most of the time. It deals with the modern scheme for URI
components, where as urlencode does things the old school way, where +
meant "space."