### PR TITLE
Try to load alphanumeric Installer class

### DIFF
--- a/system/src/Grav/Common/GPM/Installer.php
+++ b/system/src/Grav/Common/GPM/Installer.php
@@ -238,6 +238,12 @@ class Installer
             return $class_name;
         }
 
+        $class_name_alphanumeric = preg_replace('/[^a-zA-Z0-9]+/', '', $class_name);
+
+        if (class_exists($class_name_alphanumeric)) {
+            return $class_name_alphanumeric;
+        }
+
         return $installer;
     }
 


### PR DESCRIPTION
My plugin [Admin Addon Revisions](https://github.com/david-szabo97/grav-plugin-admin-addon-revisions) has dashes in its name. That way the Installer is trying to load the `Admin-addon-revisionsInstall` class, which is impossible because class name can't contain dashes.

I added a second check which tries to load the alphanumeric version, in this it will try to load `Admin-addon-revisionsInstall` first, if it can't find it will try to load the `AdminaddonrevisionsInstall`.