### PR TITLE
This allows a frontmatter.yaml file to be included in a page folder

### DIFF
--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -264,6 +264,15 @@ class Cache extends Getters
     }
 
     /**
+     * Setter method to set key (Advanced)
+     */
+    public function setKey($key)
+    {
+        $this->key = $key;
+        $this->driver->setNamespace($this->key);
+    }
+
+    /**
      * Helper method to clear all Grav caches
      *
      * @param string $remove standard|all|assets-only|images-only|cache-only

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -289,6 +289,14 @@ class Page
                     $this->raw_content = $file->markdown();
                     $this->frontmatter = $file->frontmatter();
                     $this->header = (object)$file->header();
+
+                    // If there's a `frontmatter.yaml` file merge that in with the page header
+                    // note page's own frontmatter has precedence and will overwrite any defaults
+                    $frontmatter_file = $this->path . '/' . $this->folder . '/frontmatter.yaml';
+                    if (file_exists($frontmatter_file)) {
+                        $frontmatter_data = (array) Yaml::parse(file_get_contents($frontmatter_file));
+                        $this->header = (object)array_replace_recursive($frontmatter_data, (array)$this->header);
+                    }
                 } catch (ParseException $e) {
                     $file->raw(Grav::instance()['language']->translate([
                         'FRONTMATTER_ERROR_PAGE',

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -292,10 +292,12 @@ class Page
 
                     // If there's a `frontmatter.yaml` file merge that in with the page header
                     // note page's own frontmatter has precedence and will overwrite any defaults
-                    $frontmatter_file = $this->path . '/' . $this->folder . '/frontmatter.yaml';
-                    if (file_exists($frontmatter_file)) {
-                        $frontmatter_data = (array) Yaml::parse(file_get_contents($frontmatter_file));
-                        $this->header = (object)array_replace_recursive($frontmatter_data, (array)$this->header);
+                    if (!Utils::isAdminPlugin()) {
+                        $frontmatter_file = $this->path . '/' . $this->folder . '/frontmatter.yaml';
+                        if (file_exists($frontmatter_file)) {
+                            $frontmatter_data = (array)Yaml::parse(file_get_contents($frontmatter_file));
+                            $this->header = (object)array_replace_recursive($frontmatter_data, (array)$this->header);
+                        }
                     }
                 } catch (ParseException $e) {
                     $file->raw(Grav::instance()['language']->translate([

--- a/system/src/Grav/Common/Plugin.php
+++ b/system/src/Grav/Common/Plugin.php
@@ -101,11 +101,7 @@ class Plugin implements EventSubscriberInterface, \ArrayAccess
      */
     public function isAdmin()
     {
-        if (isset($this->grav['admin'])) {
-            return true;
-        }
-
-        return false;
+        return Utils::isAdminPlugin();
     }
 
     /**

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -622,4 +622,18 @@ abstract class Utils
         //Invalid nonce
         return false;
     }
+
+    /**
+     * Simple helper method to get whether or not the admin plugin is active
+     *
+     * @return bool
+     */
+    public static function isAdminPlugin()
+    {
+        if (isset(Grav::instance()['admin'])) {
+            return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
any 'frontmatter.yaml` file will be merged into the page header. 

### Caveats with this approach:
With this approach, in the admin this will be merged in transparently and shows up as if it were in the page frontmatter itself, and then when you save, it is in fact saved back into the page.  

Doing anything else differently is going to be much more complex because we'll have to handle two ways of generating header data (one for admin ignoring this file, and one for frontend).  However it's not even that easy because this data is potentially cached, meaning we'll have to maintain two versions in cache, leading to possible inconsistencies.

This is a pretty advanced feature and would not be something that could be set via Admin so am not sure if this is a problem or not.

Also it is fine if you use **Expert** mode because that reads and saves the frontmatter in the page header directly.