### PR TITLE
Sort taxonomy filtered collections

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2634,7 +2634,8 @@ class Page
                 if (!empty($parts)) {
                     $params = [implode('.', $parts) => $params];
                 }
-                $results = $taxonomy_map->findTaxonomy($params)->published();
+                $order = $this->orderBy();
+                $results = $taxonomy_map->findTaxonomy($params, null, $order)->published();
                 break;
         }
 

--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -85,7 +85,7 @@ class Taxonomy
      *
      * @return Collection       Collection object set to contain matches found in the taxonomy map
      */
-    public function findTaxonomy($taxonomies, $operator = 'and')
+    public function findTaxonomy($taxonomies, $operator = 'and', $order = 'default')
     {
         $matches = [];
         $results = [];

--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -81,6 +81,7 @@ class Taxonomy
      *
      * @param  array  $taxonomies taxonomies to search, eg ['tag'=>['animal','cat']]
      * @param  string $operator   can be 'or' or 'and' (defaults to 'and')
+     * @param  string $order      the sort order to be applied to the taxonomy
      *
      * @return Collection       Collection object set to contain matches found in the taxonomy map
      */
@@ -110,7 +111,8 @@ class Taxonomy
             }
         }
 
-        return new Collection($results, ['taxonomies' => $taxonomies]);
+        $collection = new Collection($results, ['taxonomies' => $taxonomies]);
+        return $collection->order($order);
     }
 
     /**


### PR DESCRIPTION
This relates to #1577.

Assume you have the following structure:
```
/home
/home/featured-work
/portfolio
/portfolio/portfolio-item-1
/portfolio/portfolio-item-2
/portfolio/portfolio-item-3
```

/home is a modular page, and the /home/featured-work page is a module that
displays a number of pages with a given taxonomy from the /portfolio collection.

If each portfolio item is manually sorted (i.e. by folder prefix), then viewing
the /portfolio page displays the collection in the *correct* order.

However, when items from this collection are rendered by a page under a sibling
parent, the sort order is *incorrect*.

I believe this is a bug, but it would be good to confirm.

Looking at the code, it appears to be a straightforward fix, sorting the
collection generated from a given taxonomy.

**Test-information:**

By cp'ing the files over to an existing Grav site and testing that items displayed
by a module on the home page (from a sibling collection) were displayed as
expected.

Other pages are still sorted correctly (e.g. top-level pages in the navbar), it would
probably be sensible if someone else tests and confirms that this hasn't broken things
for them (it would be much appreciated :smiley: ).