### PR TITLE
Install plugins and themes in correct multisite folders

### DIFF
--- a/system/src/Grav/Common/GPM/Remote/AbstractPackageCollection.php
+++ b/system/src/Grav/Common/GPM/Remote/AbstractPackageCollection.php
@@ -50,6 +50,11 @@ class AbstractPackageCollection extends BaseCollection
 
         $this->fetch($refresh, $callback);
         foreach (json_decode($this->raw, true) as $slug => $data) {
+            // Temporarily fix for using multisites
+            if (isset($data['install_path'])) {
+                $path = preg_replace('~^user/~i', 'user://', $data['install_path']);
+                $data['install_path'] = Grav::instance()['locator']->findResource($path, false, true);
+            }
             $this->items[$slug] = new Package($data, $this->type);
         }
     }


### PR DESCRIPTION
When having multisite folders with different user folders and one installs a plugin or a theme, Grav always installs it in the "root" folders like `user/plugins` or `user/themes`.

This PR addresses the issue (cf. https://github.com/getgrav/grav-plugin-admin/issues/319) and fixes it with full backward-compatibilty and without any change to the Grav GPM package system.

However in the future I advise to use streams in the package system, which are resolved to the respective folders in the grav installs of the users. This PR is a step to this direction and (I guess) will be tackled in **Grav v2.x**.