### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ $ composer create-project getgrav/grav ~/webroot/grav
 
 Check out the [install procedures](http://learn.getgrav.org/basics/installation) for more information.
 
+### Nitrous Quickstart
+
+You can quickly create a free development environment for this Grav project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+Simply access your site via the `Preview > 3000` link in the IDE.
+
 # Adding Functionality
 
 You can download [plugins](http://getgrav.org/downloads/plugins) or [themes](http://getgrav.org/downloads/themes) manually from the appropriate tab on the [Downloads page on http://getgrav.org](http://getgrav.org/downloads), but the preferred solution is to use the [Grav Package Manager](http://learn.getgrav.org/advanced/grav-gpm) or `GPM`:

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,11 @@
+# Setup
+
+Welcome to your Grav project on Nitrous.
+
+## Running the development server:
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "php-apache",
+  "ports": [3000],
+  "name": "Grav",
+  "description": "Modern, Crazy Fast, Ridiculously Easy and Amazingly Powerful Flat-File CMS",
+  "scripts": {
+    "post-create": "rm -rf ~/code/public_html && cd ~/code/grav && bin/grav install && cd ~/code && mv grav public_html && sudo chown -R nitrous:www-data public_html && sudo chmod -R g+w public_html && sudo a2enmod rewrite && sudo service apache2 restart"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.