### PR TITLE
Fix Windows routing with built-in server

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -166,7 +166,7 @@ class ImageMedium extends Medium
             $this->reset();
         }
 
-        return Grav::instance()['base_url'] . '/' . ltrim($output . $this->querystring() . $this->urlHash(), '/');
+        return trim(Grav::instance()['base_url'] . '/' . ltrim($output . $this->querystring() . $this->urlHash(), '/'), '\\');
     }
 
     /**

--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -175,7 +175,7 @@ class Medium extends Data implements RenderableInterface
             $this->reset();
         }
 
-        return Grav::instance()['base_url'] . '/' . ltrim($output . $this->querystring() . $this->urlHash(), '/');
+        return trim(Grav::instance()['base_url'] . '/' . ltrim($output . $this->querystring() . $this->urlHash(), '/'), '\\');
     }
 
     /**


### PR DESCRIPTION
Strip backward-slashes from Medium.php's and ImageMedium.php's url() method, both ahead of and trailing the string. As this uses `trim()` and backward-slashes it should be safe across systems, because only Windows actually relies on them even though PHP will allow either forward- or backward-slashes in paths.

This solves [Admin 1119](https://github.com/getgrav/grav-plugin-admin/issues/1119). Tested with PHP PHP 7.0.7 and Grav from current source, on Windows 10 x64, using `php -S localhost:80 -t "C:\Users\Ole Vik\Downloads\Grav\develop" system/router.php` to run the server.