### PR TITLE
Proposal to add 'wordwrap' to list of built-in twig filters

### DIFF
--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -79,7 +79,7 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFilter('regex_replace', [$this, 'regexReplace']),
             new \Twig_SimpleFilter('safe_email', [$this, 'safeEmailFilter']),
             new \Twig_SimpleFilter('safe_truncate', ['\Grav\Common\Utils', 'safeTruncate']),
-            new \Twig_SimpleFilter('wordwrap', 'wordwrap'),
+            new \Twig_SimpleFilter('wordwrap', ['\Grav\Common\Utils', 'wordwrap']),
             new \Twig_SimpleFilter('safe_truncate_html', ['\Grav\Common\Utils', 'safeTruncateHTML']),
             new \Twig_SimpleFilter('sort_by_key', [$this, 'sortByKeyFilter']),
             new \Twig_SimpleFilter('starts_with', [$this, 'startsWithFilter']),

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -79,6 +79,7 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFilter('regex_replace', [$this, 'regexReplace']),
             new \Twig_SimpleFilter('safe_email', [$this, 'safeEmailFilter']),
             new \Twig_SimpleFilter('safe_truncate', ['\Grav\Common\Utils', 'safeTruncate']),
+            new \Twig_SimpleFilter('wordwrap', ['\Grav\Common\Utils', 'wordwrap']),
             new \Twig_SimpleFilter('safe_truncate_html', ['\Grav\Common\Utils', 'safeTruncateHTML']),
             new \Twig_SimpleFilter('sort_by_key', [$this, 'sortByKeyFilter']),
             new \Twig_SimpleFilter('starts_with', [$this, 'startsWithFilter']),

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -79,7 +79,7 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFilter('regex_replace', [$this, 'regexReplace']),
             new \Twig_SimpleFilter('safe_email', [$this, 'safeEmailFilter']),
             new \Twig_SimpleFilter('safe_truncate', ['\Grav\Common\Utils', 'safeTruncate']),
-            new \Twig_SimpleFilter('wordwrap', ['\Grav\Common\Utils', 'wordwrap']),
+            new \Twig_SimpleFilter('wordwrap', 'wordwrap'),
             new \Twig_SimpleFilter('safe_truncate_html', ['\Grav\Common\Utils', 'safeTruncateHTML']),
             new \Twig_SimpleFilter('sort_by_key', [$this, 'sortByKeyFilter']),
             new \Twig_SimpleFilter('starts_with', [$this, 'startsWithFilter']),

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -166,18 +166,43 @@ abstract class Utils
     }
 
     /**
-     * Truncate text by number of characters in a "word-safe" manor.
+     * Truncate text by number of characters in a "word-safe" manner.
      *
      * @param string $string
      * @param int    $limit
+     * @param string $break
+     * @param string $pad
      *
      * @return string
      */
-    public static function safeTruncate($string, $limit = 150)
+    public static function safeTruncate($string, $limit = 150, $break = " ", $pad = "&hellip;")
     {
-        return static::truncate($string, $limit, true);
+        return static::truncate($string, $limit, true, $break, $pad);
     }
 
