### PR TITLE
Cache now respects params / query

### DIFF
--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -120,7 +120,7 @@ class Cache extends Getters
         }
 
         // Cache key allows us to invalidate all cache on configuration changes.
-        $this->key = ($prefix ? $prefix : 'g') . '-' . substr(md5($uri->rootUrl(true) . $this->config->key() . GRAV_VERSION),
+        $this->key = ($prefix ? $prefix : 'g') . '-' . substr(md5($uri->buildUri() . $this->config->key() . GRAV_VERSION),
                 2, 8);
 
         $this->driver_setting = $this->config->get('system.cache.driver');

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -113,7 +113,7 @@ class Uri
      *
      * @return string
      */
-    private function buildUri()
+    public function buildUri()
     {
         $uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
 


### PR DESCRIPTION
Kinda mandatory, don't you think?

Now http://localhost:8888/home?o=9 or http://localhost:8888/home/o:9 are cached.