### PR TITLE
Add user to config

### DIFF
--- a/system/src/Grav/Common/User/User.php
+++ b/system/src/Grav/Common/User/User.php
@@ -29,7 +29,9 @@ class User extends Data
      */
     public static function load($username)
     {
-        $locator = Grav::instance()['locator'];
+        $grav = Grav::instance();
+        $locator = $grav['locator'];
+        $config = $grav['config'];
 
         // force lowercase of username
         $username = strtolower($username);
@@ -47,6 +49,9 @@ class User extends Data
         }
         $user = new User($content, $blueprint);
         $user->file($file);
+
+        // add user to config
+        $config->set("user", $user);
 
         return $user;
     }


### PR DESCRIPTION
I have a feeling that this is too "simple" in that no user specific config is merged with other configs but i stayed away from doing that so that plugin developers can choose whether to use user based config (for example the login plugin redirect) or if the want to use overarching config.