### PR TITLE
Fix nonces for proxied IPs

### DIFF
--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -483,23 +483,20 @@ abstract class Utils
     //TODO: Remove after 1.0.8 release
     private static function generateNonceStringOldStyle($action, $plusOneTick = false)
     {
-        $ip = $_SERVER['REMOTE_ADDR'];
-
-        $username = '';
         if (isset(self::getGrav()['user'])) {
             $user = self::getGrav()['user'];
             $username = $user->username;
+            if (isset($_SERVER['REMOTE_ADDR'])) {
+                $username .= $_SERVER['REMOTE_ADDR'];
+            }
+        } else {
+            $username = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
         }
-
-        $username .= $ip;
-
         $token = session_id();
         $i = self::nonceTick();
-
         if ($plusOneTick) {
             $i++;
         }
-
         return ( $i . '|' . $action . '|' . $username . '|' . $token . '|' . self::getGrav()['config']->get('security.salt'));
     }
 

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -454,15 +454,19 @@ abstract class Utils
      */
     private static function generateNonceString($action, $plusOneTick = false)
     {
+        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+        } else {
+            $ip = $_SERVER['REMOTE_ADDR'];
+        }
+
+        $username = '';
         if (isset(self::getGrav()['user'])) {
             $user = self::getGrav()['user'];
             $username = $user->username;
-            if (isset($_SERVER['REMOTE_ADDR'])) {
-                $username .= $_SERVER['REMOTE_ADDR'];
-            }
-        } else {
-            $username = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
         }
+
+        $username .= $ip;
 
         $token = session_id();
         $i = self::nonceTick();

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -454,7 +454,9 @@ abstract class Utils
      */
     private static function generateNonceString($action, $plusOneTick = false)
     {
-        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
+            $ip = $_SERVER['HTTP_CLIENT_IP'];
+        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
             $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
         } else {
             $ip = $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
Ensure the Nonces generation works when REMOTE_ADDR is not the real user IP address.

Since the IP is just a part of the nonce string calculation, we can rely on HTTP_X_FORWARDED_FOR.

This change was prompted by trying to run Grav on Cloud9 which REMOTE_ADDR is a random load balancer generated IP, not the user's IP.