### PR TITLE
Make sure there's an end of line after each file added to the pipeline

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -1114,7 +1114,8 @@ class Assets
                 $file = $this->cssRewrite($file, $relative_dir);
             }
 
-            $buffer .= $file;
+            $file = rtrim($file) . PHP_EOL;            
+            $buffer .= $file;    
         }
 
         // Pull out @imports and move to top


### PR DESCRIPTION
Fixes an issue with files ending with a line comment, but no new line.

Also fixes (in a case I found) the already-seen JSMin fatal issue with
"Regex not terminated" error.