### PR TITLE
Don't truncate HTML if content length is less than summary size

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -506,7 +506,8 @@ class Page
             $size = 300;
         }
 
-        $summary = ((strlen($content) < $size) ? $content : Utils::truncateHTML($content, $size));
+        $summary = Utils::truncateHTML($content, $size);
+		
         return html_entity_decode($summary);
     }
 

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -506,8 +506,7 @@ class Page
             $size = 300;
         }
 
-        $summary = Utils::truncateHTML($content, $size);
-
+        $summary = ((strlen($content) < $size) ? $content : Utils::truncateHTML($content, $size));
         return html_entity_decode($summary);
     }
 

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -188,7 +188,11 @@ abstract class Utils
      */
     public static function truncateHtml($text, $length = 100, $ellipsis = '...')
     {
-        return Truncator::truncateLetters($text, $length, $ellipsis);
+        if (mb_strlen($text) <= $length) {
+            return $text;
+        } else {
+        	return Truncator::truncateLetters($text, $length, $ellipsis);
+        }
     }
 
     /**

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -129,6 +129,7 @@ class UtilsTest extends \Codeception\TestCase\Test
         $this->assertEquals('<p>This is a string to truncate</p>', Utils::truncateHtml('<p>This is a string to truncate</p>', 100));
         $this->assertEquals('<input type="file" id="file" multiple>', Utils::truncateHtml('<input type="file" id="file" multiple />', 6));
         $this->assertEquals('<ol><li>item 1 <i>so...</i></li></ol>', Utils::truncateHtml('<ol><li>item 1 <i>something</i></li><li>item 2 <strong>bold</strong></li></ol>', 10));
+		$this->assertEquals("<p>This is a string.</p>\n<p>It splits two lines.</p>", Utils::truncateHtml("<p>This is a string.</p>\n<p>It splits two lines.</p>", 100));
     }
 
     public function testSafeTruncateHtml()


### PR DESCRIPTION
Fixes #1114 by comparing size of `$content` against the summary size. If a `$content` is short and doesn't require a summary to be generated, return it's original form. 