### PR TITLE
Precompression for (pipelined) assets (nginx::gzip_static support).

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -794,6 +794,27 @@ form:
                     validate:
                         type: bool
 
+                assets.precompress:
+                    type: toggle
+                    label: PLUGIN_ADMIN.PRECOMPRESS_ASSET
+                    help: PLUGIN_ADMIN.PRECOMPRESS_ASSET_HELP
+                    highlight: 0
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    validate:
+                        type: bool
+
+                assets.precompress_level:
+                    type: text
+                    size: x-small
+                    label: PLUGIN_ADMIN.PRECOMPRESS_ASSET_LEVEL
+                    help: PLUGIN_ADMIN.PRECOMPRESS_ASSET_LEVEL_HELP
+                    validate:
+                        type: number
+                        min: 1
+                        max: 9
+
                 assets.enable_asset_timestamp:
                     type: toggle
                     label: PLUGIN_ADMIN.ENABLED_TIMESTAMPS_ON_ASSETS

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -102,6 +102,8 @@ assets:                                          # Configuration for Assets Mana
   js_pipeline_include_externals: true            # Include external URLs in the pipeline by default
   js_pipeline_before_excludes: true              # Render the pipeline before any excluded files
   js_minify: true                                # Minify the JS during pipelining
+  precompress: false                             # Precompress assets with GZip
+  precompress_level: 9                           # Compression level to use (1 = fastest, 9 = highest)
   enable_asset_timestamp: false                  # Enable asset timestamps
   collections:
     jquery: system://assets/jquery/jquery-2.x.min.js


### PR DESCRIPTION
Compressing resources on-the-fly adds CPU-load and latency (wait for the
compression to be done) every time a resource is served. nginx offers
another way of doing things, and it's called gzip_static.

http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html

If you enable gzip_static, nginx will look for $filename.gz and serve
that directly, so no extra CPU-cost or latency is added to your
requests, speeding up the serving of your website.

This feature adds support to directly compress asset files when they are
written to disk by the Grav\Common\Assets class. Using this feature you
can also specify the compression level (default to the maximum of 9).

Since you only have to compress every resource only once, using the
maximum compression level is an ideal default.