### PR TITLE
translate(): apply sprintf even if translation key missing in yaml

### DIFF
--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -377,6 +377,10 @@ class Language
             }
         }
 
+        if (count($args) >= 1) {
+            return vsprintf($lookup, $args);
+        }
+        
         if ($html_out) {
             return '<span class="untranslated">' . $lookup . '</span>';
         } else {


### PR DESCRIPTION
Let's say someone wants to use English text as translation keys instead of constants. In that case, the en.yaml would stay empty. I know that's more effort to maintain if texts need to be changed, but it's faster to prototype this way.

The output of {{ "There are %d monkeys in the %s"|t(12, "London Zoo") }} should always be with replacements applied, regardless the contents of the yaml files.