### PR TITLE
Load `session` prior to `uri` as the initialization of Uri does some session handling for the active language

### DIFF
--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -24,8 +24,8 @@ class InitializeProcessor extends ProcessorBase implements ProcessorInterface {
         }
 
         // Initialize uri, session.
-        $this->container['uri']->init();
         $this->container['session']->init();
+        $this->container['uri']->init();
 
         $this->container->setLocale();
     }


### PR DESCRIPTION
Refs https://github.com/getgrav/grav/issues/842