### PR TITLE
Ensure Windows-compliant filenames

### DIFF
--- a/system/src/Grav/Console/Gpm/InstallCommand.php
+++ b/system/src/Grav/Console/Gpm/InstallCommand.php
@@ -563,6 +563,10 @@ class InstallCommand extends ConsoleCommand
         $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
         $this->tmp = $tmp_dir . '/Grav-' . uniqid();
         $filename = $package->slug . basename($package->zipball_url);
+        $illegal = array_merge(
+                   array_map('chr', range(0,31)),
+                   array("<", ">", ":", '"', "/", "\\", "|", "?", "*"));
+        $filename = str_replace($illegal, "_", $filename);
         $query = '';
 
         if ($package->premium) {

--- a/system/src/Grav/Console/Gpm/InstallCommand.php
+++ b/system/src/Grav/Console/Gpm/InstallCommand.php
@@ -563,10 +563,7 @@ class InstallCommand extends ConsoleCommand
         $tmp_dir = Grav::instance()['locator']->findResource('tmp://', true, true);
         $this->tmp = $tmp_dir . '/Grav-' . uniqid();
         $filename = $package->slug . basename($package->zipball_url);
-        $illegal = array_merge(
-                   array_map('chr', range(0,31)),
-                   array("<", ">", ":", '"', "/", "\\", "|", "?", "*"));
-        $filename = str_replace($illegal, "_", $filename);
+        $filename = preg_replace('/[\\\\\/:"*?<>|]+/mi', '_', $filename);
         $query = '';
 
         if ($package->premium) {


### PR DESCRIPTION
Adds an array (`$illegal`) of disallowed characters, and does a simple `str_replace` on filename prior to writing the package to /tmp, in InstallCommand->downloadPackage(). Source: [SO](http://stackoverflow.com/a/3380159/603387) and [MSDN](https://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx), tested on Windows 10 x64, PHP v7.0.7 ran via Caddy v0.9.3.

Other considerations could be added to `$illegal`, but at current they are superfluous. Did not instantiate as a Class-property as only downloadPackage() runs `file_put_contents`.