### PR TITLE
Fix system.yaml

### DIFF
--- a/user/config/system.yaml
+++ b/user/config/system.yaml
@@ -5,7 +5,8 @@ home:
 
 pages:
   theme: antimatter
-  markdown_extra: false
+  markdown:
+    extra: false
   process:
     markdown: true
     twig: false


### PR DESCRIPTION
Markdown Extra is incorrectly specified as `markdown_extra`, whereas it should be:

```
  markdown:
    extra: false
```