### PR TITLE
Respect `enable_asset_timestamp` settings for pipelined Assets

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -668,17 +668,14 @@ class Assets
      */
     protected function pipelineCss($group = 'head')
     {
-        /** @var Cache $cache */
-        $cache = Grav::instance()['cache'];
-        $key = $cache->getKey();
-
         // temporary list of assets to pipeline
         $temp_css = [];
 
         // clear no-pipeline assets lists
         $this->css_no_pipeline = [];
 
-        $uid = md5(json_encode($this->css) . $this->css_minify . $this->css_rewrite . $group . $key);
+        // Compute uid based on assets and timestamp
+        $uid = md5(json_encode($this->css) . $this->css_minify . $this->css_rewrite . $group . time());
         $file =  $uid . '.css';
         $inline_file = $uid . '-inline.css';
 
@@ -753,17 +750,14 @@ class Assets
      */
     protected function pipelineJs($group = 'head')
     {
-        /** @var Cache $cache */
-        $cache = Grav::instance()['cache'];
-        $key = $cache->getKey();
-
         // temporary list of assets to pipeline
         $temp_js = [];
 
         // clear no-pipeline assets lists
         $this->js_no_pipeline = [];
 
-        $uid = md5(json_encode($this->js) . $this->js_minify . $group . $key);
+        // Compute uid based on assets and timestamp
+        $uid = md5(json_encode($this->js) . $this->js_minify . $group . time());
         $file =  $uid . '.js';
         $inline_file = $uid . '-inline.js';
 

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -668,13 +668,17 @@ class Assets
      */
     protected function pipelineCss($group = 'head')
     {
+        /** @var Cache $cache */
+        $cache = Grav::instance()['cache'];
+        $key = $cache->getKey();
+
         // temporary list of assets to pipeline
         $temp_css = [];
 
         // clear no-pipeline assets lists
         $this->css_no_pipeline = [];
 
-        $uid = md5(json_encode($this->css) . $this->css_minify . $this->css_rewrite . $group);
+        $uid = md5(json_encode($this->css) . $this->css_minify . $this->css_rewrite . $group . $key);
         $file =  $uid . '.css';
         $inline_file = $uid . '-inline.css';
 
@@ -749,13 +753,17 @@ class Assets
      */
     protected function pipelineJs($group = 'head')
     {
+        /** @var Cache $cache */
+        $cache = Grav::instance()['cache'];
+        $key = $cache->getKey();
+
         // temporary list of assets to pipeline
         $temp_js = [];
 
         // clear no-pipeline assets lists
         $this->js_no_pipeline = [];
 
-        $uid = md5(json_encode($this->js) . $this->js_minify . $group);
+        $uid = md5(json_encode($this->js) . $this->js_minify . $group . $key);
         $file =  $uid . '.js';
         $inline_file = $uid . '-inline.js';
 

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -668,10 +668,6 @@ class Assets
      */
     protected function pipelineCss($group = 'head')
     {
-        /** @var Cache $cache */
-        $cache = Grav::instance()['cache'];
-        $key = '?' . $cache->getKey();
-
         // temporary list of assets to pipeline
         $temp_css = [];
 
@@ -691,7 +687,7 @@ class Assets
 
         // If pipeline exist return it
         if (file_exists($this->assets_dir . $file)) {
-            return $relative_path . $key;
+            return $relative_path . $this->timestamp;
         }
 
         // Remove any non-pipeline files
@@ -738,7 +734,7 @@ class Assets
         if (strlen(trim($buffer)) > 0) {
             file_put_contents($this->assets_dir . $file, $buffer);
 
-            return $relative_path . $key;
+            return $relative_path . $this->timestamp;
         } else {
             return false;
         }
@@ -753,10 +749,6 @@ class Assets
      */
     protected function pipelineJs($group = 'head')
     {
-        /** @var Cache $cache */
-        $cache = Grav::instance()['cache'];
-        $key = '?' . $cache->getKey();
-
         // temporary list of assets to pipeline
         $temp_js = [];
 
@@ -776,7 +768,7 @@ class Assets
 
         // If pipeline exist return it
         if (file_exists($this->assets_dir . $file)) {
-            return $relative_path . $key;
+            return $relative_path . $this->timestamp;
         }
 
         // Remove any non-pipeline files
@@ -813,7 +805,7 @@ class Assets
         if (strlen(trim($buffer)) > 0) {
             file_put_contents($this->assets_dir . $file, $buffer);
 
-            return $relative_path . $key;
+            return $relative_path . $this->timestamp;
         } else {
             return false;
         }


### PR DESCRIPTION
I don't know if this is intentional, but the enabled `enable_asset_timestamp` settings is not respected for pipelined assets. Even if I disable this setting the cache key is always added.

I know why the cache key should be present due to browser cache invalidation of changes. However what I don't understand is then, why this setting currently only affects non-pipelined assets (see e.g. [Assets.php#L556](https://github.com/Sommerregen/grav/blob/4cec9851a1f51d78894ee2b5cab28570a3e343e8/system/src/Grav/Common/Assets.php#L556)).

This PR is for the lazy-man. Instead of opening an issue we can discuss it here or if this behavior is intentional, feel free to close it.