### PR TITLE
Command line GPM: Avoid prompting to reinstall already installed packages

### DIFF
--- a/system/src/Grav/Console/Gpm/InstallCommand.php
+++ b/system/src/Grav/Console/Gpm/InstallCommand.php
@@ -139,8 +139,11 @@ class InstallCommand extends ConsoleCommand
 
                         foreach($dependency_data as $type => $dep_data) {
                             foreach($dep_data as $name => $dep_package) {
-
-                                $this->processPackage($dep_package);
+                                Installer::isValidDestination($this->destination . DS . $dep_package->install_path);
+                                $error_code = Installer::lastErrorCode();
+                                if (!$error_code) {
+                                    $this->processPackage($dep_package);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When installing packages with dependencies, the GPM tries to install them also if already installed. This PR avoids doing so, installing only missing packages.