### PR TITLE
Improved `authorize` Twig extension

### DIFF
--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -729,11 +729,15 @@ class TwigExtension extends \Twig_Extension
     }
 
     /**
-     * Authorize an action. Returns true if the user is logged in and has the right to execute $action.
+     * Authorize an action. Returns true if the user is logged in and
+     * has the right to execute $action.
      *
-     * @param string $action
-     *
-     * @return bool
+     * @param  string|array $action An action or a list of actions. Each
+     *                              entry can be a string like 'group.action'
+     *                              or without dot notation an associative
+     *                              array.
+     * @return bool                 Returns TRUE if the user is authorized to
+     *                              perform the action, FALSE otherwise.
      */
     public function authorize($action)
     {
@@ -741,11 +745,14 @@ class TwigExtension extends \Twig_Extension
             return false;
         }
 
-        $action = (array)$action;
-
-        foreach ($action as $a) {
-            if ($this->grav['user']->authorize($a)) {
-                return true;
+        $action = (array) $action;
+        foreach ($action as $key => $perms) {
+            $prefix = is_int($key) ? '' : $key . '.';
+            $perms = $prefix ? (array) $perms : [$perms => true];
+            foreach ($perms as $action => $authenticated) {
+                if ($this->grav['user']->authorize($prefix . $action)) {
+                    return $authenticated;
+                }
             }
         }
 


### PR DESCRIPTION
This PR addresses https://getgrav.org/forum#!/general:hiding-certain-tabs-from-no and enhances the `authorize` Twig extension method with full backward-compatibility. Thus, it can be used as usual with

```php
authorize(['admin.super', 'admin.pages']);
authorize('admin.super');
```

or with the new changes with

```php
authorize([
  'admin' => [
    'super' => true
  ],
  'site' => [
    'user' => false
  ]
]);
```

which makes it possible to set access rights for tabs via blueprints as

````yaml
assets:
  type: tab
  title: Assets
  security:
    admin:
      super: true
    site:
      user: false
  fields:
     ...
```