### PR TITLE
functions added to taxonomy and twigextension

### DIFF
--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -126,4 +126,20 @@ class Taxonomy
 
         return $this->taxonomy_map;
     }
+    
+    /**
+     * Gets item keys per taxonomy
+     *
+     * @param  string $taxonomy       taxonomy name
+     *
+     * @return array                  keys of this taxonomy
+     */
+    public function getTaxonomyItemKeys($taxonomy) {
+        if (isset($this->taxonomy_map[$taxonomy])) {
+
+            $results = array_keys($this->taxonomy_map[$taxonomy]);
+
+            return $results;
+        }
+    }
 }

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -115,6 +115,7 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('url', [$this, 'urlFunc']),
             new \Twig_SimpleFunction('json_decode', [$this, 'jsonDecodeFilter']),
             new \Twig_SimpleFunction('get_cookie', [$this, 'getCookie']),
+            new \Twig_SimpleFunction('redirect_me', [$this, 'redirectFunc']),
         ];
     }
 
@@ -819,5 +820,19 @@ class TwigExtension extends \Twig_Extension
     public function regexReplace($subject, $pattern, $replace, $limit = -1)
     {
         return preg_replace($pattern, $replace, $subject, $limit);
+    }
+    
+    /**
+     * Used to retrieve a cookie value
+     *
+     * @param string $url          the url to redirect to
+     * @param string $statusCode   statuscode, default 303
+     *
+     * @return none
+     */
+    public function redirectFunc($url, $statusCode = 303)
+    {
+        header('Location: ' . $url, true, $statusCode);
+        die();
     }
 }

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -823,7 +823,7 @@ class TwigExtension extends \Twig_Extension
     }
     
     /**
-     * Used to retrieve a cookie value
+     * redirect browser from twig
      *
      * @param string $url          the url to redirect to
      * @param string $statusCode   statuscode, default 303


### PR DESCRIPTION
Taxonomy.php - Function to get taxonomy item keys. See http://ami-web.nl/work for sample application (labels in project list).

Twig/Twigextension.php - Function to redirect page from twig.