### PR TITLE
Fix class for Config/Site "Default language"-field

### DIFF
--- a/system/blueprints/config/site.yaml
+++ b/system/blueprints/config/site.yaml
@@ -19,7 +19,7 @@ form:
                 default_lang:
                     type: text
                     label: PLUGIN_ADMIN.SITE_DEFAULT_LANG
-                    size: vsmall
+                    size: x-small
                     placeholder: PLUGIN_ADMIN.SITE_DEFAULT_LANG_PLACEHOLDER
                     help: PLUGIN_ADMIN.SITE_DEFAULT_LANG_HELP
 


### PR DESCRIPTION
`vsmall` is an incorrect class, and it should presumably be `x-small` so that the field renders the same size as  "Delimiter", used in /admin/config/site. This is how it renders currently (on larger resolutions):

![image](https://cloud.githubusercontent.com/assets/974717/24071797/07519a42-0bdb-11e7-9155-9247eb62369c.png)

Creds to Ricardo for pointing it out on Slack.