### PR TITLE
Fix natural sort when > 100 pages

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -1240,7 +1240,7 @@ class Pages
                 case 'default':
                 default:
                     $list[$key] = $key;
-                    $sort_flags = $sort_flags ?: SORT_REGULAR;
+                    $sort_flags = $sort_flags ?: SORT_NATURAL | SORT_FLAG_CASE;
             }
         }
 
@@ -1257,6 +1257,12 @@ class Pages
                 $locale = setlocale(LC_COLLATE, 0); //`setlocale` with a 0 param returns the current locale set
                 $col = Collator::create($locale);
                 if ($col) {
+                    if (($sort_flags & SORT_NATURAL) === SORT_NATURAL) {
+                        $list = preg_replace_callback('~([0-9]+)~', function($number) {
+                            return sprintf('%032d', $number);
+                        }, $list);
+                    }
+
                     $col->asort($list, $sort_flags);
                 } else {
                     asort($list, $sort_flags);

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -1240,7 +1240,7 @@ class Pages
                 case 'default':
                 default:
                     $list[$key] = $key;
-                    $sort_flags = $sort_flags ?: SORT_NATURAL | SORT_FLAG_CASE;
+                    $sort_flags = $sort_flags ?: SORT_REGULAR;
             }
         }
 

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -1258,7 +1258,7 @@ class Pages
                 $col = Collator::create($locale);
                 if ($col) {
                     if (($sort_flags & SORT_NATURAL) === SORT_NATURAL) {
-                        $list = preg_replace_callback('~([0-9]+)~', function($number) {
+                        $list = preg_replace_callback('~([0-9]+)\.~', function($number) {
                             return sprintf('%032d', $number);
                         }, $list);
                     }


### PR DESCRIPTION
When there are > 100 pages, on unix the sorting is not natural and so Grav orders 1-10, 100, 101 ...
Turns out the issue is caused by the `Collator` that we use for sorting when `intl` extension is available. `Collator` ([ref](http://php.net/manual/en/collator.asort.php))  does not support the `SORT_NATURAL` flag like the `sort` ([ref](http://php.net/manual/en/function.sort.php)) method does which is the reason this has never sorted naturally as expected.

## How to reproduce
Unzip [02.cats.zip](https://github.com/getgrav/grav/files/1136675/02.cats.zip) under your pages and load the frontend with and without the fix.

> Note: needs to be in linux


Fixes #1524