### PR TITLE
Adding 'system.errors.verbosity' to eventually replace 'system.errors.display'

### DIFF
--- a/system/src/Grav/Common/Errors/BareHandler.php
+++ b/system/src/Grav/Common/Errors/BareHandler.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package    Grav.Common.Errors
+ *
+ * @copyright  Copyright (C) 2014 - 2016 RocketTheme, LLC. All rights reserved.
+ * @license    MIT License; see LICENSE file for details.
+ */
+
+namespace Grav\Common\Errors;
+
+use Whoops\Handler\Handler;
+
+class BareHandler extends Handler
+{
+
+    /**
+     * @return int|null
+     */
+    public function handle()
+    {
+        return Handler::QUIT;
+    }
+
+}

--- a/system/src/Grav/Common/Errors/Errors.php
+++ b/system/src/Grav/Common/Errors/Errors.php
@@ -22,16 +22,34 @@ class Errors
         // Setup Whoops-based error handler
         $whoops = new \Whoops\Run;
 
-        if (isset($config['display'])) {
-            if ($config['display']) {
+        // Verbosity to eventually replace `display` entirely.
+        // If not set (legacy config) use `display`.
+        // Otherwise set to 0.
+        $verbosity = 0;
+        if (! isset($config['verbosity'])) {
+            if ( (isset($config['display'])) && ($config['display']) ) {
+                $verbosity = 2;
+            } else {
+                $verbosity = 1;
+            }
+        } else {
+            $verbosity = $config['verbosity'];
+        }
+
+        switch ($verbosity) {
+            case 2:
                 $error_page = new Whoops\Handler\PrettyPageHandler;
                 $error_page->setPageTitle('Crikey! There was an error...');
                 $error_page->addResourcePath(GRAV_ROOT . '/system/assets');
                 $error_page->addCustomCss('whoops.css');
                 $whoops->pushHandler($error_page);
-            } else {
+                break;
+            case 1:
                 $whoops->pushHandler(new SimplePageHandler);
-            }
+                break;
+            case 0:
+                $whoops->pushHandler(new BareHandler);
+                break;
         }
 
         if (method_exists('Whoops\Util\Misc', 'isAjaxRequest')) { //Whoops 2.0


### PR DESCRIPTION
* Introduces three levels of verbosity:
  * 2: Full stack trace
  * 1: Current Grav error page
  * 0: Bare 500 response

* Backwards compatible
  * If `verbosity` isn't set, then it looks at `display`.
  * Otherwise, `verbosity` is taken *instead of* `display`.
  * If accepted, I suggest marking `display` as deprecated for a release or two and documenting the change. 
  * Adopting this approach will not break legacy installs. Not updating your config file results in zero change in Grav behaviour.

References Issue #1064 and closed PR #1089. Thanks!