### PR TITLE
Fix output handling in RenderProcessor

### DIFF
--- a/system/src/Grav/Common/Processors/RenderProcessor.php
+++ b/system/src/Grav/Common/Processors/RenderProcessor.php
@@ -28,7 +28,7 @@ class RenderProcessor extends ProcessorBase implements ProcessorInterface
             // Set the header type
             $container->header();
 
-            echo $output;
+            echo $container->output;
 
             // remove any output
             $container->output = '';


### PR DESCRIPTION
Ensure that output modifications by subscribers to `onOutputGenerated` are picked up.

In contrast to 1.2.4, 1.3.0-rc.2 no longer recognizes output modifications applied by subscribers to `onOutputGenerated`.

In 1.2.4, output was rendered [in Grav.php via `echo $this->output;`](https://github.com/getgrav/grav/blob/1.2.4/system/src/Grav/Common/Grav.php#L133) after processing `onOutputGenerated` inside `RenderProcessor`.