### PR TITLE
When determining language from HTTP_ACCEPT_LANGUAGE, also try base language only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 1. [](#bugfix)
     * Fixed a bad method signature causing warning when running tests on `GPMTest` object
+    * When determining language from `HTTP_ACCEPT_LANGUAGE`, also try base language only
 
 # v1.2.0
 ## 03/31/2017

--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -203,6 +203,15 @@ class Language
                         }
                     }
 
+                    // repeat if not found, try base language only - fixes Safari sending the language code always
+                    // with a locale (e.g. it-it or fr-fr)
+                    foreach ($preferred as $lang) {
+                        $lang = substr($lang, 0, 2);
+                        if ($this->validate($lang)) {
+                            $this->active = $lang;
+                            break;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes Safari sending the language code always with a locale (e.g. it-it
or fr-fr)