### PR TITLE
Add twig/extensions to allow Twig dates translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "maximebf/debugbar": "~1.10",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "twig/extensions": "^1.3"
     },
     "require-dev": {
         "codeception/codeception": "^2.1",

--- a/system/src/Grav/Common/Twig/Twig.php
+++ b/system/src/Grav/Common/Twig/Twig.php
@@ -144,6 +144,11 @@ class Twig
             }
             $this->twig->addExtension(new TwigExtension());
 
+            // enable the Intl Twig extension if translations  are enabled
+            if (count($config->get('system.languages.supported', [])) > 0) {
+                $this->twig->addExtension(new \Twig_Extensions_Extension_Intl());
+            }
+
             $this->grav->fireEvent('onTwigExtensions');
 
             // Set some standard variables for twig


### PR DESCRIPTION
Client code can now use

`{{ a_date|localizeddate('long', 'short', grav.language.getLanguage) }}`

The extension is only loaded if translations are enabled in the system config.