### PR TITLE
Avoid to delete images/ folder after using GPM

### DIFF
--- a/system/src/Grav/Console/ConsoleTrait.php
+++ b/system/src/Grav/Console/ConsoleTrait.php
@@ -98,14 +98,12 @@ trait ConsoleTrait
      * @return int
      * @throws \Exception
      */
-    public function clearCache($all = [])
+    public function clearCache($scope = 'all')
     {
-        if ($all) {
-            $all = ['--all' => true];
-        }
+        $scope = ['--'.$scope => true];
 
         $command = new ClearCacheCommand();
-        $input = new ArrayInput($all);
+        $input = new ArrayInput($scope);
         return $command->run($input, $this->output);
     }
 

--- a/system/src/Grav/Console/Gpm/DirectInstallCommand.php
+++ b/system/src/Grav/Console/Gpm/DirectInstallCommand.php
@@ -259,7 +259,7 @@ class DirectInstallCommand extends ConsoleCommand
         Folder::delete($tmp_zip);
 
         // clear cache after successful upgrade
-        $this->clearCache();
+        $this->clearCache('cache-only');
 
         return true;
 

--- a/system/src/Grav/Console/Gpm/InstallCommand.php
+++ b/system/src/Grav/Console/Gpm/InstallCommand.php
@@ -227,7 +227,7 @@ class InstallCommand extends ConsoleCommand
         }
 
         // clear cache after successful upgrade
-        $this->clearCache();
+        $this->clearCache('cache-only');
 
         return true;
     }


### PR DESCRIPTION
When I installed or updated a Grav plugin, it deleted all the cache, but also the "compiled" images,
makes the website very slow (for a relatively complex website).

My initial reason for this patch is because I installed fastcgi_cache in order to make the site still available while
deploying with Ansible, but the images got cleared when the provisioning run the update GPM command,
then showing "missing picture" errors on the website.

This patch nows permit to use the function like :

```php
Grav\Console\ConsoleTrait::clearCache('all');
Grav\Console\ConsoleTrait::clearCache('cache-only');
```

*Please note that those examples are static, just consider the method parameter.*

And then I've linked it after the update and install classes. So when a plugin got updated/installed,
it does only clear the cache instead of clear the cache plus the compiled pictures, agressively slowing the website.

In hope that this will break nothing in the actual core, because I don't know Grav well enough to deal with all the parameters in my mind.

Thanks !