### PR TITLE
Added router to support built-in PHP web server

### DIFF
--- a/router.php
+++ b/router.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package    Grav.Core
+ *
+ * @copyright  Copyright (C) 2014 - 2016 RocketTheme, LLC. All rights reserved.
+ * @license    MIT License; see LICENSE file for details.
+ */
+
+if (PHP_SAPI !== 'cli-server') {
+    exit('This script cannot be run from browser. Run it from a CLI.');
+}
+
+if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
+    return false;
+}
+
+$_SERVER = array_merge($_SERVER, $_ENV);
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR . 'index.php';
+
+require 'index.php';
+
+error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);


### PR DESCRIPTION
I was surprised when I saw that there is no way to run grav on the built-in server, which is ideal for development, 'cos grav doesn't need a database, etc. So I'm a little researched this issue and found a solution. 
Used for the past several months for me, no any problems noticed, everything works as well.

How to run:
```
php -S localhost:8000 router.php
```

Related issues: 
https://github.com/getgrav/grav-plugin-admin/issues/2
https://github.com/getgrav/grav-plugin-admin/issues/3