### PR TITLE
Add secure and httponly parameters to sessions

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -793,6 +793,29 @@ form:
                     label: PLUGIN_ADMIN.NAME
                     help: PLUGIN_ADMIN.SESSION_NAME_HELP
 
+                session.secure:
+                    type: toggle
+                    label: PLUGIN_ADMIN.SESSION_SECURE
+                    help: PLUGIN_ADMIN.SESSION_SECURE_HELP
+                    highlight: 1
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    default: false
+                    validate:
+                        type: bool
+
+                session.httponly:
+                    type: toggle
+                    label: PLUGIN_ADMIN.SESSION_HTTPONLY
+                    help: PLUGIN_ADMIN.SESSION_HTTPONLY_HELP
+                    highlight: 1
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    default: true
+                    validate:
+                        type: bool
 
         advanced:
             type: section

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -110,5 +110,5 @@ session:
   enabled: true                             # Enable Session support
   timeout: 1800                             # Timeout in seconds
   name: grav-site                           # Name prefix of the session cookie. Use alphanumeric, dashes or underscores only. Do not use dots in the session name
-
-
+  secure: false                             # Set session secure. If true, indicates that communication for this cookie must be over an encrypted transmission. Enable this only on sites that run exclusively on HTTPS
+  httponly: true                            # Set session HTTP only. If true, indicates that cookies should be used only over HTTP, and JavaScript modification is not allowed.

--- a/system/src/Grav/Common/Session.php
+++ b/system/src/Grav/Common/Session.php
@@ -36,18 +36,20 @@ class Session extends \RocketTheme\Toolbox\Session\Session
         }
 
         if ($config->get('system.session.enabled') || $is_admin) {
-
-
             // Define session service.
             parent::__construct(
                 $session_timeout,
                 $session_path
             );
 
+            $domain = ($_SERVER['HTTP_HOST'] != 'localhost') ? $_SERVER['HTTP_HOST'] : false;
+            $secure = $config->get('system.session.secure', false);
+            $httponly = $config->get('system.session.httponly', true);
+
             $unique_identifier = GRAV_ROOT;
             $this->setName($config->get('system.session.name', 'grav_site') . '-' . substr(md5($unique_identifier), 0, 7) . ($is_admin ? '-admin' : ''));
             $this->start();
-            setcookie(session_name(), session_id(), time() + $session_timeout, $session_path);
+            setcookie(session_name(), session_id(), time() + $session_timeout, $session_path, $domain, $secure, $httponly);
         }
     }
 }

--- a/system/src/Grav/Common/Session.php
+++ b/system/src/Grav/Common/Session.php
@@ -42,7 +42,10 @@ class Session extends \RocketTheme\Toolbox\Session\Session
                 $session_path
             );
 
-            $domain = ($_SERVER['HTTP_HOST'] != 'localhost') ? $_SERVER['HTTP_HOST'] : false;
+            $domain = $uri->host();
+            if ($domain == 'localhost') {
+                $domain = '';
+            }
             $secure = $config->get('system.session.secure', false);
             $httponly = $config->get('system.session.httponly', true);
 


### PR DESCRIPTION
PR for #553

Still needs testing on a remove server, do not merge yet.

Locally it works fine on Firefox and Safari, on HTTP or HTTPS, tested both scenarios. 
Chrome limits it working when using the "localhost" domain name, not when using other aliases, I believe it's a security limitation of Chrome.