### PR TITLE
New `bin/gpm direct-install` command

### DIFF
--- a/bin/gpm
+++ b/bin/gpm
@@ -67,6 +67,7 @@ $app->addCommands(array(
     new \Grav\Console\Gpm\UninstallCommand(),
     new \Grav\Console\Gpm\UpdateCommand(),
     new \Grav\Console\Gpm\SelfupgradeCommand(),
+    new \Grav\Console\Gpm\DirectInstallCommand(),
 ));
 
 $app->run();

--- a/system/src/Grav/Common/Filesystem/Folder.php
+++ b/system/src/Grav/Common/Filesystem/Folder.php
@@ -179,7 +179,7 @@ abstract class Folder
         /** @var UniformResourceLocator $locator */
         $locator = Grav::instance()['locator'];
         if ($recursive) {
-            $flags = \RecursiveDirectoryIterator::SKIP_DOTS + \FilesystemIterator::UNIX_PATHS 
+            $flags = \RecursiveDirectoryIterator::SKIP_DOTS + \FilesystemIterator::UNIX_PATHS
                 + \FilesystemIterator::CURRENT_AS_SELF + \FilesystemIterator::FOLLOW_SYMLINKS;
             if ($locator->isStream($path)) {
                 $directory = $locator->getRecursiveIterator($path, $flags);
@@ -403,10 +403,7 @@ abstract class Folder
 
         // If the destination directory does not exist create it
         if (!is_dir($dest)) {
-            if (!mkdir($dest)) {
-                // If the destination directory could not be created stop processing
-                return false;
-            }
+            Folder::mkdir($dest);
         }
 
         // Open the source directory to read in files

--- a/system/src/Grav/Common/GPM/Installer.php
+++ b/system/src/Grav/Common/GPM/Installer.php
@@ -64,13 +64,13 @@ class Installer
     /**
      * Installs a given package to a given destination.
      *
-     * @param  string $source     The local path to the ZIP package
+     * @param  string $zip the local path to ZIP package
      * @param  string $destination The local path to the Grav Instance
-     * @param  array  $options     Options to use for installing. ie, ['install_path' => 'user/themes/antimatter']
-     *
-     * @return boolean True if everything went fine, False otherwise.
+     * @param  array $options Options to use for installing. ie, ['install_path' => 'user/themes/antimatter']
+     * @param  string $extracted The local path to the extacted ZIP package
+     * @return bool True if everything went fine, False otherwise.
      */
-    public static function install($source, $destination, $options = [])
+    public static function install($zip, $destination, $options = [], $extracted = null)
     {
         $destination = rtrim($destination, DS);
         $options = array_merge(self::$options, $options);
@@ -88,40 +88,26 @@ class Installer
             return false;
         }
 
-        $zip = new \ZipArchive();
-        $archive = $zip->open($source);
+        // Create a tmp location
+        $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
+        $tmp = $tmp_dir . '/Grav-' . uniqid();
 
-        if ($archive === true) {
-            $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
-            $tmp = $tmp_dir . '/Grav-' . uniqid();
-
-            Folder::mkdir($tmp);
-
-            $unzip = $zip->extractTo($tmp);
-
-            if (!$unzip) {
-                self::$error = self::ZIP_EXTRACT_ERROR;
-                $zip->close();
+        if (!$extracted) {
+            $extracted = self::unZip($zip, $tmp);
+            if (!$extracted) {
                 Folder::delete($tmp);
-
                 return false;
             }
-
-            $package_folder_name = $zip->getNameIndex(0);
-            $installer_file_folder = $tmp . '/' . $package_folder_name;
-
-        } else {
-            $installer_file_folder = $source;
         }
 
-        if (!file_exists($installer_file_folder)) {
+        if (!file_exists($extracted)) {
             self::$error = self::INVALID_SOURCE;
             return false;
         }
 
 
         $is_install = true;
-        $installer = self::loadInstaller($installer_file_folder, $is_install);
+        $installer = self::loadInstaller($extracted, $is_install);
 
         if (isset($options['is_update']) && $options['is_update'] === true) {
             $method = 'preUpdate';
@@ -143,16 +129,15 @@ class Installer
 
         if (!$options['sophisticated']) {
             if ($options['theme']) {
-                self::copyInstall($zip, $install_path, $tmp);
+                self::copyInstall($extracted, $install_path);
             } else {
-                self::moveInstall($zip, $install_path, $tmp);
+                self::moveInstall($extracted, $install_path);
             }
         } else {
-            self::sophisticatedInstall($zip, $install_path, $tmp);
+            self::sophisticatedInstall($extracted, $install_path);
         }
 
         Folder::delete($tmp);
-        $zip->close();
 
         if (isset($options['is_update']) && $options['is_update'] === true) {
             $method = 'postUpdate';
@@ -169,6 +154,42 @@ class Installer
 
         return true;
 
+    }
+
+    /**
+     * Unzip a file to somewhere
+     *
+     * @param $zip_file
+     * @param $destination
+     * @return bool|string
+     */
+    public static function unZip($zip_file, $destination)
+    {
+        $zip = new \ZipArchive();
+        $archive = $zip->open($zip_file);
+
+        if ($archive === true) {
+            Folder::mkdir($destination);
+
+            $unzip = $zip->extractTo($destination);
+
+
+            if (!$unzip) {
+                self::$error = self::ZIP_EXTRACT_ERROR;
+                Folder::delete($destination);
+                $zip->close();
+                return false;
+            }
+
+            $package_folder_name = $zip->getNameIndex(0);
+            $zip->close();
+            $extracted_folder = $destination . '/' . $package_folder_name;
+
+            return $extracted_folder;
+        }
+
+        self::$error = self::ZIP_EXTRACT_ERROR;
+        return false;
     }
 
 
@@ -220,80 +241,67 @@ class Installer
     }
 
     /**
-     * @param \ZipArchive $zip
+     * @param             $source_path
      * @param             $install_path
-     * @param             $tmp
      *
      * @return bool
      */
-    public static function moveInstall(\ZipArchive $zip, $install_path, $tmp)
+    public static function moveInstall($source_path, $install_path)
     {
-        $container = $zip->getNameIndex(0);
         if (file_exists($install_path)) {
             Folder::delete($install_path);
         }
 
-        Folder::move($tmp . DS . $container, $install_path);
+        Folder::move($source_path, $install_path);
 
         return true;
     }
 
     /**
-     * @param \ZipArchive $zip
+     * @param             $source_path
      * @param             $install_path
-     * @param             $tmp
      *
      * @return bool
      */
-    public static function copyInstall(\ZipArchive $zip, $install_path, $tmp)
+    public static function copyInstall($source_path, $install_path)
     {
-        $firstDir = $zip->getNameIndex(0);
-        if (empty($firstDir)) {
-            throw new \RuntimeException("Directory $firstDir is missing");
+        if (empty($source_path)) {
+            throw new \RuntimeException("Directory $source_path is missing");
         } else {
-            $tmp = realpath($tmp . DS . $firstDir);
-            Folder::rcopy($tmp, $install_path);
+            Folder::rcopy($source_path, $install_path);
         }
 
         return true;
     }
 
     /**
-     * @param \ZipArchive $zip
+     * @param             $source_path
      * @param             $install_path
-     * @param             $tmp
      *
      * @return bool
      */
-    public static function sophisticatedInstall(\ZipArchive $zip, $install_path, $tmp)
+    public static function sophisticatedInstall($source_path, $install_path)
     {
-        for ($i = 0, $l = $zip->numFiles; $i < $l; $i++) {
-            $filename = $zip->getNameIndex($i);
-            $fileinfo = pathinfo($filename);
-            $depth = count(explode(DS, rtrim($filename, '/')));
+        foreach (new \DirectoryIterator($source_path) as $file) {
 
-            if ($depth > 2) {
+            if ($file->isLink() || $file->isDot()) {
                 continue;
             }
 
-            $path = $install_path . DS . $fileinfo['basename'];
+            $path = $install_path . DS . $file->getBasename();
 
-            if (is_link($path)) {
-                continue;
-            } else {
-                if (is_dir($path)) {
-//                    Folder::delete($path);
-//                    Folder::move($tmp . DS . $filename, $path);
+            if ($file->isDir()) {
+                Folder::delete($path);
+                Folder::move($file->getPathname(), $path);
 
-                    if ($fileinfo['basename'] == 'bin') {
-                        foreach (glob($path . DS . '*') as $file) {
-//                            @chmod($file, 0755);
-                        }
+                if ($file->getBasename() == 'bin') {
+                    foreach (glob($path . DS . '*') as $bin_file) {
+                           @chmod($bin_file, 0755);
                     }
-                } else {
-//                    @unlink($path);
-//                    @copy($tmp . DS . $filename, $path);
                 }
+            } else {
+                @unlink($path);
+                @copy($file->getPathname(), $path);
             }
         }
 

--- a/system/src/Grav/Console/Gpm/DirectInstallCommand.php
+++ b/system/src/Grav/Console/Gpm/DirectInstallCommand.php
@@ -120,19 +120,6 @@ class DirectInstallCommand extends ConsoleCommand
 
             if ($type == 'grav') {
 
-                $this->output->write("  |- Checking destination...  ");
-                if ($this->gravSymlinked()) {
-                    $this->output->write("\x0D");
-                    $this->output->writeln("  |- Checking destination...  <yellow>symbolic link</yellow>");
-                    $this->output->writeln("  '- <red>ERROR: symlinks found...</red> <yellow>" . GRAV_ROOT."</yellow>");
-                    $this->output->writeln('');
-                    exit;
-
-                } else {
-                    $this->output->write("\x0D");
-                    $this->output->writeln("  |- Checking destination...  <green>ok</green>");
-                }
-
                 $this->output->write("  |- Installing package...  ");
                 Installer::install($zip, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true], $extracted);
             } else {
@@ -191,18 +178,6 @@ class DirectInstallCommand extends ConsoleCommand
 
         return true;
 
-    }
-
-    /**
-     * Determine if Grav is symlinked (system is all we need to check)
-     *
-     * @return bool
-     */
-    protected function gravSymlinked()
-    {
-        if (is_link(GRAV_ROOT . DS . 'system')) {
-            return true;
-        }
     }
 
     /**
@@ -290,12 +265,7 @@ class DirectInstallCommand extends ConsoleCommand
      */
     protected function isRemote($file)
     {
-        if (filter_var($file, FILTER_VALIDATE_URL))
-        {
-            return true;
-        } else {
-            return false;
-        }
+        return (bool) filter_var($file, FILTER_VALIDATE_URL);
     }
 
     /**

--- a/system/src/Grav/Console/Gpm/DirectInstallCommand.php
+++ b/system/src/Grav/Console/Gpm/DirectInstallCommand.php
@@ -9,22 +9,16 @@
 namespace Grav\Console\Gpm;
 
 use Grav\Common\Grav;
+use Grav\Common\Utils;
 use Grav\Common\Filesystem\Folder;
-use Grav\Common\GPM\GPM;
 use Grav\Common\GPM\Installer;
 use Grav\Common\GPM\Response;
-use Grav\Common\GPM\Remote\Package as Package;
-
 use Grav\Console\ConsoleCommand;
 use Symfony\Component\Console\Input\InputArgument;
-
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class DirectInstallCommand extends ConsoleCommand
 {
-
-    protected $tmp;
 
     /**
      *
@@ -48,42 +42,185 @@ class DirectInstallCommand extends ConsoleCommand
      */
     protected function serve()
     {
-
         $package_file = $this->input->getArgument('package-file');
 
-        if ($this->isRemote($package_file)) {
-            $local_file = $this->downloadPackage($package_file);
-        } else {
-            $local_file = $this->copyPackage($package_file);
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('Are you sure you want to direct-install <cyan>'.$package_file.'</cyan> [y|N] ', false);
+
+        $answer = $helper->ask($this->input, $this->output, $question);
+
+        if (!$answer) {
+            $this->output->writeln("existing...");
+            $this->output->writeln('');
+            exit;
         }
 
-        if (file_exists($local_file)) {
-            $this->output->writeln($local_file);
-            $extracted_location = $this->unzipPackage($local_file);
+        $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
+        $tmp_zip = $tmp_dir . '/Grav-' . uniqid();
 
-            $type = $this->getPackageType($extracted_location);
+        $this->output->writeln("");
+        $this->output->writeln("Preparing to install <cyan>" . $package_file . "</cyan>");
 
-            if ($type == 'grav') {
-                Installer::install($extracted_location, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true]);
-            } else {
-//                $destination =
+
+        if ($this->isRemote($package_file)) {
+            $zip = $this->downloadPackage($package_file, $tmp_zip);
+        } else {
+            $zip = $this->copyPackage($package_file, $tmp_zip);
+        }
+
+        if (file_exists($zip)) {
+            $tmp_source = $tmp_dir . '/Grav-' . uniqid();
+
+            $this->output->write("  |- Extracting package...    ");
+            $extracted = Installer::unZip($zip, $tmp_source);
+
+            if (!$extracted) {
+                $this->output->write("\x0D");
+                $this->output->writeln("  |- Extracting package...    <red>failed</red>");
+                exit;
             }
 
-            // if Grav:
-            //Installer::install($this->file, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true]);
-            // If Theme or Plugin
-            //Installer::install($this->file, $this->destination, ['install_path' => $package->install_path, 'theme' => (($type == 'themes')), 'is_update' => $is_update]);
-            $error_code = Installer::lastErrorCode();
-            Folder::delete($local_file);
+            $this->output->write("\x0D");
+            $this->output->writeln("  |- Extracting package...    <green>ok</green>");
 
+            $type = $this->getPackageType($extracted);
+
+            if (!$type) {
+                $this->output->writeln("  '- <red>ERROR: Not a valid Grav package</red>");
+                $this->output->writeln('');
+                exit;
+            }
+
+            if ($type == 'grav') {
+
+                $this->output->write("  |- Checking destination...  ");
+                if ($this->gravSymlinked()) {
+                    $this->output->write("\x0D");
+                    $this->output->writeln("  |- Checking destination...  <yellow>symbolic link</yellow>");
+                    $this->output->writeln("  '- <red>ERROR: symlinks found...</red> <yellow>" . GRAV_ROOT."</yellow>");
+                    $this->output->writeln('');
+                    exit;
+
+                } else {
+                    $this->output->write("\x0D");
+                    $this->output->writeln("  |- Checking destination...  <green>ok</green>");
+                }
+
+                $this->output->write("  |- Installing package...  ");
+                Installer::install($zip, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true], $extracted);
+            } else {
+                $name = $this->getPackageName($extracted);
+
+                if (!$name) {
+                    $this->output->writeln("<red>ERROR: Name could not be determined.</red> Please specify with --name|-n");
+                    $this->output->writeln('');
+                    exit;
+                }
+
+                $install_path = $this->getInstallPath($type, $name);
+                $is_update = file_exists($install_path);
+
+                $this->output->write("  |- Checking destination...  ");
+
+                Installer::isValidDestination(GRAV_ROOT . DS . $install_path);
+                if (Installer::lastErrorCode() == Installer::IS_LINK) {
+                    $this->output->write("\x0D");
+                    $this->output->writeln("  |- Checking destination...  <yellow>symbolic link</yellow>");
+                    $this->output->writeln("  '- <red>ERROR: symlink found...</red>  <yellow>" . GRAV_ROOT . DS . $install_path . '</yellow>');
+                    $this->output->writeln('');
+                    exit;
+
+                } else {
+                    $this->output->write("\x0D");
+                    $this->output->writeln("  |- Checking destination...  <green>ok</green>");
+                }
+
+                $this->output->write("  |- Installing package...  ");
+
+                Installer::install($zip, GRAV_ROOT, ['install_path' => $install_path, 'theme' => (($type == 'theme')), 'is_update' => $is_update], $extracted);
+            }
+
+            Folder::delete($tmp_source);
+
+            $this->output->write("\x0D");
+
+            if(Installer::lastErrorCode()) {
+                $this->output->writeln("  '- <red>Installation failed or aborted.</red>");
+                $this->output->writeln('');
+            } else {
+                $this->output->writeln("  |- Installing package...    <green>ok</green>");
+                $this->output->writeln("  '- <green>Success!</green>  ");
+                $this->output->writeln('');
+            }
 
         } else {
-            // error about jacked up local file
+            $this->output->writeln("  '- <red>ERROR: ZIP package could not be found</red>");
         }
 
+        Folder::delete($tmp_zip);
+
+        // clear cache after successful upgrade
+        $this->clearCache();
+
+        return true;
 
     }
 
+    /**
+     * Determine if Grav is symlinked (system is all we need to check)
+     *
+     * @return bool
+     */
+    protected function gravSymlinked()
+    {
+        if (is_link(GRAV_ROOT . DS . 'system')) {
+            return true;
+        }
+    }
+
+    /**
+     * Get the install path for a name and a particular type of package
+     *
+     * @param $type
+     * @param $name
+     * @return string
+     */
+    protected function getInstallPath($type, $name)
+    {
+        $locator = Grav::instance()['locator'];
+
+        if ($type == 'theme') {
+            $install_path = $locator->findResource('themes://', false) . DS . $name;
+        } else {
+            $install_path = $locator->findResource('plugins://', false) . DS . $name;
+        }
+        return $install_path;
+    }
+
+    /**
+     * Try to guess the package name from the source files
+     *
+     * @param $source
+     * @return bool|string
+     */
+    protected function getPackageName($source)
+    {
+        foreach (glob($source . "*.yaml") as $filename) {
+            $name = strtolower(basename($filename, '.yaml'));
+            if ($name == 'blueprints') {
+                continue;
+            }
+            return $name;
+        }
+        return false;
+    }
+
+    /**
+     * Try to guess the package type from the source files
+     *
+     * @param $source
+     * @return bool|string
+     */
     protected function getPackageType($source)
     {
         if (
@@ -92,10 +229,38 @@ class DirectInstallCommand extends ConsoleCommand
         ) {
             return 'grav';
         } else {
+            // must have a blueprint
+            if (!file_exists($source . '/blueprints.yaml')) {
+                return false;
+            }
+
             // either theme or plugin
+            $name = basename($source);
+            if (Utils::contains($name, 'theme')) {
+                return 'theme';
+            } elseif (Utils::contains($name, 'plugin')) {
+                return 'plugin';
+            }
+            foreach (glob($source . "*.php") as $filename) {
+                $contents = file_get_contents($filename);
+                if (Utils::contains($contents, 'Grav\Common\Theme')) {
+                    return 'theme';
+                } elseif (Utils::contains($contents, 'Grav\Common\Plugin')) {
+                    return 'plugin';
+                }
+            }
+
+            // Assume it's a theme
+            return 'theme';
         }
     }
 
+    /**
+     * Determine if this is a local or a remote file
+     *
+     * @param $file
+     * @return bool
+     */
     protected function isRemote($file)
     {
         if (filter_var($file, FILTER_VALIDATE_URL))
@@ -106,82 +271,64 @@ class DirectInstallCommand extends ConsoleCommand
         }
     }
 
-    private function unzipPackage($zipfile)
+    /**
+     * Download the zip package via the URL
+     *
+     * @param $package_file
+     * @param $tmp
+     * @return null|string
+     */
+    private function downloadPackage($package_file, $tmp)
     {
-        $zip = new \ZipArchive();
-        $archive = $zip->open($zipfile);
+        $this->output->write("  |- Downloading package...     0%");
 
-
-        if ($archive !== true) {
-            self::$error = 'Couldn\'t open ZIP file';
-
-            return false;
-        }
-
-        $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
-        $tmp = $tmp_dir . '/Grav-' . uniqid();
-
-        Folder::mkdir($tmp);
-
-        $unzip = $zip->extractTo($tmp);
-
-        if (!$unzip) {
-            self::$error = 'Extraction of ZIP failed';
-            $zip->close();
-            Folder::delete($tmp);
-
-            return false;
-        }
-
-        $package_folder_name = $zip->getNameIndex(0);
-        $installer_file_folder = $tmp . '/' . $package_folder_name;
-
-        return $installer_file_folder;
-    }
-
-    private function downloadPackage($package_file)
-    {
         $package = parse_url($package_file);
 
-        $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
-        $this->tmp = $tmp_dir . '/Grav-' . uniqid();
+
         $filename = basename($package['path']);
         $output = Response::get($package_file, [], [$this, 'progress']);
 
         if ($output) {
-            Folder::mkdir($this->tmp);
+            Folder::mkdir($tmp);
 
             $this->output->write("\x0D");
             $this->output->write("  |- Downloading package...   100%");
             $this->output->writeln('');
 
-            file_put_contents($this->tmp . DS . $filename, $output);
+            file_put_contents($tmp . DS . $filename, $output);
 
-            return $this->tmp . DS . $filename;
+            return $tmp . DS . $filename;
         }
 
         return null;
 
     }
 
-    private function copyPackage($package_file)
+    /**
+     * Copy the local zip package to tmp
+     *
+     * @param $package_file
+     * @param $tmp
+     * @return null|string
+     */
+    private function copyPackage($package_file, $tmp)
     {
+        $this->output->write("  |- Copying package...         0%");
+
         $package_file = realpath($package_file);
 
         if (file_exists($package_file)) {
-            $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
-            $this->tmp = $tmp_dir . '/Grav-' . uniqid();
             $filename = basename($package_file);
 
-            Folder::mkdir($this->tmp);
+            Folder::mkdir($tmp);
 
             $this->output->write("\x0D");
-            $this->output->write("  |- Downloading package...   100%");
+            $this->output->write("  |- Copying package...       100%");
             $this->output->writeln('');
 
-            copy(realpath($package_file), $this->tmp . DS . $filename);
+            copy(realpath($package_file), $tmp . DS . $filename);
 
-            return $this->tmp . DS . $filename;
+            return $tmp . DS . $filename;
         }
 
         return null;

--- a/system/src/Grav/Console/Gpm/DirectInstallCommand.php
+++ b/system/src/Grav/Console/Gpm/DirectInstallCommand.php
@@ -120,6 +120,19 @@ class DirectInstallCommand extends ConsoleCommand
 
             if ($type == 'grav') {
 
+                $this->output->write("  |- Checking destination...  ");
+                Installer::isValidDestination(GRAV_ROOT . '/system');
+                if (Installer::IS_LINK === Installer::lastErrorCode()) {
+                    $this->output->write("\x0D");
+                    $this->output->writeln("  |- Checking destination...  <yellow>symbolic link</yellow>");
+                    $this->output->writeln("  '- <red>ERROR: symlinks found...</red> <yellow>" . GRAV_ROOT."</yellow>");
+                    $this->output->writeln('');
+                    exit;
+                }
+
+                $this->output->write("\x0D");
+                $this->output->writeln("  |- Checking destination...  <green>ok</green>");
+
                 $this->output->write("  |- Installing package...  ");
                 Installer::install($zip, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true], $extracted);
             } else {

--- a/system/src/Grav/Console/Gpm/DirectInstallCommand.php
+++ b/system/src/Grav/Console/Gpm/DirectInstallCommand.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @package    Grav.Console
+ *
+ * @copyright  Copyright (C) 2014 - 2016 RocketTheme, LLC. All rights reserved.
+ * @license    MIT License; see LICENSE file for details.
+ */
+
+namespace Grav\Console\Gpm;
+
+use Grav\Common\Grav;
+use Grav\Common\Filesystem\Folder;
+use Grav\Common\GPM\GPM;
+use Grav\Common\GPM\Installer;
+use Grav\Common\GPM\Response;
+use Grav\Common\GPM\Remote\Package as Package;
+
+use Grav\Console\ConsoleCommand;
+use Symfony\Component\Console\Input\InputArgument;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class DirectInstallCommand extends ConsoleCommand
+{
+
+    protected $tmp;
+
+    /**
+     *
+     */
+    protected function configure()
+    {
+        $this
+            ->setName("direct-install")
+            ->setAliases(['directinstall'])
+            ->addArgument(
+                'package-file',
+                InputArgument::REQUIRED,
+                'The local location or remote URL to an installable package file'
+            )
+            ->setDescription("Installs Grav, plugin, or theme directly from a file or a URL")
+            ->setHelp('The <info>direct-install</info> command installs Grav, plugin, or theme directly from a file or a URL');
+    }
+
+    /**
+     * @return int|null|void
+     */
+    protected function serve()
+    {
+
+        $package_file = $this->input->getArgument('package-file');
+
+        if ($this->isRemote($package_file)) {
+            $local_file = $this->downloadPackage($package_file);
+        } else {
+            $local_file = $this->copyPackage($package_file);
+        }
+
+        if (file_exists($local_file)) {
+            $this->output->writeln($local_file);
+            $extracted_location = $this->unzipPackage($local_file);
+
+            $type = $this->getPackageType($extracted_location);
+
+            if ($type == 'grav') {
+                Installer::install($extracted_location, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true]);
+            } else {
+//                $destination =
+            }
+
+            // if Grav:
+            //Installer::install($this->file, GRAV_ROOT, ['sophisticated' => true, 'overwrite' => true, 'ignore_symlinks' => true]);
+            // If Theme or Plugin
+            //Installer::install($this->file, $this->destination, ['install_path' => $package->install_path, 'theme' => (($type == 'themes')), 'is_update' => $is_update]);
+            $error_code = Installer::lastErrorCode();
+            Folder::delete($local_file);
+
+
+        } else {
+            // error about jacked up local file
+        }
+
+
+    }
+
+    protected function getPackageType($source)
+    {
+        if (
+            file_exists($source . '/system/defines.php') &&
+            file_exists($source . '/system/config/system.yaml')
+        ) {
+            return 'grav';
+        } else {
+            // either theme or plugin
+        }
+    }
+
+    protected function isRemote($file)
+    {
+        if (filter_var($file, FILTER_VALIDATE_URL))
+        {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private function unzipPackage($zipfile)
+    {
+        $zip = new \ZipArchive();
+        $archive = $zip->open($zipfile);
+
+
+        if ($archive !== true) {
+            self::$error = 'Couldn\'t open ZIP file';
+
+            return false;
+        }
+
+        $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
+        $tmp = $tmp_dir . '/Grav-' . uniqid();
+
+        Folder::mkdir($tmp);
+
+        $unzip = $zip->extractTo($tmp);
+
+        if (!$unzip) {
+            self::$error = 'Extraction of ZIP failed';
+            $zip->close();
+            Folder::delete($tmp);
+
+            return false;
+        }
+
+        $package_folder_name = $zip->getNameIndex(0);
+        $installer_file_folder = $tmp . '/' . $package_folder_name;
+
+        return $installer_file_folder;
+    }
+
+    private function downloadPackage($package_file)
+    {
+        $package = parse_url($package_file);
+
+        $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
+        $this->tmp = $tmp_dir . '/Grav-' . uniqid();
+        $filename = basename($package['path']);
+        $output = Response::get($package_file, [], [$this, 'progress']);
+
+        if ($output) {
+            Folder::mkdir($this->tmp);
+
+            $this->output->write("\x0D");
+            $this->output->write("  |- Downloading package...   100%");
+            $this->output->writeln('');
+
+            file_put_contents($this->tmp . DS . $filename, $output);
+
+            return $this->tmp . DS . $filename;
+        }
+
+        return null;
+
+    }
+
+    private function copyPackage($package_file)
+    {
+        $package_file = realpath($package_file);
+
+        if (file_exists($package_file)) {
+            $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
+            $this->tmp = $tmp_dir . '/Grav-' . uniqid();
+            $filename = basename($package_file);
+
+            Folder::mkdir($this->tmp);
+
+            $this->output->write("\x0D");
+            $this->output->write("  |- Downloading package...   100%");
+            $this->output->writeln('');
+
+            copy(realpath($package_file), $this->tmp . DS . $filename);
+
+            return $this->tmp . DS . $filename;
+        }
+
+        return null;
+
+    }
+}


### PR DESCRIPTION
## Overview
This allows for direct installation of a local ZIP package or a remote URL based ZIP package.  

## Purpose

This command is intended for testing or troubleshooting where you might want to install a particular version of a plugin or a theme.  

## Usage

For example to install v1.0.1 of the **Cors** plugin:

```
bin/gpm direct-install https://github.com/getgrav/grav-plugin-cors/archive/1.0.1.zip
```

To install a local plugin:

```
bin/gpm direct-install /Users/bob/downloads/grav-plugin-archives.zip
```

This also works for Grav core, however, if you install a version prior to the introduction of `bin/gpm direct-install` you won't be able to use the command after you 'downgrade'

```
bin/gpm direct-install https://github.com/getgrav/grav/releases/download/1.1.4/grav-update-v1.1.4.zip
```

## Notes

1. This command will not allow installation on top of **symlinked directories** (that also goes for symlinked installations of Grav itself
2. This command **does not pay attention to dependencies**.  Please use `bin/gpm install` for that.
