### PR TITLE
Add params, query and fragment when redirecting to a language or default route

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -152,18 +152,35 @@ class Grav extends Container
 
             // Redirection tests
             if ($page) {
+                $url = $page->route();
+
+                if ($uri->params()) {
+                    if ($url == '/') { //Avoid double slash
+                        $url = $uri->params();
+                    } else {
+                        $url .= $uri->params();
+                    }
+                }
+                if ($uri->query()) {
+                    $url .= '?' . $uri->query();
+                }
+                if ($uri->fragment()) {
+                    $url .= '#' . $uri->fragment();
+                }
+
                 // Language-specific redirection scenarios
                 if ($language->enabled()) {
                     if ($language->isLanguageInUrl() && !$language->isIncludeDefaultLanguage()) {
-                        $c->redirect($page->route());
+                        $c->redirect($url);
                     }
                     if (!$language->isLanguageInUrl() && $language->isIncludeDefaultLanguage()) {
-                        $c->redirectLangSafe($page->route());
+                        $c->redirectLangSafe($url);
                     }
                 }
+
                 // Default route test and redirect
                 if ($c['config']->get('system.pages.redirect_default_route') && $page->route() != $path) {
-                    $c->redirectLangSafe($page->route());
+                    $c->redirectLangSafe($url);
                 }
             }
 


### PR DESCRIPTION
Fix an issue in the Grav lang redirect. E.g. I call `/order/id:order-20160320-202557-668641/token:2mgb4D27S3`, if multilang is ON, and the lang is prefixed, Grav loads the page `/en/order/`, losing all the parameters and additional URL segments