### PR TITLE
[WIP] Web Server Config URL Rewrite Rules White List

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -56,9 +56,9 @@ RewriteRule .* index.php [L]
 # Block all direct access for these folders
 RewriteRule ^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
 # Block access to specific file types for these system folders
-RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block access to specific file types for these user folders
-RewriteRule ^(user)/(.*)\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(user)/(.*)\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block all direct access to .md files:
 RewriteRule \.md$ error [F]
 # Block all direct access to files and folders beginning with a dot

--- a/.htaccess
+++ b/.htaccess
@@ -54,7 +54,7 @@ RewriteRule .* index.php [L]
 
 ## Begin - Security
 # Block all direct access for these folders
-RewriteRule ^(.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
+RewriteRule ^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
 # Block access to specific file types for these system folders
 RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block access to specific file types for these user folders
@@ -64,7 +64,7 @@ RewriteRule \.md$ error [F]
 # Block all direct access to files and folders beginning with a dot
 RewriteRule (^|/)\.(?!well-known) - [F]
 # Block access to specific files in the root folder
-RewriteRule ^(LICENSE.txt|composer.lock|composer.json|\.htaccess)$ error [F]
+RewriteRule ^(LICENSE\.txt|composer\.lock|composer\.json|\.htaccess)$ error [F]
 ## End - Security
 
 </IfModule>

--- a/webserver-configs/Caddyfile
+++ b/webserver-configs/Caddyfile
@@ -10,12 +10,12 @@ rewrite {
 }
 # deny running scripts inside core system folders
 rewrite {
-    r       /(system|vendor)/.*\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$
+    r       /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
     to  	/403
 }
 # deny running scripts inside user folder
 rewrite {
-    r       /user/.*\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$
+    r       /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
     to  	/403
 }
 # deny access to specific files in the root folder

--- a/webserver-configs/Caddyfile
+++ b/webserver-configs/Caddyfile
@@ -5,7 +5,7 @@ fastcgi / 127.0.0.1:9000 php
 # Begin - Security
 # deny all direct access for these folders
 rewrite {
-    r       /(.git|cache|bin|logs|backups|tests)/.*$
+    r       /(\.git|cache|bin|logs|backups|tests)/.*$
     to  	/403
 }
 # deny running scripts inside core system folders
@@ -20,7 +20,7 @@ rewrite {
 }
 # deny access to specific files in the root folder
 rewrite {
-    r       /(LICENSE.txt|composer.lock|composer.json|nginx.conf|web.config|htaccess.txt|\.htaccess)
+    r       /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess)
     to  	/403
 }
 

--- a/webserver-configs/Caddyfile-0.8.x
+++ b/webserver-configs/Caddyfile-0.8.x
@@ -12,12 +12,12 @@ rewrite {
 }
 # deny running scripts inside core system folders
 rewrite {
-    r       /(system|vendor)/.*\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$
+    r       /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
     status  403
 }
 # deny running scripts inside user folder
 rewrite {
-    r       /user/.*\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$
+    r       /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
     status  403
 }
 # deny access to specific files in the root folder

--- a/webserver-configs/Caddyfile-0.8.x
+++ b/webserver-configs/Caddyfile-0.8.x
@@ -7,7 +7,7 @@ fastcgi / 127.0.0.1:9000 php
 # Begin - Security
 # deny all direct access for these folders
 rewrite {
-    r       /(.git|cache|bin|logs|backups|tests)/.*$
+    r       /(\.git|cache|bin|logs|backups|tests)/.*$
     status  403
 }
 # deny running scripts inside core system folders
@@ -22,7 +22,7 @@ rewrite {
 }
 # deny access to specific files in the root folder
 rewrite {
-    r       /(LICENSE.txt|composer.lock|composer.json|nginx.conf|web.config|htaccess.txt|\.htaccess)
+    r       /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess)
     status  403
 }
 ## End - Security

--- a/webserver-configs/htaccess.txt
+++ b/webserver-configs/htaccess.txt
@@ -56,9 +56,9 @@ RewriteRule .* index.php [L]
 # Block all direct access for these folders
 RewriteRule ^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
 # Block access to specific file types for these system folders
-RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block access to specific file types for these user folders
-RewriteRule ^(user)/(.*)\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(user)/(.*)\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block all direct access to .md files:
 RewriteRule \.md$ error [F]
 # Block all direct access to files and folders beginning with a dot

--- a/webserver-configs/htaccess.txt
+++ b/webserver-configs/htaccess.txt
@@ -54,7 +54,7 @@ RewriteRule .* index.php [L]
 
 ## Begin - Security
 # Block all direct access for these folders
