### PR TITLE
Changing back the default redirect code from 301 to 302.

### DIFF
--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -58,8 +58,8 @@ pages:
   etag: false                                    # Set the etag header tag
   vary_accept_encoding: false                    # Add `Vary: Accept-Encoding` header
   redirect_default_route: false                  # Automatically redirect to a page's default route
-  redirect_default_code: 301                     # Default code to use for redirects
-  redirect_trailing_slash: true                  # Handle automatically or 301 redirect a trailing / URL
+  redirect_default_code: 302                     # Default code to use for redirects
+  redirect_trailing_slash: true                  # Handle automatically or 302 redirect a trailing / URL
   ignore_files: [.DS_Store]                      # Files to ignore in Pages
   ignore_folders: [.git, .idea]                  # Folders to ignore in Pages
   ignore_hidden: true                            # Ignore all Hidden files and folders

--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -174,7 +174,7 @@ class Grav extends Container
         }
 
         if ($code === null) {
-            $code = $this['config']->get('system.pages.redirect_default_code', 301);
+            $code = $this['config']->get('system.pages.redirect_default_code', 302);
         }
 
         if (isset($this['session'])) {

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -295,9 +295,9 @@ class Uri
             $uri = str_replace($setup_base, '', $uri);
         }
 
-        // If configured to, redirect trailing slash URI's with a 301 redirect
+        // If configured to, redirect trailing slash URI's with a 302 redirect
         if ($config->get('system.pages.redirect_trailing_slash', false) && $uri != '/' && Utils::endsWith($uri, '/')) {
-            $grav->redirect(str_replace($this->root, '', rtrim($uri, '/')), 301);
+            $grav->redirect(str_replace($this->root, '', rtrim($uri, '/')), 302);
         }
 
         // process params


### PR DESCRIPTION
A permanent redirect can not be changed remotely once it has been sent.

Permanent redirects (301 / 308) are exactly what the their descriptive
name suggest. A 301 or 308 will be indefinitely cached client-side,
sometimes even when a user clears their cache.

They should be used to keep search engine page rankings by sending a
permanent redirect on a page by page basis, not for site to site or
protocols (http to https).

Especially on a new Grav installation, the default should not be 301.

My reasoning is that with the first visit to a new installation, before
even doing anything else, the 301 is already permanently cached in the
browser.

Additionally, temporary redirects can be influenced remotely and are not
that expensive on the webserver nowadays with event-based handlers.