### PR TITLE
Added ability to never cache twig. 

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -244,6 +244,17 @@ form:
                     validate:
                         type: bool
 
+                pages.never_cache_twig:
+                    type: toggle
+                    label: PLUGIN_ADMIN.NEVER_CACHE_TWIG
+                    help: PLUGIN_ADMIN.NEVER_CACHE_TWIG_HELP
+                    highlight: 0
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    validate:
+                        type: bool
+
                 pages.frontmatter.process_twig:
                     type: toggle
                     label: PLUGIN_ADMIN.FRONTMATTER_PROCESS_TWIG

--- a/system/blueprints/pages/default.yaml
+++ b/system/blueprints/pages/default.yaml
@@ -225,6 +225,30 @@ form:
                     twig: Twig
                   use: keys
 
+                header.twig_first:
+                  type: toggle
+                  toggleable: true
+                  label: PLUGIN_ADMIN.TWIG_FIRST
+                  help: PLUGIN_ADMIN.TWIG_FIRST_HELP
+                  highlight: 0
+                  options:
+                    1: PLUGIN_ADMIN.YES
+                    0: PLUGIN_ADMIN.NO
+                  validate:
+                    type: bool
+
+                header.never_cache_twig:
+                  type: toggle
+                  toggleable: true
+                  label: PLUGIN_ADMIN.NEVER_CACHE_TWIG
+                  help: PLUGIN_ADMIN.NEVER_CACHE_TWIG_HELP
+                  highlight: 0
+                  options:
+                    1: PLUGIN_ADMIN.YES
+                    0: PLUGIN_ADMIN.NO
+                  validate:
+                    type: bool
+
                 header.child_type:
                   type: select
                   toggleable: true

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -36,6 +36,7 @@ pages:
     markdown: true                          # Process Markdown
     twig: false                             # Process Twig
   twig_first: false                         # Process Twig before markdown when processing both on a page
+  never_cache_twig: false                   # Only cache content, never cache twig processed in content (incompatible with `twig_first: true`)
   events:
     page: true                              # Enable page level events
     twig: true                              # Enable Twig level events

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -572,16 +572,16 @@ class Page
             $twig_first = isset($this->header->twig_first) ? $this->header->twig_first : $config->get('system.pages.twig_first',
                 true);
 
+            // never cache twig means it's always run after content
+            $never_cache_twig = isset($this->header->never_cache_twig) ? $this->header->never_cache_twig : $config->get('system.pages.never_cache_twig',
+                false);
 
             // if no cached-content run everything
-            if ($this->content === false || $cache_enable === false) {
-                $this->content = $this->raw_content;
-                Grav::instance()->fireEvent('onPageContentRaw', new Event(['page' => $this]));
+            if ($never_cache_twig) {
+                if ($this->content === false || $cache_enable === false) {
+                    $this->content = $this->raw_content;
+                    Grav::instance()->fireEvent('onPageContentRaw', new Event(['page' => $this]));
 
-                if ($twig_first) {
-                    if ($process_twig) {
-                        $this->processTwig();
-                    }
                     if ($process_markdown) {
                         $this->processMarkdown();
                     }
@@ -589,21 +589,47 @@ class Page
                     // Content Processed but not cached yet
                     Grav::instance()->fireEvent('onPageContentProcessed', new Event(['page' => $this]));
 
-                } else {
-                    if ($process_markdown) {
-                        $this->processMarkdown();
-                    }
-
-                    // Content Processed but not cached yet
-                    Grav::instance()->fireEvent('onPageContentProcessed', new Event(['page' => $this]));
-
-                    if ($process_twig) {
-                        $this->processTwig();
+                    if ($cache_enable) {
+                        $this->cachePageContent();
                     }
                 }
 
-                if ($cache_enable) {
-                    $this->cachePageContent();
+                if ($process_twig) {
+                    $this->processTwig();
+                }
+
+            } else {
+                if ($this->content === false || $cache_enable === false) {
+                    $this->content = $this->raw_content;
+                    Grav::instance()->fireEvent('onPageContentRaw', new Event(['page' => $this]));
+
+                    if ($twig_first) {
+                        if ($process_twig) {
+                            $this->processTwig();
+                        }
+                        if ($process_markdown) {
+                            $this->processMarkdown();
+                        }
+
+                        // Content Processed but not cached yet
+                        Grav::instance()->fireEvent('onPageContentProcessed', new Event(['page' => $this]));
+
+                    } else {
+                        if ($process_markdown) {
+                            $this->processMarkdown();
+                        }
+
+                        // Content Processed but not cached yet
+                        Grav::instance()->fireEvent('onPageContentProcessed', new Event(['page' => $this]));
+
+                        if ($process_twig) {
+                            $this->processTwig();
+                        }
+                    }
+
+                    if ($cache_enable) {
+                        $this->cachePageContent();
+                    }
                 }
             }
 


### PR DESCRIPTION
 This makes it possible to cache content, but always process twig. Useful for regular but especially modular pages. 

```
never_cache_twig: true
```

Enabling this will allow you to add a processing logic that can change dynamically on each page load, rather than caching the results and storing it for each page load.

This can be enabled/disabled site-wide in the `system.yaml`, or on a specific page.

This allows twig logic to be processed on every page load even if the page is a modular subpage.  This is similar to disabling the cache completely, however, cache is still used to store the regular content that has been processed by markdown, plugins, etc.  So performance is better than disabling the cache, but not as good as caching content+twig processing.

NOTE: This is not compatible with `twig_first: true` currently because **all** processing is happening in the one Twig call.

It might be possible to refactor the twig processing to handle page processing and modular processing independently.  I can look at this later. 

Please test!