### PR TITLE
Change field validation of `system.session.timeout` to accept `0`

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -1003,7 +1003,7 @@ form:
                     help: PLUGIN_ADMIN.TIMEOUT_HELP
                     validate:
                         type: number
-                        min: 1
+                        min: 0
 
                 session.name:
                     type: text


### PR DESCRIPTION
In commit 08920d5 it was allowed to set `system.session.timeout` to be `0`.
But the admin plugin refused to save this value because of the defined validation rules.
To fix this issue I changed the min. value of the validation rule from 1 to 0. 

I'll be grateful if you could accept this PR.