### PR TITLE
Fix `Utils::normalizePath()` truncating zeros out of path

### DIFF
--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -330,7 +330,7 @@ abstract class Utils
         $segments = explode('/', trim($path, '/'));
         $ret = [];
         foreach ($segments as $segment) {
-            if (($segment == '.') || empty($segment)) {
+            if (($segment == '.') || strlen($segment) == 0) {
                 continue;
             }
             if ($segment == '..') {


### PR DESCRIPTION
As per https://getgrav.org/forum#!/chitchat:file-x-is-not-within-the `Utils::normalizePath()` truncates zeros out of the path. The minimal use case to produce the issue is

```php
echo Utils::normalizePath('/3/0/2/1'); // returns '/3/2/1'
```

The reason is the `empty($segment)` check, which returns true for `empty('0')` due to type casting. This is obviosly wrong, since a path segment consisting of '0' is definitely non-empty ;-).