### PR TITLE
Fix parents for home page second level childs when hide home in url is enabled

### DIFF
--- a/system/blueprints/pages/default.yaml
+++ b/system/blueprints/pages/default.yaml
@@ -139,7 +139,7 @@ form:
                       type: select
                       label: PLUGIN_ADMIN.PARENT
                       classes: fancy
-                      '@data-options': '\Grav\Common\Page\Pages::parents'
+                      '@data-options': '\Grav\Common\Page\Pages::parentsRawRoutes'
                       '@data-default': '\Grav\Plugin\admin::route'
                       options:
                         '/': PLUGIN_ADMIN.DEFAULT_OPTION_ROOT

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -398,7 +398,7 @@ class Pages
      * @return array
      * @throws \RuntimeException
      */
-    public function getList(Page $current = null, $level = 0)
+    public function getList(Page $current = null, $level = 0, $rawRoutes = false)
     {
         if (!$current) {
             if ($level) {
@@ -411,11 +411,16 @@ class Pages
         $list = array();
 
         if (!$current->root()) {
-            $list[$current->route()] = str_repeat('&nbsp; ', ($level-1)*2) . $current->title();
+            if ($rawRoutes) {
+                $route = $current->rawRoute();
+            } else {
+                $route = $current->route();
+            }
+            $list[$route] = str_repeat('&nbsp; ', ($level-1)*2) . $current->title();
         }
 
         foreach ($current->children() as $next) {
-            $list = array_merge($list, $this->getList($next, $level + 1));
+            $list = array_merge($list, $this->getList($next, $level + 1, $rawRoutes));
         }
 
         return $list;
@@ -517,18 +522,42 @@ class Pages
     }
 
     /**
-     * Get available parents.
+     * Get available parents routes
      *
      * @return array
      */
     public static function parents()
+    {
+        $rawRoutes = false;
+        return self::getParents($rawRoutes);
+    }
+
+    /**
+     * Get available parents raw routes.
+     *
+     * @return array
+     */
+    public static function parentsRawRoutes()
+    {
+        $rawRoutes = true;
+        return self::getParents($rawRoutes);
+    }
+
+    /**
+     * Get available parents routes
+     *
+     * @param bool $rawRoutes get the raw route or the normal route
+     *
+     * @return array
+     */
+    private static function getParents($rawRoutes)
     {
         $grav = Grav::instance();
 
         /** @var Pages $pages */
         $pages = $grav['pages'];
 
-        $parents = $pages->getList();
+        $parents = $pages->getList(null, 0, $rawRoutes);
 
         /** @var Admin $admin */
         $admin = $grav['admin'];
@@ -544,6 +573,7 @@ class Pages
         }
 
         return $parents;
+
     }
 
     /**


### PR DESCRIPTION
TESTING IN PROGRESS

Return the parent routes in the `route` options.

Added a Pages::parentsRawRoutes() method, uses the same internal method
as Pages::parents().

Refactored Pages::getList() to accept an optional $rawRoutes bool and
if set, return the raw routes