### PR TITLE
Remove ircmaxell/password-compat as it's intended to provide forward compatibility for PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "filp/whoops": "2.0.0-alpha2",
         "monolog/monolog": "~1.0",
         "gregwar/image": "~2.0",
-        "ircmaxell/password-compat": "1.0.*",
         "mrclay/minify": "~2.2",
         "donatj/phpuseragentparser": "~0.3",
         "pimple/pimple": "~3.0",


### PR DESCRIPTION
However, it will still be installed in `vendor` as required by
`rockettheme/toolbox`