### PR TITLE
Don’t set default param_sep, use system constant

### DIFF
--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -5,7 +5,7 @@ wrapped_site: false                         # For themes/plugins to know if Grav
 reverse_proxy_setup: false                  # Running in a reverse proxy scenario with different webserver ports than proxy
 force_ssl: false                            # If enabled, Grav forces to be accessed via HTTPS (NOTE: Not an ideal solution)
 custom_base_url: ''                         # Set the base_url manually
-param_sep:                                  # Automatically is selected based on PATH_SEPERATOR, but can be manually chosen. Use ';' for Apache on windows
+param_sep: ':'                              # Will automatically set correctly for windows
 
 languages:
   supported: []                             # List of languages supported. eg: [en, fr, de]

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -1,11 +1,11 @@
 absolute_urls: false                        # Absolute or relative URLs for `base_url`
 timezone: ''                                # Valid values: http://php.net/manual/en/timezones.php
 default_locale:                             # Default locale (defaults to system)
+param_sep: ':'                              # Parameter separator, use ';' for Apache on windows
 wrapped_site: false                         # For themes/plugins to know if Grav is wrapped by another platform
 reverse_proxy_setup: false                  # Running in a reverse proxy scenario with different webserver ports than proxy
 force_ssl: false                            # If enabled, Grav forces to be accessed via HTTPS (NOTE: Not an ideal solution)
 custom_base_url: ''                         # Set the base_url manually
-param_sep: ':'                              # Will automatically set correctly for windows
 
 languages:
   supported: []                             # List of languages supported. eg: [en, fr, de]

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -1,11 +1,11 @@
 absolute_urls: false                        # Absolute or relative URLs for `base_url`
 timezone: ''                                # Valid values: http://php.net/manual/en/timezones.php
 default_locale:                             # Default locale (defaults to system)
-param_sep: ':'                              # Parameter separator, use ';' for Apache on windows
 wrapped_site: false                         # For themes/plugins to know if Grav is wrapped by another platform
 reverse_proxy_setup: false                  # Running in a reverse proxy scenario with different webserver ports than proxy
 force_ssl: false                            # If enabled, Grav forces to be accessed via HTTPS (NOTE: Not an ideal solution)
 custom_base_url: ''                         # Set the base_url manually
+param_sep:                                  # Automatically is selected based on PATH_SEPERATOR, but can be manually chosen. Use ';' for Apache on windows
 
 languages:
   supported: []                             # List of languages supported. eg: [en, fr, de]

--- a/system/src/Grav/Common/Processors/ConfigurationProcessor.php
+++ b/system/src/Grav/Common/Processors/ConfigurationProcessor.php
@@ -8,6 +8,8 @@
 
 namespace Grav\Common\Processors;
 
+use Grav\Common\Utils;
+
 class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface {
 
     public $id = '_config';
@@ -17,7 +19,8 @@ class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface
       	$this->container['config']->init();
 
       	// Set param_sep based on system level PATH_SEPARATOR if not already set
-      	if (!$this->container['config']->get('system.param_sep')) {
+        $param_sep = $this->container['config']->get('system.param_sep');
+      	if  ($param_sep !== PATH_SEPARATOR && Utils::isWindows()) {
       	    $this->container['config']->set('system.param_sep', PATH_SEPARATOR);
         }
 

--- a/system/src/Grav/Common/Processors/ConfigurationProcessor.php
+++ b/system/src/Grav/Common/Processors/ConfigurationProcessor.php
@@ -18,7 +18,7 @@ class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface
     public function process() {
       	$this->container['config']->init();
 
-      	// Set param_sep based on system level PATH_SEPARATOR if not already set
+      	// Set param_sep based on system level PATH_SEPARATOR if on windows
         $param_sep = $this->container['config']->get('system.param_sep');
       	if  ($param_sep !== PATH_SEPARATOR && Utils::isWindows()) {
       	    $this->container['config']->set('system.param_sep', PATH_SEPARATOR);

--- a/system/src/Grav/Common/Processors/ConfigurationProcessor.php
+++ b/system/src/Grav/Common/Processors/ConfigurationProcessor.php
@@ -10,21 +10,23 @@ namespace Grav\Common\Processors;
 
 use Grav\Common\Utils;
 
-class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface {
+class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface
+{
 
     public $id = '_config';
     public $title = 'Configuration';
 
-    public function process() {
-      	$this->container['config']->init();
+    public function process()
+    {
+        $this->container['config']->init();
 
-      	// Set param_sep based on system level PATH_SEPARATOR if on windows
+        // Set param_sep based on system level PATH_SEPARATOR if on windows
         $param_sep = $this->container['config']->get('system.param_sep');
-      	if  ($param_sep !== PATH_SEPARATOR && Utils::isWindows()) {
-      	    $this->container['config']->set('system.param_sep', PATH_SEPARATOR);
+        if ($param_sep !== PATH_SEPARATOR && Utils::isWindows()) {
+            $this->container['config']->set('system.param_sep', PATH_SEPARATOR);
         }
 
-      	return $this->container['plugins']->setup();
+        return $this->container['plugins']->setup();
     }
 
 }

--- a/system/src/Grav/Common/Processors/ConfigurationProcessor.php
+++ b/system/src/Grav/Common/Processors/ConfigurationProcessor.php
@@ -20,9 +20,8 @@ class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface
     {
         $this->container['config']->init();
 
-        // Set param_sep based on system level PATH_SEPARATOR if on windows
-        $param_sep = $this->container['config']->get('system.param_sep');
-        if ($param_sep !== PATH_SEPARATOR && Utils::isWindows()) {
+        // Set param_sep based on system level PATH_SEPARATOR if on windows + apache
+        if ($this->container['config']->get('system.param_sep') !== PATH_SEPARATOR && Utils::isWindows() && Utils::isApache()) {
             $this->container['config']->set('system.param_sep', PATH_SEPARATOR);
         }
 

--- a/system/src/Grav/Common/Processors/ConfigurationProcessor.php
+++ b/system/src/Grav/Common/Processors/ConfigurationProcessor.php
@@ -15,6 +15,12 @@ class ConfigurationProcessor extends ProcessorBase implements ProcessorInterface
 
     public function process() {
       	$this->container['config']->init();
+
+      	// Set param_sep based on system level PATH_SEPARATOR if not already set
+      	if (!$this->container['config']->get('system.param_sep')) {
+      	    $this->container['config']->set('system.param_sep', PATH_SEPARATOR);
+        }
+
       	return $this->container['plugins']->setup();
     }
 

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -842,4 +842,13 @@ abstract class Utils
     public static function isWindows() {
         return strncasecmp(PHP_OS, 'WIN', 3) == 0;
     }
+
+    /**
+     * Utility to determine if the server running PHP is Apache
+     *
+     * @return bool
+     */
+    public static function isApache() {
+        return strpos($_SERVER["SERVER_SOFTWARE"], 'Apache') !== false;
+    }
 }


### PR DESCRIPTION
Basically this removes the default value from the `system.yaml` file and sets it based on the system `PARAM_SEPARATOR` constant if the value is not already set/overridden in user `system.yaml`.