### PR TITLE
Update Publish date to be today's date

### DIFF
--- a/system/blueprints/pages/default.yaml
+++ b/system/blueprints/pages/default.yaml
@@ -73,6 +73,7 @@ form:
                   label: PLUGIN_ADMIN.PUBLISHED_DATE
                   toggleable: true
                   help: PLUGIN_ADMIN.PUBLISHED_DATE_HELP
+                  default: now
 
                 header.unpublish_date:
                   type: datetime


### PR DESCRIPTION
If you're going to publish right away then this is correct, if you're going to publish in the future then you can click through and select the proper date. This leaves ```header.date``` alone.