### PR TITLE
Use correct ratio when applying image filters to image alternatives

### DIFF
--- a/system/src/Grav/Common/Page/Media.php
+++ b/system/src/Grav/Common/Page/Media.php
@@ -110,8 +110,9 @@ class Media extends Getters
                     $types['alternative'][$i] = MediumFactory::scaledFromMedium($alternatives[$max]['file'], $max, $i);
                 }
 
-                foreach ($types['alternative'] as $ratio => $altMedium) {
+                foreach ($types['alternative'] as $altMedium) {
                     if ($altMedium['file'] != $medium) {
+                        $ratio = $altMedium['file']->get('width') / $medium->get('width');
                         $medium->addAlternative($ratio, $altMedium['file']);
                     }
                 }

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -497,7 +497,7 @@ class ImageMedium extends Medium
         try {
             call_user_func_array([$this->image, $method], $args);
 
-            foreach ($this->alternatives as $ratio => $medium) {
+            foreach ($this->alternatives as $medium) {
                 if (!$medium->image) {
                     $medium->image();
                 }
@@ -509,7 +509,7 @@ class ImageMedium extends Medium
                 if (isset(self::$magic_resize_actions[$method])) {
                     foreach (self::$magic_resize_actions[$method] as $param) {
                         if (isset($args_copy[$param])) {
-                            $args_copy[$param] = (int) $args_copy[$param] * $ratio;
+                            $args_copy[$param] *= $medium->get('ratio');
                         }
                     }
                 }


### PR DESCRIPTION
Because of the changes in #1107, the keys of the image alternatives array is no longer the ratio, but rather the image width. We now make sure to calculate the ratio correctly and use the appropriate one when applying the image filters. This fixes #1136 