### PR TITLE
Allow grav to be installed as a composer project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "getgrav/grav",
-    "type": "library",
+    "type": "project",
     "description": "Modern, Crazy Fast, Ridiculously Easy and Amazingly Powerful Flat-File CMS",
     "keywords": ["cms","flat-file cms","flat cms","flatfile cms","php"],
     "homepage": "http://getgrav.org",
@@ -40,5 +40,8 @@
     },
     "archive": {
         "exclude": ["VERSION"]
+    },
+    "scripts": {
+        "post-create-project-cmd": "bin/grav install"
     }
 }


### PR DESCRIPTION
As a developer, instead of ([as described in the docs](http://learn.getgrav.org/basics/installation#option-2-install-from-github))

```shell
$ git clone https://github.com/getgrav/grav.git
$ cd grav
$ composer install --no-dev -o
$ bin/grav install
```

I would like to be able to execute

```shell
$ composer create-project getgrav/grav my_new_grav_project
```
to bootstrap a new Grav project.

This PR includes the following changes:
- Change package type from `library` to `project`
  - This ~~is needed to be able to execute the `composer create-project` command, and also~~[<sup>1</sup>](#issuecomment-168844993) fits better, in my opinion
- Add a `post-create-project` command which executes the `bin/grav install` command after project creation.

This has the following benefits:
- It is possible to bootstrap a new project with one single command instead of four
- Other than with a `git clone`, no `.git` directory is created in the project root
- It is possible to specify a specific grav version (e.g. `^1.0` or `dev-develop`)

If you consider merging this PR, the project also must be submitted to http://packagist.org so that `composer create-project` can find it.

:octocat: