### PR TITLE
Check for modular folder in `Types::scanTemplates`

### DIFF
--- a/system/src/Grav/Common/Page/Types.php
+++ b/system/src/Grav/Common/Page/Types.php
@@ -82,8 +82,10 @@ class Types implements \ArrayAccess, \Iterator, \Countable
         }
 
         $modular_uri = rtrim($uri, '/') . '/modular';
-        foreach (Folder::all($modular_uri, $options) as $type) {
-            $this->register('modular/' . $type);
+        if (is_dir($modular_uri)) {
+            foreach (Folder::all($modular_uri, $options) as $type) {
+                $this->register('modular/' . $type);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes #1059 and allows themes not to have any `templates/modular` folder right now, if they don't provide modular templates either.