### PR TITLE
Add more controls over HTML5 video attributes (autoplay, poster, loop, controls)

### DIFF
--- a/system/src/Grav/Common/Page/Medium/VideoMedium.php
+++ b/system/src/Grav/Common/Page/Medium/VideoMedium.php
@@ -31,6 +31,75 @@ class VideoMedium extends Medium
     }
 
     /**
+     * Allows to set or remove the HTML5 default controls
+     *
+     * @param bool $display
+     * @return $this
+     */
+    public function controls($display = true)
+    {
+        if($display)
+        {
+            $this->attributes['controls'] = true;
+        }
+        else
+        {
+            unset($this->attributes['controls']);
+        }
+        return $this;
+    }
+
+    /**
+     * Allows to set the video's poster image
+     *
+     * @param $urlImage
+     * @return $this
+     */
+    public function poster($urlImage)
+    {
+        $this->attributes['poster'] = $urlImage;
+        return $this;
+    }
+
+    /**
+     * Allows to set the loop attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function loop($status = false)
+    {
+        if($status)
+        {
+            $this->attributes['loop'] = true;
+        }
+        else
+        {
+            unset($this->attributes['loop']);
+        }
+        return $this;
+    }
+
+    /**
+     * Allows to set the autoplay attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function autoplay($status = false)
+    {
+        if($status)
+        {
+            $this->attributes['autoplay'] = true;
+        }
+        else
+        {
+            unset($this->attributes['autoplay']);
+        }
+        return $this;
+    }
+
+    /**
      * Reset medium.
      *
      * @return $this


### PR DESCRIPTION
I implemented some methods to support basic features of HTML5 videos. I saw this pull request https://github.com/getgrav/grav/pull/1092 after. I have then adjusted to fit the requirement mentioned.

Example in Markdown :
`
![video.mov](video.mov?loop=1&controls=0&autoplay=1)
`
Example in twig :
`
{% set header_image_media = page.media.videos|first %}
{{ header_image_media.loop(true).autoplay(true).controls(false).poster("/path/to/image").html() }}
`