### PR TITLE
Fix for #612

### DIFF
--- a/webserver-configs/web.config
+++ b/webserver-configs/web.config
@@ -52,4 +52,7 @@
             </rules>
         </rewrite>
     </system.webServer>
+    <system.web>
+        <httpRuntime requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
+    </system.web>
 </configuration>


### PR DESCRIPTION
This should work for most IIS systems and Azure. 

Local versions of IIS tend not to validate URL's so no problems there (for the most part)
Azure IIS does validate and this should work with default Azure settings.