### PR TITLE
SSL Verify Peer

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -982,6 +982,27 @@ form:
                     label: PLUGIN_ADMIN.PROXY_URL
                     help: PLUGIN_ADMIN.PROXY_URL_HELP
 
+                gpm.method:
+                    type: toggle
+                    label: PLUGIN_ADMIN.GPM_METHOD
+                    highlight: auto
+                    help: PLUGIN_ADMIN.GPM_METHOD_HELP
+                    options:
+                        auto: PLUGIN_ADMIN.AUTO
+                        fopen: PLUGIN_ADMIN.FOPEN
+                        curl: PLUGIN_ADMIN.CURL
+
+                gpm.verify_peer:
+                    type: toggle
+                    label: PLUGIN_ADMIN.VERIFY_PEER
+                    highlight: 1
+                    help: PLUGIN_ADMIN.VERIFY_PEER_HELP
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    validate:
+                        type: bool
+
                 reverse_proxy_setup:
                     type: toggle
                     label: PLUGIN_ADMIN.REVERSE_PROXY

--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -994,9 +994,9 @@ form:
 
                 gpm.verify_peer:
                     type: toggle
-                    label: PLUGIN_ADMIN.VERIFY_PEER
+                    label: PLUGIN_ADMIN.GPM_VERIFY_PEER
                     highlight: 1
-                    help: PLUGIN_ADMIN.VERIFY_PEER_HELP
+                    help: PLUGIN_ADMIN.GPM_VERIFY_PEER_HELP
                     options:
                         1: PLUGIN_ADMIN.YES
                         0: PLUGIN_ADMIN.NO

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -129,3 +129,5 @@ session:
 gpm:
   releases: stable                           # Set to either 'stable' or 'testing'
   proxy_url:                                 # Configure a manual proxy URL for GPM (eg 127.0.0.1:3128)
+  method: 'auto'                             # Either 'curl', 'fopen' or 'auto'. 'auto' will try fopen first and if not available cURL
+  verify_peer: false                          # Sometimes on some systems (Windows most commonly) GPM is unable to connect because the SSL certificate cannot be verified. Disabling this setting might help.

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -130,4 +130,4 @@ gpm:
   releases: stable                           # Set to either 'stable' or 'testing'
   proxy_url:                                 # Configure a manual proxy URL for GPM (eg 127.0.0.1:3128)
   method: 'auto'                             # Either 'curl', 'fopen' or 'auto'. 'auto' will try fopen first and if not available cURL
-  verify_peer: false                          # Sometimes on some systems (Windows most commonly) GPM is unable to connect because the SSL certificate cannot be verified. Disabling this setting might help.
+  verify_peer: true                          # Sometimes on some systems (Windows most commonly) GPM is unable to connect because the SSL certificate cannot be verified. Disabling this setting might help.

--- a/system/src/Grav/Common/GPM/Response.php
+++ b/system/src/Grav/Common/GPM/Response.php
@@ -41,6 +41,7 @@ class Response
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_TIMEOUT        => 15,
             CURLOPT_HEADER         => false,
+            //CURLOPT_SSL_VERIFYPEER => false, // this is set in the constructor since it's a setting
             /**
              * Example of callback parameters from within your own class
              */
@@ -48,11 +49,17 @@ class Response
             //CURLOPT_PROGRESSFUNCTION => [$this, 'progress']
         ],
         'fopen' => [
-            'method'          => 'GET',
-            'user_agent'      => 'Grav GPM',
-            'max_redirects'   => 5,
-            'follow_location' => 1,
-            'timeout'         => 15,
+            'method'           => 'GET',
+            'user_agent'       => 'Grav GPM',
+            'max_redirects'    => 5,
+            'follow_location'  => 1,
+            'timeout'          => 15,
+            /* // this is set in the constructor since it's a setting
+            'ssl'              => [
+                'verify_peer'      => false,
+                'verify_peer_name' => false,
+            ],
+            */
             /**
              * Example of callback parameters from within your own class
              */
@@ -101,8 +108,59 @@ class Response
         } catch (\Exception $e) {
         }
 
-        $options = array_replace_recursive(self::$defaults, $options);
-        $method  = 'get' . ucfirst(strtolower(self::$method));
+        $config = Grav::instance()['config'];
+        $overrides = [];
+
+        // SSL Verify Peer and Proxy Setting
+        $settings = [
+            'method'      => $config->get('system.gpm.method', self::$method),
+            'verify_peer' => $config->get('system.gpm.verify_peer', true),
+            // `system.proxy_url` is for fallback
+            // introduced with 1.1.0-beta.1 probably safe to remove at some point
+            'proxy_url'   => $config->get('system.gpm.proxy_url', $config->get('system.proxy_url', false)),
+        ];
+
+        $overrides = array_replace_recursive([], $overrides, [
+            'curl' => [
+                CURLOPT_SSL_VERIFYPEER => $settings['verify_peer']
+            ],
+            'fopen' => [
+                'ssl' => [
+                    'verify_peer' => $settings['verify_peer'],
+                    'verify_peer_name' => $settings['verify_peer'],
+                ]
+            ]
+        ]);
+
+        // Proxy Setting
+        if ($settings['proxy_url']) {
+            $proxy = parse_url($settings['proxy_url']);
+            $fopen_proxy = ($proxy['scheme'] ?: 'http') . '://' . $proxy['host'] . (isset($proxy['port']) ? ':' . $proxy['port'] : '');
+
+            $overrides = array_replace_recursive([], $overrides, [
+                'curl' => [
+                    CURLOPT_PROXY => $proxy['host'],
+                    CURLOPT_PROXYTYPE => 'HTTP'
+                ],
+                'fopen' => [
+                    'proxy'           => $fopen_proxy,
+                    'request_fulluri' => true
+                ]
+            ]);
+
+            if (isset($proxy['port'])) {
+                $overrides['curl'][CURLOPT_PROXYPORT] = $proxy['port'];
+            }
+
+            if (isset($proxy['user']) && isset($proxy['pass'])) {
+                $fopen_auth = $auth = base64_encode($proxy['user'] . ':' . $proxy['pass']);
+                $overrides['curl'][CURLOPT_PROXYUSERPWD] = $proxy['user'] . ':' . $proxy['pass'];
+                $overrides['fopen']['header'] = "Proxy-Authorization: Basic $fopen_auth";
+            }
+        }
+
+        $options = array_replace_recursive(self::$defaults, $options, $overrides);
+        $method  = 'get' . ucfirst(strtolower($settings['method']));
 
         self::$callback = $callback;
         return static::$method($uri, $options, $callback);
