### PR TITLE
Add a onPageContentFromCache event

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -520,6 +520,9 @@ class Page
                 if ($cache_enable) {
                     $this->cachePageContent();
                 }
+            } else {
+                // Inform plugins that content was cached
+                self::getGrav()->fireEvent('onPageContentFromCache', new Event(['page' => $this]));                
             }
 
             // Handle summary divider


### PR DESCRIPTION
This event notifies plugins that content came from the cache.
It allows plugins to inspect this cached content and
decide if specific plugin related assets need to be added.

Now plugins typically use the onTwigSiteVariables callback to add their assets to a HTML page;
irrespectively whether the page makes actually use to that plugin.
That is because there's no other means for a plugin to check on cached pages
(onPageContentRaw nor onPageContentProcessed are broadcast for cached content).