### PR TITLE
feat(admin): add setting to split admin and front-end session

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -967,6 +967,18 @@ form:
                     label: PLUGIN_ADMIN.SESSION_PATH
                     help: PLUGIN_ADMIN.SESSION_PATH_HELP
 
+                session.split_admin:
+                    type: toggle
+                    label: PLUGIN_ADMIN.SESSION_SPLIT
+                    help: PLUGIN_ADMIN.SESSION_SPLIT_HELP
+                    highlight: 1
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    default: true
+                    validate:
+                        type: bool
+
         advanced:
             type: section
             title: PLUGIN_ADMIN.ADVANCED

--- a/system/src/Grav/Common/Session.php
+++ b/system/src/Grav/Common/Session.php
@@ -77,7 +77,12 @@ class Session extends BaseSession
 
             $unique_identifier = GRAV_ROOT;
             $inflector = new Inflector();
-            $this->setName($inflector->hyphenize($config->get('system.session.name', 'grav_site')) . '-' . substr(md5($unique_identifier), 0, 7) . ($is_admin ? '-admin' : ''));
+            $session_name = $inflector->hyphenize($config->get('system.session.name', 'grav_site')) . '-' . substr(md5($unique_identifier), 0, 7);
+            $split_admin_session = $config->get('system.session.split_admin', true);
+            if ($is_admin && $split_admin_session) {
+              $session_name .= '-admin';
+            }
+            $this->setName($session_name);
             $this->start();
             setcookie(session_name(), session_id(), time() + $session_timeout, $session_path, $domain, $secure, $httponly);
         }


### PR DESCRIPTION
It was discussed in #1085 

The default is to use a split session as before.

I will also create a PR for the admin plugin with these translations (en):

```
SESSION_SPLIT: "Split admin & front-end session"
SESSION_SPLIT_HELP: "By changing this field, your session will become invalid and you will be required to login again."
```