### PR TITLE
A way to override default Parsedown behavior

### DIFF
--- a/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
+++ b/system/src/Grav/Common/Markdown/ParsedownGravTrait.php
@@ -63,9 +63,13 @@ trait ParsedownGravTrait
      * @param $type
      * @param $tag
      */
-    public function addBlockType($type, $tag, $continuable = false, $completable = false)
+    public function addBlockType($type, $tag, $continuable = false, $completable = false, $index = null)
     {
-        $this->BlockTypes[$type] [] = $tag;
+        if (!isset($index)) {
+            $this->BlockTypes[$type] [] = $tag;
+        } else {
+            array_splice($this->BlockTypes[$type], $index, 0, $tag);
+        }
 
         if ($continuable) {
             $this->continuable_blocks[] = $tag;
@@ -82,10 +86,17 @@ trait ParsedownGravTrait
      * @param $type
      * @param $tag
      */
-    public function addInlineType($type, $tag)
+    public function addInlineType($type, $tag, $index = null)
     {
-        $this->InlineTypes[$type] [] = $tag;
-        $this->inlineMarkerList .= $type;
+        if (!isset($index)) {
+            $this->InlineTypes[$type] [] = $tag;
+        } else {
+            array_splice($this->InlineTypes[$type], $index, 0, $tag);
+        }
+        
+        if (strpos($this->inlineMarkerList, $type) === false) {
+            $this->inlineMarkerList .= $type;
+        }
     }
 
     /**


### PR DESCRIPTION
As discussed in #736 It's possible to override default Parsedown processing if the new `tag` for existing `type` will be inserted into the array in higher position then the standard tag we want to override.