### PR TITLE
fix lighttpd config

### DIFF
--- a/webserver-configs/lighttpd.conf
+++ b/webserver-configs/lighttpd.conf
@@ -36,7 +36,7 @@ $HTTP["url"] =~ "^/grav_path/(.git|cache|bin|logs|backup|tests)/(.*)" {
 $HTTP["url"] =~ "^/grav_path/(system|user|vendor)/(.*)\.(txt|md|html|yaml|php|twig|sh|bat)$" {
     url.access-deny = ("")
 }
-$HTTP["url"] =~ "^/grav_path/(\.(.*))|(\.(.*)/)" {
+$HTTP["url"] =~ "^/grav_path/(\.(.*))" {
     url.access-deny = ("")
 }
 url.access-deny = (".md","~",".inc")


### PR DESCRIPTION
Consider the following path: `/grav_path/user/pages/01.home/_about/profilepic.jpg`
The pattern `^/grav_path/(\.(.*))|(\.(.*)/)` will match `.home/_about/` and will therefore forbid access to this image.

If I understand it right, this pattern should prevent access to dot files. In this case, it should be fine to simply remove the right *or branch*.

Another note: the `lighttpd.conf` also contains the following rule:
```
$HTTP["url"] =~ "^/grav_path/(.git|cache|bin|logs|backup|tests)/(.*)" {
    url.access-deny = ("")
}
```

I think this rule is redundant, because the other rule already catches all dotfiles?