### PR TITLE
Causes configuration error (nginx)

### DIFF
--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -34,7 +34,7 @@ server {
         # fastcgi_pass 127.0.0.1:9000;
 
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_index index.php;
+        # fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
     }


### PR DESCRIPTION
Output of `nginx -t`:

nginx: [emerg] "fastcgi_index" directive is duplicate in /etc/nginx/sites-enabled/example.com:70
nginx: configuration file /etc/nginx/nginx.conf test failed