### PR TITLE
Updated gitignore for user/config/security.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ user/plugins/*
 user/themes/*
 !user/themes/.*
 user/localhost/config/security.yaml
+user/config/security.yaml
 
 # OS Generated
 .DS_Store*


### PR DESCRIPTION
On my installation, the security.yaml file is located in user/config/ folder.