### PR TITLE
Added autoplay and hide controls methods

### DIFF
--- a/system/src/Grav/Common/Page/Medium/VideoMedium.php
+++ b/system/src/Grav/Common/Page/Medium/VideoMedium.php
@@ -30,6 +30,33 @@ class VideoMedium extends Medium
         ];
     }
 
+
+    /**
+     * Set video autoplay on
+     *
+     * @return $this
+     */
+    public function autoplay()
+    {
+        $this->attributes['autoplay'] = true;
+
+        return $this;
+    }
+
+
+    /**
+     * Set controls visibility off
+     *
+     * @return $this
+     */
+    public function hideControls()
+    {
+        unset($this->attributes['controls']);
+
+        return $this;
+    }
+
+
     /**
      * Reset medium.
      *

--- a/system/src/Grav/Common/Page/Medium/VideoMedium.php
+++ b/system/src/Grav/Common/Page/Medium/VideoMedium.php
@@ -45,6 +45,19 @@ class VideoMedium extends Medium
 
 
     /**
+     * Set video loop
+     *
+     * @return $this
+     */
+    public function loop()
+    {
+        $this->attributes['loop'] = true;
+
+        return $this;
+    }
+
+
+    /**
      * Set controls visibility off
      *
      * @return $this


### PR DESCRIPTION
VideoMedium doesn't have a public interface that allows to set some basic video tag attributes like "autoplay" or to remove the "controls" attribute. 

I decided to implement two public methods that can supply the missing functionality for add the attribute "autoplay" and remove the "controls" attribute.
