### PR TITLE
Translate dates automatically in Twig filter

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -254,12 +254,7 @@ class Grav extends Container
         $this['uri']->init();
         $this['session']->init();
 
-        // Initialize Locale if set and configured.
-        if ($this['language']->enabled() && $this['config']->get('system.languages.override_locale')) {
-            setlocale(LC_ALL, $this['language']->getLanguage());
-        } elseif ($this['config']->get('system.default_locale')) {
-            setlocale(LC_ALL, $this['config']->get('system.default_locale'));
-        }
+        $this->setLocale();
 
         $debugger->stopTimer('init');
 
@@ -306,6 +301,20 @@ class Grav extends Container
         $this->fireEvent('onOutputRendered');
 
         register_shutdown_function([$this, 'shutdown']);
+    }
+
+    /**
+     * Set the system locale based on the language and configuration
+     */
+    public function setLocale()
+    {
+        // Initialize Locale if set and configured.
+        if ($this['language']->enabled() && $this['config']->get('system.languages.override_locale')) {
+            $language = $this['language']->getLanguage();
+            setlocale(LC_ALL, count($language < 3) ? ($language . '_' . strtoupper($language)) : $language );
+        } elseif ($this['config']->get('system.default_locale')) {
+            setlocale(LC_ALL, $this['config']->get('system.default_locale'));
+        }
     }
 
     /**


### PR DESCRIPTION
The Twig `date` filter does not translate dates automatically for us.
This PR lets `|date()` translate the date based on the locale.