### PR TITLE
Fixes #635 use mv instead of rename as that does not support cross volume operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 1. [](#bugfix)
     * Fixed case where extracting a package would cause an error during rename
+    * Fixed [#635](https://github.com/getgrav/grav/issues/635) use mv instead of rename as that does not support cross volume operations
 
 # v1.1.9
 ## 12/13/2016

--- a/system/src/Grav/Common/Filesystem/Folder.php
+++ b/system/src/Grav/Common/Filesystem/Folder.php
@@ -341,8 +341,8 @@ abstract class Folder
         self::create(dirname($target));
 
         // Just rename the directory.
-        if (self::execIsDisabled()) {
-            // exec disabled. Cannot use mv. Fallback to rename() although
+        if (self::execIsDisabled() || self::isWindows()) {
+            // exec disabled, or windows. Cannot use mv. Fallback to rename() although
             // not working cross volumes
             $success = @rename($source, $target);
             if (!$success) {
@@ -360,6 +360,15 @@ abstract class Folder
         // Make sure that the change will be detected when caching.
         @touch(dirname($source));
         @touch(dirname($target));
+    }
+
+    /**
+     * Utility method to determine if the current OS is Windows
+     *
+     * @return bool
+     */
+    private static function isWindows() {
+        return strncasecmp(PHP_OS, 'WIN', 3) == 0;
     }
 
     /**

--- a/system/src/Grav/Common/Filesystem/Folder.php
+++ b/system/src/Grav/Common/Filesystem/Folder.php
@@ -341,11 +341,10 @@ abstract class Folder
         self::create(dirname($target));
 
         // Just rename the directory.
-        $success = @rename($source, $target);
+        exec("mv $source $target", $output, $return_val);
 
-        if (!$success) {
-            $error = error_get_last();
-            throw new \RuntimeException($error['message']);
+        if ($return_val !== 0) {
+           throw new \RuntimeException($error['message']);
         }
 
         // Make sure that the change will be detected when caching.

--- a/system/src/Grav/Common/Filesystem/Folder.php
+++ b/system/src/Grav/Common/Filesystem/Folder.php
@@ -9,6 +9,7 @@
 namespace Grav\Common\Filesystem;
 
 use Grav\Common\Grav;
+use Grav\Common\Utils;
 use RocketTheme\Toolbox\ResourceLocator\UniformResourceLocator;
 
 abstract class Folder
@@ -341,7 +342,7 @@ abstract class Folder
         self::create(dirname($target));
 
         // Just rename the directory.
-        if (self::execIsDisabled() || self::isWindows()) {
+        if (self::execIsDisabled() || Utils::isWindows()) {
             // exec disabled, or windows. Cannot use mv. Fallback to rename() although
             // not working cross volumes
             $success = @rename($source, $target);
@@ -360,15 +361,6 @@ abstract class Folder
         // Make sure that the change will be detected when caching.
         @touch(dirname($source));
         @touch(dirname($target));
-    }
-
-    /**
-     * Utility method to determine if the current OS is Windows
-     *
-     * @return bool
-     */
-    private static function isWindows() {
-        return strncasecmp(PHP_OS, 'WIN', 3) == 0;
     }
 
     /**

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -813,4 +813,13 @@ abstract class Utils
 
         return $array;
     }
+
+    /**
+     * Utility method to determine if the current OS is Windows
+     *
+     * @return bool
+     */
+    public static function isWindows() {
+        return strncasecmp(PHP_OS, 'WIN', 3) == 0;
+    }
 }


### PR DESCRIPTION
Still TODO:

- [x] Check exec() is not disabled
- [x] Fallback to rename()
- [x] Check on windows