### PR TITLE
Allow to set `system.session.timeout` to 0 to clear session on browser close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v1.3.0-rc.5
 ## mm/dd/2017
 
+1. [](#new)
+    * Setting `system.session.timeout` to 0 clears the session when the browser session ends [#1538](https://github.com/getgrav/grav/pull/1538)
 1. [](#bugfix)
     * Fixed global media files disappearing after a reload [#1545](https://github.com/getgrav/grav/issues/1545)
     * Set folder name as required during validation [grav-plugin-admin#1146](https://github.com/getgrav/grav-plugin-admin/issues/1146)

--- a/system/src/Grav/Common/Session.php
+++ b/system/src/Grav/Common/Session.php
@@ -84,7 +84,7 @@ class Session extends BaseSession
             }
             $this->setName($session_name);
             $this->start();
-            setcookie(session_name(), session_id(), time() + $session_timeout, $session_path, $domain, $secure, $httponly);
+            setcookie(session_name(), session_id(), $session_timeout ? time() + $session_timeout : 0, $session_path, $domain, $secure, $httponly);
         }
     }
 


### PR DESCRIPTION
(Refs https://github.com/getgrav/grav-plugin-login/issues/121) 

We didn’t allow 0 as an expiry value for `setcookie` http://php.net/manual/it/function.setcookie.php.

If “remember me” is not checked, and the browser is closed AND it’s not set to continue your session (see https://stackoverflow.com/a/10772420/205039), the session will be cleared.

Remember: Admin has its own session lifetime setting in its configuration.