### PR TITLE
Fix class for Config/System"Default ordering"

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -102,7 +102,7 @@ form:
 
                 pages.order.by:
                     type: select
-                    size: long
+                    size: large
                     classes: fancy
                     label: PLUGIN_ADMIN.DEFAULT_ORDERING
                     help: PLUGIN_ADMIN.DEFAULT_ORDERING_HELP
@@ -155,6 +155,7 @@ form:
 
                 pages.append_url_extension:
                     type: text
+                    size: x-small
                     placeholder: "e.g. .html"
                     label: PLUGIN_ADMIN.APPEND_URL_EXT
                     help: PLUGIN_ADMIN.APPEND_URL_EXT_HELP


### PR DESCRIPTION
Fix class for both "Default ordering" and "Append URL extension".

![Bug Preview](https://cloud.githubusercontent.com/assets/7531933/24073894/e2815bc8-0bf6-11e7-803b-140d132bc29a.png)