@@ -199,21 +257,6 @@ class Response
         $options  = $args[1];
         $callback = $args[2];
 
-        // if proxy set add that
-        $config = Grav::instance()['config'];
-        $proxy_url = $config->get('system.gpm.proxy_url', $config->get('system.proxy_url'));
-        if ($proxy_url) {
-            $parsed_url = parse_url($proxy_url);
-
-            $options['fopen']['proxy'] = ($parsed_url['scheme'] ?: 'http') . '://' . $parsed_url['host'] . (isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '');
-            $options['fopen']['request_fulluri'] = true;
-
-            if (isset($parsed_url['user']) && isset($parsed_url['pass'])) {
-                $auth = base64_encode($parsed_url['user'] . ':' . $parsed_url['pass']);
-                $options['fopen']['header'] = "Proxy-Authorization: Basic $auth";
-            }
-        }
-
         if ($callback) {
             $options['fopen']['notification'] = ['self', 'progress'];
         }
@@ -274,24 +317,6 @@ class Response
                     CURLOPT_PROGRESSFUNCTION => ['self', 'progress']
                 ]
             );
-        }
-
-        // if proxy set add that
-        $config = Grav::instance()['config'];
-        $proxy_url = $config->get('system.gpm.proxy_url', $config->get('system.proxy_url'));
-        if ($proxy_url) {
-            $parsed_url = parse_url($proxy_url);
-
-            $options['curl'][CURLOPT_PROXY] = $parsed_url['host'];
-            $options['curl'][CURLOPT_PROXYTYPE] = 'HTTP';
-
-            if (isset($parsed_url['port'])) {
-                $options['curl'][CURLOPT_PROXYPORT] = $parsed_url['port'];
-            }
-
-            if (isset($parsed_url['user']) && isset($parsed_url['pass'])) {
-                $options['curl'][CURLOPT_PROXYUSERPWD] = $parsed_url['user'] . ':' . $parsed_url['pass'];
-            }
         }
 
         // no open_basedir set, we can proceed normally

--- a/system/src/Grav/Common/GPM/Response.php
+++ b/system/src/Grav/Common/GPM/Response.php
@@ -41,7 +41,7 @@ class Response
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_TIMEOUT        => 15,
             CURLOPT_HEADER         => false,
-            //CURLOPT_SSL_VERIFYPEER => false, // this is set in the constructor since it's a setting
+            //CURLOPT_SSL_VERIFYPEER => true, // this is set in the constructor since it's a setting
             /**
              * Example of callback parameters from within your own class
              */
@@ -56,8 +56,8 @@ class Response
             'timeout'          => 15,
             /* // this is set in the constructor since it's a setting
             'ssl'              => [
-                'verify_peer'      => false,
-                'verify_peer_name' => false,
+                'verify_peer'      => true,
+                'verify_peer_name' => true,
             ],
             */
             /**


### PR DESCRIPTION
## Overview
In some occasions we've noticed people unable to connect to GPM. After further investigations it turns out that on some systems (Windows only has been confirmed so far), the SSL certificate cannot be verified, causing GPM to fail (references: #1044, #1008 and potentially #850).
The to go solution is to disable the peer verification from `cURL` and `fopen`.

## Purpose
This PR adds 2 new optional system config: `system.gpm.verify_peer` (default: `true`) and `system.gpm.method` (default: `auto`).

## `system.gpm.verify_peer`

When enabled, the SSL certificate gets verified by either fopen or cURL methods. If disabled the checks is skipped (this is not advised but might be the only viable solution for some people)

## `system.gpm.method`

By default is set to `auto`. Auto automatically tests if the `fopen` mechanism is available and if it is gets used. Otherwise it tries to see if `cURL` is available and if it is use that instead.

Usually `auto` works fine but there might be some instances where some might want to force either methods. This new setting will allow to do so.

## Notes
 * As long as the changes reported above, this PR also makes some code rearrangement for the Proxy, it should just work the same but might be good to get this reviewed/tested.
 * This PR also introduces settings for Admin, new lang have been added with https://github.com/getgrav/grav-plugin-admin/commit/0a2b1d790f4cb4b189837c215eeda158a75e44dd.