### PR TITLE
ImageMedium#derivatives now works with image filters

### DIFF
--- a/system/src/Grav/Common/Page/Media.php
+++ b/system/src/Grav/Common/Page/Media.php
@@ -74,16 +74,12 @@ class Media extends Getters
             }
 
             // Create the base medium
-            if (!empty($types['base'])) {
+            if (empty($types['base'])) {
+                $max = max(array_keys($types['alternative']));
+                $medium = $types['alternative'][$max]['file'];
+            } else {
                 $medium = MediumFactory::fromFile($types['base']['file']);
                 $medium && $medium->set('size', $types['base']['size']);
-            } else if (!empty($types['alternative'])) {
-                $altMedium = reset($types['alternative']);
-                $ratio = key($types['alternative']);
-
-                $altMedium = $altMedium['file'];
-
-                $medium = MediumFactory::scaledFromMedium($altMedium, $ratio, 1)['file'];
             }
 
             if (empty($medium)) {
@@ -103,10 +99,9 @@ class Media extends Getters
             // Build missing alternatives
             if (!empty($types['alternative'])) {
                 $alternatives = $types['alternative'];
-
                 $max = max(array_keys($alternatives));
 
-                for ($i=2; $i < $max; $i++) {
+                for ($i=$max; $i > 0; $i--) {
                     if (isset($alternatives[$i])) {
                         continue;
                     }
@@ -115,7 +110,9 @@ class Media extends Getters
                 }
 
                 foreach ($types['alternative'] as $ratio => $altMedium) {
-                    $medium->addAlternative($ratio, $altMedium['file']);
+                    if ($altMedium['file'] != $medium) {
+                        $medium->addAlternative($ratio, $altMedium['file']);
+                    }
                 }
             }
 

--- a/system/src/Grav/Common/Page/Media.php
+++ b/system/src/Grav/Common/Page/Media.php
@@ -101,7 +101,7 @@ class Media extends Getters
                 $alternatives = $types['alternative'];
                 $max = max(array_keys($alternatives));
 
-                for ($i=$max; $i > 0; $i--) {
+                for ($i=$max; $i > 1; $i--) {
                     if (isset($alternatives[$i])) {
                         continue;
                     }

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -228,7 +228,7 @@ class ImageMedium extends Medium
         // Clear any alternatives that have already been implied by the image's
         // filename (eg. ones that had "@2x" or similar appended to their
         // filenames)
-        $this->clearAlternatives();
+        $this->reset();
 
         while ($width <= $max_width) {
             $ratio = $width / $this->get('width');

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -239,12 +239,20 @@ class ImageMedium extends Medium
             }
 
             $derivative = MediumFactory::fromFile($this->get('filepath'));
-            $derivative_width = $derivative->get('width') * $ratio;
-            $derivative_height = $derivative->get('height') * $ratio;
-            $derivative->resize($derivative_width, $derivative_height);
-            $derivative->set('width', $derivative_width);
-            $derivative->set('height', $derivative_height);
-            $this->addAlternative($ratio, $derivative);
+
+            // It's possible that MediumFactory::fromFile returns null if the
+            // original image file no longer exists and this class instance was
+            // retrieved from the page cache
+            if (isset($derivative)) {
+                $derivative_width = $derivative->get('width') * $ratio;
+                $derivative_height = $derivative->get('height') * $ratio;
+
+                $derivative->resize($derivative_width, $derivative_height);
+                $derivative->set('width', $derivative_width);
+                $derivative->set('height', $derivative_height);
+
+                $this->addAlternative($ratio, $derivative);
+            }
         }
 
         return $this;

--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -100,7 +100,7 @@ class Medium extends Data implements RenderableInterface
         }
 
         $alternative->set('ratio', $ratio);
-        $this->alternatives[(float) $ratio] = $alternative;
+        $this->alternatives[(string) $ratio] = $alternative;
     }
 
     /**

--- a/system/src/Grav/Common/Page/Medium/MediumFactory.php
+++ b/system/src/Grav/Common/Page/Medium/MediumFactory.php
@@ -119,8 +119,8 @@ class MediumFactory
         }
 
         $ratio = $to / $from;
-        $width = (int) ($medium->get('width') * $ratio);
-        $height = (int) ($medium->get('height') * $ratio);
+        $width = $medium->get('width') * $ratio;
+        $height = $medium->get('height') * $ratio;
 
         $basename = $medium->get('basename');
         $basename = str_replace('@'.$from.'x', '@'.$to.'x', $basename);


### PR DESCRIPTION
My original motivation for writing this PR was the problem described in #1016, where using the `derivatives` method on an image in a Twig template wouldn't work well in combination with the other method of producing responsive images in Grav - appending a pixel density indicator to the image's filename (eg. "@2x").

The underlying problem here also meant that image filters would not work in combination with image derivatives. They would work with image alternatives, which is what was generated from appending "@2x" to the filename of the image, but it wouldn't work with derivatives.

This commit fixes both the first and the second problem by making it so that the ImageMedium#derivatives method doesn't add image variants to a separate array, but rather to the same array as it would have if the filename method was used.

I've made some line comments to highlight a few things in the code as well!