### PR TITLE
Deleted Whoops aliases

### DIFF
--- a/system/src/Grav/Common/Service/ErrorServiceProvider.php
+++ b/system/src/Grav/Common/Service/ErrorServiceProvider.php
@@ -4,9 +4,6 @@ namespace Grav\Common\Service;
 use Grav\Common\Errors\Errors;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Whoops\Handler\JsonResponseHandler;
-use Whoops\Handler\PrettyPageHandler;
-use Whoops\Handler\PlainTextHandler;
 
 class ErrorServiceProvider implements ServiceProviderInterface
 {


### PR DESCRIPTION
Deleted Whoops aliases as they are in `Grav\Common\Errors` implemented. In this file are unusued