### PR TITLE
Adds a check for the header 'HTTP_X_FORWARDED_PROTO'

### DIFF
--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -125,6 +125,8 @@ class Uri
         // set the base
         if (isset($_SERVER['HTTPS'])) {
             $scheme = (strtolower(@$_SERVER['HTTPS']) == 'on') ? 'https://' : 'http://';
+        } elseif ( (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https') ) {
+            $scheme = 'https://';
         } else {
             $scheme = 'http://';
         }


### PR DESCRIPTION
Adds a check for the header 'HTTP_X_FORWARDED_PROTO' to discover whether the scheme should be 'https'. This is necessary in some shared hosting or load balancing situations where the SSL negotiation happens upstream.