### PR TITLE
CSS pipeline rewrite URL fix for webserver root-based paths

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -1255,18 +1255,8 @@ class Assets
 
             $old_url = $matches[2];
 
-            // ensure link is not rooted to webserver
-            if (strpos($old_url, '/') === 0) {
-                return $matches[0];
-            }
-
-            // ensure this is not a data url
-            if (strpos($old_url, 'data:') === 0) {
-                return $matches[0];
-            }
-
-            // ensure this is not a remote url
-            if ($this->isRemoteLink($old_url)) {
+            // Ensure link is not rooted to webserver, a data URL, or to a remote host
+            if (Utils::startsWith($old_url, '/') || Utils::startsWith($old_url, 'data') || $this->isRemoteLink($old_url)) {
                 return $matches[0];
             }
 

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -1255,6 +1255,11 @@ class Assets
 
             $old_url = $matches[2];
 
+            // ensure link is not rooted to webserver
+            if (strpos($old_url, '/') === 0) {
+                return $matches[0];
+            }
+
             // ensure this is not a data url
             if (strpos($old_url, 'data:') === 0) {
                 return $matches[0];

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -1256,7 +1256,7 @@ class Assets
             $old_url = $matches[2];
 
             // Ensure link is not rooted to webserver, a data URL, or to a remote host
-            if (Utils::startsWith($old_url, '/') || Utils::startsWith($old_url, 'data') || $this->isRemoteLink($old_url)) {
+            if (Utils::startsWith($old_url, '/') || Utils::startsWith($old_url, 'data:') || $this->isRemoteLink($old_url)) {
                 return $matches[0];
             }
 


### PR DESCRIPTION
Fixes #1382

In this function, there are now three `if` clauses in a row without `else` and with the same action in their body. Could perhaps be refactored. For now, I've just added that third, making it look crowded :(