### PR TITLE
add ext-zip requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "maximebf/debugbar": "~1.10",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-zip": "*"
     },
     "require-dev": {
         "codeception/codeception": "^2.1",


### PR DESCRIPTION
Hello,

I had ext-zip requirement in composer.json due to ZipArchive Usage.
When ext-zip isn't install, bin/gpm doesn't work.

Do you have a check config script, same as Symfony when installing for first time ?

bye