### PR TITLE
Fix local themes with same folder name (slug) as a theme published on the GPM

### DIFF
--- a/system/src/Grav/Common/GPM/GPM.php
+++ b/system/src/Grav/Common/GPM/GPM.php
@@ -194,7 +194,7 @@ class GPM extends Iterator
         }
 
         foreach ($this->installed['plugins'] as $slug => $plugin) {
-            if (!isset($repository[$slug]) || $plugin->symlink) {
+            if (!isset($repository[$slug]) || $plugin->symlink || !$plugin->version || $plugin->gpm === false) {
                 continue;
             }
 
@@ -272,7 +272,7 @@ class GPM extends Iterator
         }
 
         foreach ($this->installed['themes'] as $slug => $plugin) {
-            if (!isset($repository[$slug]) || $plugin->symlink) {
+            if (!isset($repository[$slug]) || $plugin->symlink || !$plugin->version || $plugin->gpm === false) {
                 continue;
             }
 


### PR DESCRIPTION
If a blueprint has no version specified, it's not a GPM package, do not try to update it (CLI/Admin).

Introduces a check on `gpm: false` in the theme/plugin blueprint, and also avoid trying to update if no version is specified in the blueprint, which means it's not a package published on the GPM.