### PR TITLE
composer.json: Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,10 @@
     },
     "scripts": {
         "post-create-project-cmd": "bin/grav install"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
As a follow up to #585, this PR adds a branch alias for the develop branch, see https://getcomposer.org/doc/articles/aliases.md#aliases

This allows developers to create new bleeding edge Grav projects with composer through the slightly nicer looking

```
$ composer create-project getgrav/grav ~/webroot/grav 1.x-dev
```

instead of 

```
$ composer create-project getgrav/grav ~/webroot/grav dev-develop
```

(which still will work)

:octocat: 