### PR TITLE
Fix default sort order

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -1259,7 +1259,7 @@ class Pages
                 if ($col) {
                     if (($sort_flags & SORT_NATURAL) === SORT_NATURAL) {
                         $list = preg_replace_callback('~([0-9]+)\.~', function($number) {
-                            return sprintf('%032d', $number[0]);
+                            return sprintf('%032d.', $number[0]);
                         }, $list);
                     }
 


### PR DESCRIPTION
[This](https://github.com/getgrav/grav/commit/287a51148a3cdc74d70f6dd9e1de0c3d336b8fae) appears to have broken page ordering (see #1574).

Test-information:

Did a quick test on a personal project, clearing cache and reloading
the page fixed the default sort order of the navbar (i.e. it displayed
according to numeric folder prefixes).