### PR TITLE
Allow `user/account.yaml` overrides + implemented more robust theme init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## xx/xx/2017
 
 1. [](#improved)
+    * Allow `user/accounts.yaml` overrides and implemented more robust theme initialization
     * Added various `ancestor` helper methods in Page and Pages classes [#1362](https://github.com/getgrav/grav/pull/1362)
     * Added `isajaxrequest()` Twig function [#1400](https://github.com/getgrav/grav/issues/1400)
     * Added ability to inline CSS and JS code via Asset manager [#1377](https://github.com/getgrav/grav/pull/1377)

--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -224,10 +224,14 @@ class Themes extends Iterator
         $locator = $this->grav['locator'];
 
         $registered = stream_get_wrappers();
-        $schemes = $config->get(
-            "themes.{$name}.streams.schemes",
-            ['theme' => ['paths' => $locator->findResources("themes://{$name}", false)]]
-        );
+
+        $schemes = [
+            'theme' => [
+                'type' => 'ReadOnlyStream',
+                'paths' => $locator->findResources("themes://{$name}", false)
+            ]
+        ];
+        $schemes += $config->get("themes.{$name}.streams.schemes", []);
 
         foreach ($schemes as $scheme => $config) {
             if (isset($config['paths'])) {

--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -225,13 +225,13 @@ class Themes extends Iterator
 
         $registered = stream_get_wrappers();
 
-        $schemes = [
+        $schemes = $config->get("themes.{$name}.streams.schemes", []);
+        $schemes += [
             'theme' => [
                 'type' => 'ReadOnlyStream',
                 'paths' => $locator->findResources("themes://{$name}", false)
             ]
         ];
-        $schemes += $config->get("themes.{$name}.streams.schemes", []);
 
         foreach ($schemes as $scheme => $config) {
             if (isset($config['paths'])) {


### PR DESCRIPTION
I stumbled across this minor issue, when trying to extend the base `user/accounts.yaml` configuration. It turned out that there were some edge cases, that `loadLanguages` [Themes.php#L256](https://github.com/getgrav/grav/blob/develop/system/src/Grav/Common/Themes.php#L256) was called, but `theme://` was actually not registered yet. This PR fixes this. It further allows now overriding the `user/account.yaml` file that will be shown in Admin plugin and allows to use the `theme://` scheme inside the actual theme itself via, e.g.

```yaml
# Grav streams
streams:
  schemes:
    blueprints:
      type: ReadOnlyStream
      prefixes:
        '':
          - 'theme://blueprints'
``` 