### PR TITLE
Feature: Better assets pipelining

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -361,7 +361,7 @@ class Assets
             'asset'    => $asset,
             'priority' => intval($priority ?: 10),
             'order'    => count($this->js),
-            'pipeline' => (bool)$pipeline,
+            'pipeline' => (bool) $pipeline,
             'loading'  => $loading ?: '',
             'group'    => $group ?: 'head',
             'modified' => $modified
@@ -1112,8 +1112,8 @@ class Assets
         } catch (\Exception $e) {
         }
 
-        $base_url = $absolute ? '/' : $this->base_url;
-        return $asset ? $base_url . ltrim($asset, '/') : false;
+        $uri = $absolute ? $asset : $this->base_url . ltrim($asset, '/');
+        return $asset ? $uri : false;
     }
 
     /**

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -677,14 +677,11 @@ class Assets
         // temporary list of assets to pipeline
         $temp_css = [];
 
-        /** @var Cache $cache */
-        $cache = Grav::instance()['cache'];
-
         // clear no-pipeline assets lists
         $this->css_no_pipeline = [];
 
         // Compute uid based on assets and timestamp
-        $uid = md5(json_encode($this->css) . $this->css_minify . $this->css_rewrite . $group . $cache->getKey());
+        $uid = md5(json_encode($this->css) . $this->css_minify . $this->css_rewrite . $group);
         $file =  $uid . '.css';
         $inline_file = $uid . '-inline.css';
 
@@ -762,14 +759,11 @@ class Assets
         // temporary list of assets to pipeline
         $temp_js = [];
 
-        /** @var Cache $cache */
-        $cache = Grav::instance()['cache'];
-
         // clear no-pipeline assets lists
         $this->js_no_pipeline = [];
 
         // Compute uid based on assets and timestamp
-        $uid = md5(json_encode($this->js) . $this->js_minify . $group . $cache->getKey());
+        $uid = md5(json_encode($this->js) . $this->js_minify . $group);
         $file =  $uid . '.js';
         $inline_file = $uid . '-inline.js';
 

--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -40,7 +40,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'priority' => 10,
             'order'    => 0,
             'pipeline' => true,
-            'group'    => 'head'
+            'group'    => 'head',
+            'modified' => false
         ], reset($array));
 
         $this->assets->add('test.js');
@@ -53,7 +54,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'priority' => 10,
             'order'    => 0,
             'pipeline' => true,
-            'group'    => 'head'
+            'group'    => 'head',
+            'modified' => false
         ], reset($array));
 
         //test addCss(). Test adding asset to a separate group
@@ -68,7 +70,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'priority' => 10,
             'order'    => 0,
             'pipeline' => true,
-            'group'    => 'head'
+            'group'    => 'head',
+            'modified' => false
         ], reset($array));
 
         //test addCss() adding asset to a separate group, and with an alternate rel attribute
@@ -90,7 +93,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'order'    => 0,
             'pipeline' => true,
             'loading'  => '',
-            'group'    => 'head'
+            'group'    => 'head',
+            'modified' => false
         ], reset($array));
 
         //Test CSS Groups
@@ -107,7 +111,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'priority' => 10,
             'order'    => 0,
             'pipeline' => true,
-            'group'    => 'footer'
+            'group'    => 'footer',
+            'modified' => false
         ], reset($array));
 
         //Test JS Groups
@@ -125,7 +130,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'order'    => 0,
             'pipeline' => true,
             'loading'  => '',
-            'group'    => 'footer'
+            'group'    => 'footer',
+            'modified' => false
         ], reset($array));
 
         //Test async / defer
@@ -141,7 +147,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'order'    => 0,
             'pipeline' => true,
             'loading'  => 'async',
-            'group'    => 'head'
+            'group'    => 'head',
+            'modified' => false
         ], reset($array));
 
         $this->assets->reset();
@@ -156,7 +163,8 @@ class AssetsTest extends \Codeception\TestCase\Test
             'order'    => 0,
             'pipeline' => true,
             'loading'  => 'defer',
-            'group'    => 'head'
+            'group'    => 'head',
+            'modified' => false
         ], reset($array));
 
         //Test adding media queries


### PR DESCRIPTION
This PR is an enhancement of PR #906, where we have used the cache key as a stable key for pipeline generation. Now whenever an asset has changed the pipeline will be regenerated again. This is possible, because a modification time is added to each (local) asset. Remote assets are ignored so far, since it is difficult to actually retrieve a reliable modification time...