### PR TITLE
fixed array handling

### DIFF
--- a/system/src/Grav/Common/Data/Validation.php
+++ b/system/src/Grav/Common/Data/Validation.php
@@ -582,9 +582,10 @@ class Validation
             foreach ($values as $key => $value) {
                 if (is_array($value)) {
                     $value = implode(',', $value);
-                }
-
-                $values[$key] =  array_map('trim', explode(',', $value));
+                    $values[$key] =  array_map('trim', explode(',', $value));
+                } else {
+                    $values[$key] =  trim($value);
+                }                
             }
         }
 


### PR DESCRIPTION
if the input array looks like this: 
array('valA','valB') (not a keyed array)

The return result before my change was:
array(array('valA'),array('valB'))

The return result after my change is:
array('valA','valB')

(here is an example that got bug me: https://getgrav.org/forum#!/theme-development:no-select-multiple-in-backe)