### PR TITLE
Adding xlsm to supported mime types

### DIFF
--- a/system/config/media.yaml
+++ b/system/config/media.yaml
@@ -114,6 +114,9 @@ types:
   xlm:
     type: file
     mime: application/vnd.ms-excel
+  xlsm:
+    type: file
+    mime: application/vnd.ms-excel
   xld:
     type: file
     mime: application/vnd.ms-excel


### PR DESCRIPTION
Most of Excel family is there except for macro-capable xls in Office 2007. Tested and working to enable .xlsm file upload.