### PR TITLE
Remove end date check if not specified (better 32-bit support)

### DIFF
--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -270,17 +270,30 @@ class Collection extends Iterator
     public function dateRange($startDate, $endDate = false, $field = false)
     {
         $start = Utils::date2timestamp($startDate);
-        $end = $endDate ? Utils::date2timestamp($endDate) : strtotime("now +1000 years");
+        $end = $endDate ? Utils::date2timestamp($endDate) : false;
 
         $date_range = [];
 
-        foreach ($this->items as $path => $slug) {
-            $page = $this->pages->get($path);
-            if ($page !== null) {
-                $date = $field ? strtotime($page->value($field)) : $page->date();
+        if ($end) {
+            foreach ($this->items as $path => $slug) {
+                $page = $this->pages->get($path);
+                if ($page !== null) {
+                    $date = $field ? strtotime($page->value($field)) : $page->date();
 
-                if ($date > $start && $date < $end) {
-                    $date_range[$path] = $slug;
+                    if ($date > $start && $date < $end) {
+                        $date_range[$path] = $slug;
+                    }
+                }
+            }
+        } else {
+            foreach ($this->items as $path => $slug) {
+                $page = $this->pages->get($path);
+                if ($page !== null) {
+                    $date = $field ? strtotime($page->value($field)) : $page->date();
+
+                    if ($date > $start) {
+                        $date_range[$path] = $slug;
+                    }
                 }
             }
         }

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -280,7 +280,7 @@ class Collection extends Iterator
                 if ($page !== null) {
                     $date = $field ? strtotime($page->value($field)) : $page->date();
 
-                    if ($date > $start && $date < $end) {
+                    if ($date >= $start && $date <= $end) {
                         $date_range[$path] = $slug;
                     }
                 }
@@ -291,7 +291,7 @@ class Collection extends Iterator
                 if ($page !== null) {
                     $date = $field ? strtotime($page->value($field)) : $page->date();
 
-                    if ($date > $start) {
+                    if ($date >= $start) {
                         $date_range[$path] = $slug;
                     }
                 }


### PR DESCRIPTION
Related to https://github.com/getgrav/grav/issues/898

I can't find better way to remove it with DRY principle :expressionless:
With smaller code we need to check a value for each `$this->items` iteration.

Also it can be used with `PHP_INT_MAX` with previous version of this code.