### PR TITLE
Fixed what I think may have been an oversight.

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -756,16 +756,6 @@ class Page
         $cache_id = md5('page' . $this->id());
         $cache->save($cache_id, ['content' => $this->content, 'content_meta' => $this->content_meta]);
     }
-
-    /**
-     * Needed by the onPageContentProcessed event to get the raw page content
-     *
-     * @return string   the current raw page content
-     */
-    public function getRawContent()
-    {
-        return $this->raw_content;
-    }
     
     /**
      * Needed by the onPageContentProcessed event to get the page content
@@ -775,16 +765,6 @@ class Page
     public function getContent()
     {
         return $this->content;
-    }
-
-    /**
-     * Needed by the onPageContentProcessed event to set the raw page content
-     *
-     * @param $content
-     */
-    public function setRawContent($content)
-    {
-        $this->raw_content = $content;
     }
     
     /**
@@ -884,7 +864,7 @@ class Page
      *
      * @return null
      */
-    public function rawMarkdown($var = null)
+    public function rawContent($var = null)
     {
         if ($var !== null) {
             $this->raw_content = $var;

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -760,9 +760,19 @@ class Page
     /**
      * Needed by the onPageContentProcessed event to get the raw page content
      *
-     * @return string   the current page content
+     * @return string   the current raw page content
      */
     public function getRawContent()
+    {
+        return $this->raw_content;
+    }
+    
+    /**
+     * Needed by the onPageContentProcessed event to get the page content
+     *
+     * @return string   the current page content
+     */
+    public function getContent()
     {
         return $this->content;
     }
@@ -773,6 +783,16 @@ class Page
      * @param $content
      */
     public function setRawContent($content)
+    {
+        $this->raw_content = $content;
+    }
+    
+    /**
+     * Needed by the onPageContentProcessed event to set the processed page content
+     *
+     * @param $content
+     */
+    public function setContent($content)
     {
         $this->content = $content;
     }


### PR DESCRIPTION
getRawContent and setRawContent were structured to get and set the content AFTER the content had already been processed. I ran into this problem while developing a plugin for my own personal use. If this was not an oversight and was in fact the intended behavior, then the wording is very misleading. lol.