### PR TITLE
Nicetime fix: 0 seconds from now -> just now

### DIFF
--- a/system/languages/en.yaml
+++ b/system/languages/en.yaml
@@ -60,6 +60,7 @@ NICETIME:
     BAD_DATE: Bad date
     AGO: ago
     FROM_NOW: from now
+    JUST_NOW: just now
     SECOND: second
     MINUTE: minute
     HOUR: hour

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -445,6 +445,9 @@ class TwigExtension extends \Twig_Extension
             $difference = $now - $unix_date;
             $tense      = $this->grav['language']->translate('NICETIME.AGO', null, true);
 
+        } else if ($now == $unix_date) {
+            $tense      = $this->grav['language']->translate('NICETIME.JUST_NOW', null, false);
+            
         } else {
             $difference = $unix_date - $now;
             $tense      = $this->grav['language']->translate('NICETIME.FROM_NOW', null, true);
@@ -469,8 +472,13 @@ class TwigExtension extends \Twig_Extension
         }
 
         $periods[$j] = $this->grav['language']->translate($periods[$j], null, true);
-
-        return "$difference $periods[$j] {$tense}";
+        
+        if ($now == $unix_date) {
+            return "{$tense}";
+        }
+        else {
+            return "$difference $periods[$j] {$tense}";
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes the weird message that appears when the posting time equals the current date, for example if a user submits a comment and checks the time their comment was posted right away.

Will probably require the JUST_NOW variable to be added to all translations.