### PR TITLE
bugfix: translation key couldn't contain dot

### DIFF
--- a/system/src/Grav/Common/Config/Languages.php
+++ b/system/src/Grav/Common/Config/Languages.php
@@ -41,4 +41,9 @@ class Languages extends Data
     {
         $this->items = array_merge_recursive($this->items, $data);
     }
+    
+    public function getTranslation($lang, $key, $default = null) 
+    {
+        return isset($this->items[$lang][$key]) ? $this->items[$lang][$key] : $default;
+    }
 }

--- a/system/src/Grav/Common/Config/Languages.php
+++ b/system/src/Grav/Common/Config/Languages.php
@@ -44,6 +44,6 @@ class Languages extends Data
     
     public function getTranslation($lang, $key, $default = null) 
     {
-        return isset($this->items[$lang][$key]) ? $this->items[$lang][$key] : $default;
+        return isset($this->items[$lang][$key]) ? $this->items[$lang][$key] : $this->get($lang . '.' . $key, $default);
     }
 }

--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -410,7 +410,7 @@ class Language
             }
 
             foreach ((array)$languages as $lang) {
-                $translation_array = (array)Grav::instance()['languages']->get($lang . '.' . $key, null);
+                $translation_array = (array)Grav::instance()['languages']->getTranslation($lang, $key, null);
                 if ($translation_array && array_key_exists($index, $translation_array)) {
                     return $translation_array[$index];
                 }
@@ -435,7 +435,7 @@ class Language
      */
     public function getTranslation($lang, $key, $array_support = false)
     {
-        $translation = Grav::instance()['languages']->get($lang . '.' . $key, null);
+        $translation = Grav::instance()['languages']->getTranslation($lang, $key, null);
         if (!$array_support && is_array($translation)) {
             return (string)array_shift($translation);
         }


### PR DESCRIPTION
Let's say someone wants to use English text as translation keys instead of constants. I know that's more effort to maintain if texts need to be changed, but it's faster to prototype this way.

{{ "This is a sentence."|t }} or {{ "e.g."|t }} wasn't working before due to "." being used as a separator by RocketTheme\Toolbox\ArrayTraits\NestedArrayAccess. This patch fixes it.