### PR TITLE
Call finalizeObject on Config from loadCompiledFile() when cache is already built

### DIFF
--- a/system/src/Grav/Common/Config/CompiledBase.php
+++ b/system/src/Grav/Common/Config/CompiledBase.php
@@ -192,7 +192,9 @@ abstract class CompiledBase
         }
 
         $this->createObject($cache['data']);
-
+        
+        $this->finalizeObject();
+        
         return true;
     }
 


### PR DESCRIPTION
finalizeObject, which assigns the checksum to the Config object, was
never called after the cache was built.

So the checksum on Config was always empty.