+    /**
+     * Word wrap a string at a given column length in a "word-safe" manner.
+     *
+     * @param string $string    The string to be wrapped
+     * @param int    $limit     The maximum width of a given line
+     * @param string $eol       The string you wish to use to separate the lines
+     * @param string $break     The string at which you can break a line
+     * @param string $pad       The string used by the upstream `truncate` function to break a line with
+     *
+     * @return string
+     */
+    public static function wordwrap($string, $limit = 150, $eol = "\n", $break = " ", $pad = '') {
+        $lines = [];
+
+        $working = $string;
+        while (mb_strlen($working) > 0) {
+            $line = static::safeTruncate($working, $limit, $break, $pad);
+            $lines[] = $line;
+            $working = mb_substr($working, mb_strlen($line));
+        }
+
+        return implode($eol, $lines);
+    }
 
     /**
      * Truncate HTML by number of characters. not "word-safe"!
@@ -194,7 +219,7 @@ abstract class Utils
     }
 
     /**
-     * Truncate HTML by number of characters in a "word-safe" manor.
+     * Truncate HTML by number of characters in a "word-safe" manner.
      *
      * @param  string $text
      * @param  int    $length in words

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -181,30 +181,6 @@ abstract class Utils
     }
 
     /**
-     * Word wrap a string at a given column length in a "word-safe" manner.
-     *
-     * @param string $string    The string to be wrapped
-     * @param int    $limit     The maximum width of a given line
-     * @param string $eol       The string you wish to use to separate the lines
-     * @param string $break     The string at which you can break a line
-     * @param string $pad       The string used by the upstream `truncate` function to break a line with
-     *
-     * @return string
-     */
-    public static function wordwrap($string, $limit = 150, $eol = "\n", $break = " ", $pad = '') {
-        $lines = [];
-
-        $working = $string;
-        while (mb_strlen($working) > 0) {
-            $line = static::safeTruncate($working, $limit, $break, $pad);
-            $lines[] = $line;
-            $working = mb_substr($working, mb_strlen($line));
-        }
-
-        return implode($eol, $lines);
-    }
-
-    /**
      * Truncate HTML by number of characters. not "word-safe"!
      *
      * @param  string $text

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -181,6 +181,84 @@ abstract class Utils
     }
 
     /**
+     * Word wrap a string at a given column length in a "word-safe" manner.
+     *
+     * @param string $string    The string to be wrapped
+     * @param int    $limit     The maximum width of a given line
+     * @param string $eol       The string you wish to use to separate the lines
+     * @param string $break     The string at which you can break a line
+     *
+     * @return string
+     * 
+     * We can't leverage Utils::truncate() because of how it handles long words at the end of the string.
+     */
+     public static function wordwrap($string, $limit = 150, $eol = "\n", $break = " ") {
+        $lines = [];
+
+        $working = $string;
+        while (mb_strlen($working) > 0) {
+            $line = '';
+
+            // return with no change if string is shorter than $limit
+            if (mb_strlen($working) <= $limit) {
+                $line = $working;
+            }
+
+            // is $break present between $limit and the end of the string?
+            elseif (($breakpoint = static::findBreakpoint($working, $limit, $break)) !== null) {
+                $line = mb_substr($working, 0, $breakpoint);
+            } else {
+                $line = $working;
+            }
+
+            $lines[] = $line;
+            $working = mb_substr($working, mb_strlen($line)+1);
+        }
+        return implode($eol, $lines);
+    }
+
+    /**
+     * Find the breakpoint to support word-safe wordwrapping
+     *
+     * @param string $string    The string to be searched
+     * @param int    $limit     The maximum width of a given line
+     * @param string $breakstr  The string at which you can break a line
+     *
+     * @return integer
+     */
+    private static function findBreakpoint($string, $limit, $breakstr=" ") {
+        $breaks = [];
+
+        $last = 0;
+        while (($last = mb_strpos($string, $breakstr, $last)) !== false) {
+            $breaks[] = $last;
+            $last = $last + mb_strlen($breakstr);
+            if ($last > $limit) {
+                break;
+            }
+        }
+
+        if (count($breaks) === 0) {
+            # We're at the end of the string and there is no break string anywhere.
+            return null;
+        } elseif (count($breaks) === 1) {
+            # The break string doesn't occur within the limit,
+            # but there's a break point after, meaning there's still string that needs breaking. 
+            return $breaks[0];
+        } else {
+            $last = end($breaks);
+            $secondlast = prev($breaks);
+            if ($last <= $limit) {
+                # Edge case near the end of the string.
+                return $last;
+            } else {
+                # This is the most common case.
+                return $secondlast;
+            }
+        }
+    }
+
+    /**
      * Truncate HTML by number of characters. not "word-safe"!
      *
      * @param  string $text

--- a/tests/unit/Grav/Common/Twig/TwigExtensionTest.php
+++ b/tests/unit/Grav/Common/Twig/TwigExtensionTest.php
@@ -123,6 +123,18 @@ class TwigExtensionTest extends \Codeception\TestCase\Test
 
     }
 
+    public function testWordwrapFilter() {
+        $teststr = 'Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error albucius eum. Sit no quas populo accusamus.';
+        $results80 = "Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error\nalbucius eum. Sit no quas populo accusamus.";
+        $results40 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei posse\nerror albucius eum. Sit no quas populo\naccusamus.";
+        $results39 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei\nposse error albucius eum. Sit no quas\npopulo accusamus.";
+        $results10 = "Lorem\nipsum\ndolor sit\namet,\nsolet\nrecusabo\nconcludaturque\neu duo, ei\nposse\nerror\nalbucius\neum. Sit\nno quas\npopulo\naccusamus.";
+        $this->assertSame($results80,   $this->twig_ext->wordwrap($teststr, 80));
+        $this->assertSame($results40,   $this->twig_ext->wordwrap($teststr, 40));
+        $this->assertSame($results39,   $this->twig_ext->wordwrap($teststr, 39));
+        $this->assertSame($results10,   $this->twig_ext->wordwrap($teststr, 10));
+    }
+
     public function testRepeatFunc()
     {
 

--- a/tests/unit/Grav/Common/Twig/TwigExtensionTest.php
+++ b/tests/unit/Grav/Common/Twig/TwigExtensionTest.php
@@ -123,18 +123,6 @@ class TwigExtensionTest extends \Codeception\TestCase\Test
 
     }
 
-    public function testWordwrapFilter() {
-        $teststr = 'Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error albucius eum. Sit no quas populo accusamus.';
-        $results80 = "Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error\nalbucius eum. Sit no quas populo accusamus.";
-        $results40 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei posse\nerror albucius eum. Sit no quas populo\naccusamus.";
-        $results39 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei\nposse error albucius eum. Sit no quas\npopulo accusamus.";
-        $results10 = "Lorem\nipsum\ndolor sit\namet,\nsolet\nrecusabo\nconcludaturque\neu duo, ei\nposse\nerror\nalbucius\neum. Sit\nno quas\npopulo\naccusamus.";
-        $this->assertSame($results80,   $this->twig_ext->wordwrap($teststr, 80));
-        $this->assertSame($results40,   $this->twig_ext->wordwrap($teststr, 40));
-        $this->assertSame($results39,   $this->twig_ext->wordwrap($teststr, 39));
-        $this->assertSame($results10,   $this->twig_ext->wordwrap($teststr, 10));
-    }
-
     public function testRepeatFunc()
     {
 

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -114,6 +114,28 @@ class UtilsTest extends \Codeception\TestCase\Test
 
     }
 
+    public function testWordwrap() {
+        $teststr = 'Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error albucius eum. Sit no quas populo accusamus.';
+        $mb_teststr = 'Лорем ипсум долор сит амет, цум еа иллуд платонем инцидеринт, еу хис феугиат сцаевола! Фацилис диссентиет яуо еи, еум ет.';
+        $r80 = "Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error\nalbucius eum. Sit no quas populo accusamus.";
+        $mb_r80 = "Лорем ипсум долор сит амет, цум еа иллуд платонем инцидеринт, еу хис феугиат\nсцаевола! Фацилис диссентиет яуо еи, еум ет.";
+        $r40 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei posse\nerror albucius eum. Sit no quas populo\naccusamus.";
+        $mb_r40 = "Лорем ипсум долор сит амет, цум еа иллуд\nплатонем инцидеринт, еу хис феугиат\nсцаевола! Фацилис диссентиет яуо еи, еум\nет.";
+        $r39 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei\nposse error albucius eum. Sit no quas\npopulo accusamus.";
+        $mb_r39 = "Лорем ипсум долор сит амет, цум еа\nиллуд платонем инцидеринт, еу хис\nфеугиат сцаевола! Фацилис диссентиет\nяуо еи, еум ет.";
+        $r10 = "Lorem\nipsum\ndolor sit\namet,\nsolet\nrecusabo\nconcludaturque\neu duo, ei\nposse\nerror\nalbucius\neum. Sit\nno quas\npopulo\naccusamus.";
+        $mb_r10 = "Лорем\nипсум\nдолор сит\nамет, цум\nеа иллуд\nплатонем\nинцидеринт,\nеу хис\nфеугиат\nсцаевола!\nФацилис\nдиссентиет\nяуо еи,\nеум ет.";
+
+        $this->assertEquals($r80, Utils::wordwrap($teststr, 80));
+        $this->assertEquals($r40, Utils::wordwrap($teststr, 40));
+        $this->assertEquals($r39, Utils::wordwrap($teststr, 39));
+        $this->assertEquals($r10, Utils::wordwrap($teststr, 10));
+        $this->assertEquals($mb_r80, Utils::wordwrap($mb_teststr, 80));
+        $this->assertEquals($mb_r40, Utils::wordwrap($mb_teststr, 40));
+        $this->assertEquals($mb_r39, Utils::wordwrap($mb_teststr, 39));
+        $this->assertEquals($mb_r10, Utils::wordwrap($mb_teststr, 10));
+    }
+
     public function testSafeTruncate()
     {
         $this->assertEquals('This ', Utils::safeTruncate('This is a string to truncate', 1));

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -116,14 +116,15 @@ class UtilsTest extends \Codeception\TestCase\Test
 
     public function testWordwrap() {
         $teststr = 'Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error albucius eum. Sit no quas populo accusamus.';
-        $mb_teststr = 'Лорем ипсум долор сит амет, цум еа иллуд платонем инцидеринт, еу хис феугиат сцаевола! Фацилис диссентиет яуо еи, еум ет.';
         $r80 = "Lorem ipsum dolor sit amet, solet recusabo concludaturque eu duo, ei posse error\nalbucius eum. Sit no quas populo accusamus.";
-        $mb_r80 = "Лорем ипсум долор сит амет, цум еа иллуд платонем инцидеринт, еу хис феугиат\nсцаевола! Фацилис диссентиет яуо еи, еум ет.";
         $r40 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei posse\nerror albucius eum. Sit no quas populo\naccusamus.";
-        $mb_r40 = "Лорем ипсум долор сит амет, цум еа иллуд\nплатонем инцидеринт, еу хис феугиат\nсцаевола! Фацилис диссентиет яуо еи, еум\nет.";
         $r39 = "Lorem ipsum dolor sit amet, solet\nrecusabo concludaturque eu duo, ei\nposse error albucius eum. Sit no quas\npopulo accusamus.";
-        $mb_r39 = "Лорем ипсум долор сит амет, цум еа\nиллуд платонем инцидеринт, еу хис\nфеугиат сцаевола! Фацилис диссентиет\nяуо еи, еум ет.";
         $r10 = "Lorem\nipsum\ndolor sit\namet,\nsolet\nrecusabo\nconcludaturque\neu duo, ei\nposse\nerror\nalbucius\neum. Sit\nno quas\npopulo\naccusamus.";
+
+        $mb_teststr = 'Лорем ипсум долор сит амет, цум еа иллуд платонем инцидеринт, еу хис феугиат сцаевола! Фацилис диссентиет яуо еи, еум ет.';
+        $mb_r80 = "Лорем ипсум долор сит амет, цум еа иллуд платонем инцидеринт, еу хис феугиат\nсцаевола! Фацилис диссентиет яуо еи, еум ет.";
+        $mb_r40 = "Лорем ипсум долор сит амет, цум еа иллуд\nплатонем инцидеринт, еу хис феугиат\nсцаевола! Фацилис диссентиет яуо еи, еум\nет.";
+        $mb_r39 = "Лорем ипсум долор сит амет, цум еа\nиллуд платонем инцидеринт, еу хис\nфеугиат сцаевола! Фацилис диссентиет\nяуо еи, еум ет.";
         $mb_r10 = "Лорем\nипсум\nдолор сит\nамет, цум\nеа иллуд\nплатонем\nинцидеринт,\nеу хис\nфеугиат\nсцаевола!\nФацилис\nдиссентиет\nяуо еи,\nеум ет.";
 
         $this->assertEquals($r80, Utils::wordwrap($teststr, 80));


### PR DESCRIPTION
I'm proposing to include this because it's a natural extension of the already existing `truncate` filters.
- Fixed two typos
- Added backwards-compatible parameters to `safeTruncate` function.
- Wrote a `wordwrap` filter that leverages `safeTruncate` to wrap a long string at a given length in a word-safe manner.

Thanks!