-RewriteRule ^(.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
+RewriteRule ^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
 # Block access to specific file types for these system folders
 RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block access to specific file types for these user folders
@@ -64,7 +64,7 @@ RewriteRule \.md$ error [F]
 # Block all direct access to files and folders beginning with a dot
 RewriteRule (^|/)\.(?!well-known) - [F]
 # Block access to specific files in the root folder
-RewriteRule ^(LICENSE.txt|composer.lock|composer.json|\.htaccess)$ error [F]
+RewriteRule ^(LICENSE\.txt|composer\.lock|composer\.json|\.htaccess)$ error [F]
 ## End - Security
 
 </IfModule>

--- a/webserver-configs/lighttpd.conf
+++ b/webserver-configs/lighttpd.conf
@@ -33,7 +33,7 @@ $HTTP["url"] =~ "^/grav_path/(LICENSE\.txt|composer\.json|composer\.lock|nginx\.
 $HTTP["url"] =~ "^/grav_path/(\.git|cache|bin|logs|backup|tests)/(.*)" {
     url.access-deny = ("")
 }
-$HTTP["url"] =~ "^/grav_path/(system|user|vendor)/(.*)\.(txt|md|html|yaml|php|twig|sh|bat)$" {
+$HTTP["url"] =~ "^/grav_path/(system|user|vendor)/(.*)\.(txt|md|html|yaml|yml|php|twig|sh|bat)$" {
     url.access-deny = ("")
 }
 $HTTP["url"] =~ "^/grav_path/(\.(.*))" {

--- a/webserver-configs/lighttpd.conf
+++ b/webserver-configs/lighttpd.conf
@@ -27,10 +27,10 @@ url.rewrite-if-not-file = (
 )
 
 #IMPROVING SECURITY
-$HTTP["url"] =~ "^/grav_path/(LICENSE.txt|composer.json|composer.lock|nginx.conf|web.config)$" {
+$HTTP["url"] =~ "^/grav_path/(LICENSE\.txt|composer\.json|composer\.lock|nginx\.conf|web\.config)$" {
     url.access-deny = ("")
 }
-$HTTP["url"] =~ "^/grav_path/(.git|cache|bin|logs|backup|tests)/(.*)" {
+$HTTP["url"] =~ "^/grav_path/(\.git|cache|bin|logs|backup|tests)/(.*)" {
     url.access-deny = ("")
 }
 $HTTP["url"] =~ "^/grav_path/(system|user|vendor)/(.*)\.(txt|md|html|yaml|php|twig|sh|bat)$" {

--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -18,13 +18,13 @@ server {
 
     ## Begin - Security
     # deny all direct access for these folders
-    location ~* /(.git|cache|bin|logs|backup|tests)/.*$ { return 403; }
+    location ~* /(\.git|cache|bin|logs|backup|tests)/.*$ { return 403; }
     # deny running scripts inside core system folders
     location ~* /(system|vendor)/.*\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny running scripts inside user folder
     location ~* /user/.*\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny access to specific files in the root folder
-    location ~ /(LICENSE.txt|composer.lock|composer.json|nginx.conf|web.config|htaccess.txt|\.htaccess) { return 403; }
+    location ~ /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) { return 403; }
     ## End - Security
 
     ## Begin - PHP

--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -20,9 +20,9 @@ server {
     # deny all direct access for these folders
     location ~* /(\.git|cache|bin|logs|backup|tests)/.*$ { return 403; }
     # deny running scripts inside core system folders
-    location ~* /(system|vendor)/.*\.(txt|xml|md|html|yaml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
+    location ~* /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny running scripts inside user folder
-    location ~* /user/.*\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
+    location ~* /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny access to specific files in the root folder
     location ~ /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) { return 403; }
     ## End - Security

--- a/webserver-configs/web.config
+++ b/webserver-configs/web.config
@@ -22,7 +22,7 @@
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="ignore_folders" stopProcessing="true">
-                    <match url="^(.git|cache|bin|logs|backup|webserver-configs|tests)/(.*)" ignoreCase="false" />
+                    <match url="^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*)" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="system" stopProcessing="true">

--- a/webserver-configs/web.config
+++ b/webserver-configs/web.config
@@ -18,7 +18,7 @@
                     <action type="Rewrite" url="index.php" />
                 </rule>
                 <rule name="user_error_redirect" stopProcessing="true">
-                    <match url="^(user)/(.*)\.(txt|md|yaml|php|pl|py|cgi|twig|sh|bat)$" ignoreCase="false" />
+                    <match url="^(user)/(.*)\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="ignore_folders" stopProcessing="true">
@@ -26,11 +26,11 @@
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="system" stopProcessing="true">
-                    <match url="^system/(.*)\.(txt|md|html|yaml|php|twig|sh|bat)$" ignoreCase="false" />
+                    <match url="^system/(.*)\.(txt|md|html|yaml|yml|php|twig|sh|bat)$" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="vendor" stopProcessing="true">
-                    <match url="^vendor/(.*)\.(txt|md|html|yaml|php|twig|sh|bat)$" ignoreCase="false" />
+                    <match url="^vendor/(.*)\.(txt|md|html|yaml|yml|php|twig|sh|bat)$" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
             </rules>


### PR DESCRIPTION
Hey All,

When looking into the current `.htaccess` file's URL rewrite rules, I noticed a couple small issues:
- Periods are not escaped when black listing specific files (e.g., `LICENSE.txt`), meaning that other files/folders are perhaps unintentionally blacklisted (e.g., `LICENSEatxt`; likely not really an issue in practice).
- The `.yml` file type extension is not black listed (although `.yaml` is), meaning files such as `/codeception.yml` are accessible via HTTP requests.

This pull request so far simply addresses these two specific issues, however the last issue above has bothered me in a broader way. In general, it is often preferable (from a security point of view) to use a white list instead of a black list when it comes to filtering things (e.g., firewall rules, sanitizing input to prevent XSS, etc). The example of `.yaml` vs `.yml` mentioned above really highlights the limitations/issues with using a black list approach, and I think switching to a primarily white list based approach could be an easy win for improving Grav's default configuration.

In exploring this idea with a website I'm currently working on, I've so far determined that files need to be served from these folders:
- `/` (usually only for a few specific files such as `robots.txt`, `favicon.ico`, etc)
- `/assets`
- `/images`
- `/system/assets`
- `/system/images`
- `/user/pages`
- `/user/plugins`
- `/user/themes`

There may be additional areas that I haven't caught yet, but these are the most obvious sources. With the current URL rewrite rules, it's possible to serve up files in all sorts of irrelevant directories. For example, visitors can get specific version information about installed dependencies through files like `/vendor/composer/installed.json`.

So a simple place to start with a white list might be something along the lines of:

```
# Whitelist specific folders
RewriteCond %{REQUEST_URI} !^/[^/]*$
RewriteCond %{REQUEST_URI} !^/\.well-known/
RewriteCond %{REQUEST_URI} !^/(assets|images)/
RewriteCond %{REQUEST_URI} !^/system/(assets|images)/
RewriteCond %{REQUEST_URI} !^/user/(pages|plugins|themes)/
RewriteRule .+ error [F]
```

This rule would be placed before the existing black list rules, since we still want to avoid serving up specific types of files even under these directories. The clearest example is with plugins - they're a giant mix of code vs assets, and it's likely impossible to know ahead of time what folders under any specific plugin are safe to serve (though perhaps there is a convention for this already established in the documentation? I haven't dived into plugin internals yet).

This specific rule still wouldn't solve issues like serving up `/codeception.yml`, but it's a step in the right direction. The tricky part about a white list is coming up with something that provides value while still working for the overwhelming majority of existing/future website setups (without requiring additional configuration overhead on the website maintainer).

For the sake of completeness (and extra ideas), on the site I'm working on, I've locked things down even further by using the following (so far; still testing/in-development):

```
## Begin - Security
# Whitelist specific folders/files
RewriteCond %{REQUEST_URI} !^/\.well-known/
RewriteCond %{REQUEST_URI} !^/(assets|images)/
RewriteCond %{REQUEST_URI} !^/system/(assets|images)/
RewriteCond %{REQUEST_URI} !^/user/pages/
RewriteCond %{REQUEST_URI} !^/user/(plugins|themes)/.*\.(jpg|jpeg|gif|png|css|css\.map|js|eot|svg|ttf|woff|woff2)$
RewriteCond %{REQUEST_URI} !^/(index\.php|favicon\.ico|favicon\.png|favicon\.gif|robots\.txt|humans\.txt)?$
RewriteRule .* error [F]

# Blacklist specific file types in all subfolders
RewriteRule /.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]

# Blacklist dot files
RewriteRule (^|/)\.(?!well-known) - [F]
## End - Security
```

Here I've gone ahead and white listed only specific file types under the `user/plugins` and `user/themes` folders (I imagine the list of allowed extensions will need to grow if additional plugins are installed, making this likely non-ideal for a default `.htaccess`). Additionally, only specific files in the root directory are accessible. Beyond that, I apply the current file extensions black list.

Anyways, now that I've written all this up - what do you all think? Is this something you'd be interested in pursuing/merging? I'm happy to provide patches for `.htaccess` and `web.config`, but I am unfamiliar with the other server config formats and do not have a testing environment for them.


Regards,
--- Scott