### PR TITLE
Reworked PHP CLI router PR #1218

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,12 @@ if (!is_file($autoload)) {
     die("Please run: <i>bin/grav install</i>");
 }
 
+if (PHP_SAPI == 'cli-server') {
+    if (!isset($_SERVER['PHP_CLI_ROUTER'])) {
+        die("PHP webserver requires a router to run Grav, please use: <pre>php -S {$_SERVER["SERVER_NAME"]}:{$_SERVER["SERVER_PORT"]} system/router.php</pre>");
+    }
+}
+
 use Grav\Common\Grav;
 use RocketTheme\Toolbox\Event\Event;
 

--- a/system/router.php
+++ b/system/router.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package    Grav.Core
+ *
+ * @copyright  Copyright (C) 2014 - 2016 RocketTheme, LLC. All rights reserved.
+ * @license    MIT License; see LICENSE file for details.
+ */
+
+if (PHP_SAPI !== 'cli-server') {
+    exit('This script cannot be run from browser. Run it from a CLI.');
+}
+
+$_SERVER['PHP_CLI_ROUTER'] = true;
+
+if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
+    return false;
+}
+
+$_SERVER = array_merge($_SERVER, $_ENV);
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR . 'index.php';
+
+require 'index.php';
+
+error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);


### PR DESCRIPTION
This is a slight reworking of the original #1218 PR that added a custom `router.php` to enable support via the built-in CLI command. 

This moves the router under `system/` folder and also provides an error if you try to use the built-in webserver without the router option.