### PR TITLE
Add timestamp to configuration settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v1.2.4
 ## 04/xx/2017
 
+1. [](#improved)
+    * Add timestamp to configuration settings [#1445](https://github.com/getgrav/grav/pull/1445)
 1. [](#bugfix)
     * Allow multiple calls to `Themes::initTheme()` without throwing errors
     * Fixed querystrings in root pages with multi-lang enabled [#1436](https://github.com/getgrav/grav/issues/1436)

--- a/system/src/Grav/Common/Config/CompiledBase.php
+++ b/system/src/Grav/Common/Config/CompiledBase.php
@@ -28,6 +28,11 @@ abstract class CompiledBase
     public $checksum;
 
     /**
+     * @var string  Timestamp of compiled configuration
+     */
+    public $timestamp;
+
+    /**
      * @var string Cache folder to be used.
      */
     protected $cacheFolder;
@@ -59,9 +64,10 @@ abstract class CompiledBase
             throw new \BadMethodCallException('Cache folder not defined.');
         }
 
+        $this->path = $path ? rtrim($path, '\\/') . '/' : '';
         $this->cacheFolder = $cacheFolder;
         $this->files = $files;
-        $this->path = $path ? rtrim($path, '\\/') . '/' : '';
+        $this->timestamp = 0;
     }
 
     /**
@@ -83,6 +89,16 @@ abstract class CompiledBase
      * Function gets called when cached configuration is saved.
      */
     public function modified() {}
+
+    /**
+     * Get timestamp of compiled configuration
+     *
+     * @return int Timestamp of compiled configuration
+     */
+    public function timestamp()
+    {
+        return $this->timestamp ?: time();
+    }
 
     /**
      * Load the configuration.
@@ -196,6 +212,7 @@ abstract class CompiledBase
         }
 
         $this->createObject($cache['data']);
+        $this->timestamp = isset($cache['timestamp']) ? $cache['timestamp'] : 0;
 
         $this->finalizeObject();
 

--- a/system/src/Grav/Common/Config/CompiledConfig.php
+++ b/system/src/Grav/Common/Config/CompiledConfig.php
@@ -77,6 +77,7 @@ class CompiledConfig extends CompiledBase
     protected function finalizeObject()
     {
         $this->object->checksum($this->checksum());
+        $this->object->timestamp($this->timestamp());
     }
 
     /**

--- a/system/src/Grav/Common/Config/CompiledLanguages.php
+++ b/system/src/Grav/Common/Config/CompiledLanguages.php
@@ -38,6 +38,7 @@ class CompiledLanguages extends CompiledBase
     protected function finalizeObject()
     {
         $this->object->checksum($this->checksum());
+        $this->object->timestamp($this->timestamp());
     }
 
 

--- a/system/src/Grav/Common/Config/Config.php
+++ b/system/src/Grav/Common/Config/Config.php
@@ -17,6 +17,7 @@ class Config extends Data
 {
     protected $checksum;
     protected $modified = false;
+    protected $timestamp = 0;
 
     public function key()
     {
@@ -39,6 +40,15 @@ class Config extends Data
         }
 
         return $this->modified;
+    }
+
+    public function timestamp($timestamp = null)
+    {
+        if ($timestamp !== null) {
+            $this->timestamp = $timestamp;
+        }
+
+        return $this->timestamp;
     }
 
     public function reload()

--- a/system/src/Grav/Common/Config/Languages.php
+++ b/system/src/Grav/Common/Config/Languages.php
@@ -30,6 +30,15 @@ class Languages extends Data
         return $this->modified;
     }
 
+    public function timestamp($timestamp = null)
+    {
+        if ($timestamp !== null) {
+            $this->timestamp = $timestamp;
+        }
+
+        return $this->timestamp;
+    }
+
     public function reformat()
     {
         if (isset($this->items['plugins'])) {


### PR DESCRIPTION
This PR adds a timestamp to configuration settings of the last compilation time, which can be very helpful for plugins to detect configuration changes or show, how long has been passed since the last refreshments.