### PR TITLE
Fix for the blueprint fix.

### DIFF
--- a/system/src/Grav/Common/Data/Validation.php
+++ b/system/src/Grav/Common/Data/Validation.php
@@ -339,7 +339,7 @@ class Validation
 
     protected static function filterNumber($value, array $params, array $field)
     {
-        return self::validateFloat($value, $params) ? (float) $value : (int) $value;
+        return (string)(int)$value !== (string)(float)$value ? (float) $value : (int) $value;
     }
 
     protected static function filterDateTime($value, array $params, array $field)


### PR DESCRIPTION
Discussed with @mahagr.

Saved YAML configs gave undesired extra parameter (!!float 1 for example) because floats were not being cast back to integers upon save. This was even true when the filterNumber function was giving back a correct parameter. filter_var from validateFloat was actually perserving the float variable type which the YAML engine perserved upon Yaml::dump.

This is a unconventional fix, but it is the simplest way to handle this edge case.