### PR TITLE
Make it possible to include debug bar also into non-HTML responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [](#improved)
     * Optionally remove unpublished pages from the translated languages, move into untranslated list [#1482](https://github.com/getgrav/grav/pull/1482)
     * Improved reliability of `hash` filecheck method
+    * Make it possible to include debug bar also into non-HTML responses
 1. [](#bugfix)
     * Fix output handling in RenderProcessor [#1483](https://github.com/getgrav/grav/pull/1483)
 

--- a/system/src/Grav/Common/Debugger.php
+++ b/system/src/Grav/Common/Debugger.php
@@ -36,6 +36,9 @@ class Debugger
      */
     public function __construct()
     {
+        // Enable debugger until $this->init() gets called.
+        $this->enabled = true;
+
         $this->debugbar = new StandardDebugBar();
         $this->debugbar['time']->addMeasure('Loading', $this->debugbar['time']->getRequestStartTime(), microtime(true));
     }
@@ -50,6 +53,9 @@ class Debugger
     {
         $this->grav = Grav::instance();
         $this->config = $this->grav['config'];
+
+        // Enable/disable debugger based on configuration.
+        $this->enabled = $this->config->get('system.debugger.enabled');
 
         if ($this->enabled()) {
             $this->debugbar->addCollector(new ConfigCollector((array)$this->config->get('system'), 'Config'));
@@ -70,10 +76,6 @@ class Debugger
     {
         if (isset($state)) {
             $this->enabled = $state;
-        } else {
-            if (!isset($this->enabled)) {
-                $this->enabled = $this->config->get('system.debugger.enabled');
-            }
         }
 
         return $this->enabled;
@@ -91,7 +93,6 @@ class Debugger
             // Only add assets if Page is HTML
             $page = $this->grav['page'];
             if ($page->templateFormat() != 'html') {
-                $this->enabled = false;
                 return $this;
             }
 
@@ -163,6 +164,12 @@ class Debugger
     public function render()
     {
         if ($this->enabled()) {
+            // Only add assets if Page is HTML
+            $page = $this->grav['page'];
+            if ($page->templateFormat() != 'html') {
+                return $this;
+            }
+
             echo $this->renderer->render();
         }
 
@@ -176,9 +183,27 @@ class Debugger
      */
     public function sendDataInHeaders()
     {
-        $this->debugbar->sendDataInHeaders();
+        if ($this->enabled()) {
+            $this->debugbar->sendDataInHeaders();
+        }
 
         return $this;
+    }
+
+    /**
+     * Returns collected debugger data.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        if (!$this->enabled()) {
+            return null;
+        }
+
+        $this->timers = [];
+
+        return $this->debugbar->getData();
     }
 
     /**
@@ -191,7 +216,7 @@ class Debugger
      */
     public function startTimer($name, $description = null)
     {
-        if ($name[0] == '_' || $this->config->get('system.debugger.enabled')) {
+        if ($name[0] == '_' || $this->enabled()) {
             $this->debugbar['time']->startMeasure($name, $description);
             $this->timers[] = $name;
         }
@@ -208,7 +233,7 @@ class Debugger
      */
     public function stopTimer($name)
     {
-        if (in_array($name, $this->timers) && ($name[0] == '_' || $this->config->get('system.debugger.enabled'))) {
+        if (in_array($name, $this->timers) && ($name[0] == '_' || $this->enabled())) {
             $this->debugbar['time']->stopMeasure($name);
         }
 

--- a/system/src/Grav/Common/Debugger.php
+++ b/system/src/Grav/Common/Debugger.php
@@ -166,7 +166,7 @@ class Debugger
         if ($this->enabled()) {
             // Only add assets if Page is HTML
             $page = $this->grav['page'];
-            if ($page->templateFormat() != 'html') {
+            if ($page->templateFormat() != 'html' || !$this->renderer) {
                 return $this;
             }
 

--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -247,11 +247,6 @@ class Grav extends Container
             header('ETag: "' . md5($page->raw() . $page->modified()).'"');
         }
 
-        // Set debugger data in headers
-        if (!($format === null || $format == 'html')) {
-            $this['debugger']->enabled(false);
-        }
-
         // Set HTTP response code
         if (isset($this['page']->header()->http_response_code)) {
             http_response_code($this['page']->header()->http_response_code);


### PR DESCRIPTION
Right now debugbar gets turned off on all non-HTML pages. Unfortunately enabling debug manually is not ideal and does not even really work as all of the debug messages added before calling `enable(true)` (not to mention other data) get lost.

This update will make the Debugger class less dependent on the configuration as well as keeps the debugbar enabled all the time. If the response isn't in HTML, the output will just not be rendered by default but is available for the plugins/templates.