### PR TITLE
ETag header should be inside double quotes

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -235,7 +235,7 @@ class Grav extends Container
 
         // Calculate a Hash based on the raw file
         if ($page->eTag()) {
-            header('ETag: ' . md5($page->raw() . $page->modified()));
+            header('ETag: "' . md5($page->raw() . $page->modified()).'"');
         }
 
         // Set debugger data in headers


### PR DESCRIPTION
It's small change, but still...
https://tools.ietf.org/html/rfc7232#section-2.3