### PR TITLE
fix #1501 path is lost when redirecting to detected language

### DIFF
--- a/system/src/Grav/Common/Service/PageServiceProvider.php
+++ b/system/src/Grav/Common/Service/PageServiceProvider.php
@@ -73,7 +73,7 @@ class PageServiceProvider implements ServiceProviderInterface
                         $c->redirect($url);
                     }
                     if (!$language->isLanguageInUrl() && $language->isIncludeDefaultLanguage()) {
-                        $c->redirectLangSafe($url);
+                        $c->redirectLangSafe($path);
                     }
                 }
                 // Default route test and redirect


### PR DESCRIPTION
As far as I can see $path contains the original path from the url. Currently $url=='/' which means that the following redirection occurs : 

http://domain/mypage -> http://domain/en

Instead of :

http://domain/mypage -> http://domain/en/mypage

Im not sure whether the same should be done for the if condition immediately preceding this one though? :o/