### PR TITLE
Fixing a minor bug in Number validation.

### DIFF
--- a/system/src/Grav/Common/Data/Validation.php
+++ b/system/src/Grav/Common/Data/Validation.php
@@ -339,7 +339,7 @@ class Validation
 
     protected static function filterNumber($value, array $params, array $field)
     {
-        return (int) $value;
+        return self::validateFloat($value, $params) ? (float) $value : (int) $value;
     }
 
     protected static function filterDateTime($value, array $params, array $field)
@@ -585,7 +585,7 @@ class Validation
                     $values[$key] =  array_map('trim', explode(',', $value));
                 } else {
                     $values[$key] =  trim($value);
-                }                
+                }
             }
         }
 


### PR DESCRIPTION
The function validateNumber only checks for numeric values, regardless of int or float contexts.

**By PHP isNumeric**

"42",
1337,
0x539,
02471,
0b10100111001,
1337e0,
"not numeric",
array(),
9.1

**Will evaluate respectively**

'42' is numeric
'1337' is numeric
'1337' is numeric
'1337' is numeric
'1337' is numeric
'1337' is numeric
'not numeric' is NOT numeric
'Array' is NOT numeric
'9.1' is numeric

Grav though does not support all value types for a variety of reasons. One being YAML Blueprint definitions, where it makes sense to make a new type value for a more specialized format. Specifically for numbers if a more advance number format it would make sense to make a new type for that number format.

YAML spec specifically allows both Integer or Float contexts. As seen in Grav the validate class validateInt and validateFloat. This is useful when the output formats explicitly needs to be a certain format.

However, in the case of generic numeric contexts, which numbers could be floats or ints dynamically, the values are cast back to an int currently in Grav numeric validation. Having dynamic primitive number formats is important, true in an interpreted language like JavaScript where 1 and 1.0 will both work for a number value.

The reason to cast the type of the variable still is to prevent wide selection of number formats, and to keep Grav in line with primitive YAML field formats.