### PR TITLE
Add ability to link to file on gist

### DIFF
--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -623,12 +623,17 @@ class TwigExtension extends \Twig_Extension
      * Output a Gist
      *
      * @param  string $id
+     * @param  string $file
      *
      * @return string
      */
-    public function gistFunc($id)
+    public function gistFunc($id, $file = false)
     {
-        return '<script src="https://gist.github.com/' . $id . '.js"></script>';
+        $url = 'https://gist.github.com/' . $id . '.js';
+        if ($file) {
+            $url .= '?file=' . $file;
+        }
+        return '<script src="' . $url . '"></script>';
     }
 
     /**


### PR DESCRIPTION
Now when the file is passed to the gist filter only that file will be displayed, not the whole gist.

Example usage:

```{{ gist("000000000000000000000000", "somefile.php") }}```

Backward compatible by the way.