### PR TITLE
Gregwar/Image supports gaussianBlur, so should Grav

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -51,7 +51,7 @@ class ImageMedium extends Medium
         'resize', 'forceResize', 'cropResize', 'crop', 'zoomCrop',
         'negate', 'brightness', 'contrast', 'grayscale', 'emboss',
         'smooth', 'sharp', 'edge', 'colorize', 'sepia', 'enableProgressive',
-        'rotate', 'flip', 'fixOrientation'
+        'rotate', 'flip', 'fixOrientation', 'gaussianBlur'
     ];
 
     /**


### PR DESCRIPTION
Since grav uses the GD Adapter of Gregwar/Image and has no option to change it, this should be safe to implement, when the latest Version of the Lib is used.