### PR TITLE
.htaccess change to detect HTTPS forwarding

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,6 +13,16 @@ RewriteEngine On
 
 ## End - RewriteBase
 
+## Begin - X-Forwarded-Proto
+# In some hosted or load balanced environments, SSL negotiation happens upstream.
+# In order for Grav to recognize the connection as secure, you need to uncomment
+# the following lines.
+#
+# RewriteCond %{HTTP:X-Forwarded-Proto} https
+# RewriteRule .* - [E=HTTPS:on]
+#
+## End - X-Forwarded-Proto
+
 ## Begin - Exploits
 # If you experience problems on your site block out the operations listed below
 # This attempts to block the most common type of exploit `attempts` to Grav


### PR DESCRIPTION
In some hosted or load balanced environments, SSL negotiation happens upstream. In order for Grav to recognize the connections as secure, you need to check for the 'HTTP_X_FORWARDED_PROTO' header.

I know @w00fz had concerns about header forging, and I don't see how this approach sidesteps that, but at least it's not in the Grav code itself. I'm open to adding some wording to the description, warning against any hazards. I don't know enough to know what the real risks are. In my case, I trust my provider to manage the SSL correctly. 

I hope I'm not wasting your time. I'm just trying to get `\Grav\Common\Uri` to natively generate `https` URLs. I just want to give back if it will help make things easier for future users. I've already created a Grav-specific page on my provider's wiki explaining the fix.

Thanks for your time!