### PR TITLE
Fix setting session cookie twice

### DIFF
--- a/system/src/Grav/Common/Session.php
+++ b/system/src/Grav/Common/Session.php
@@ -83,8 +83,9 @@ class Session extends BaseSession
               $session_name .= '-admin';
             }
             $this->setName($session_name);
+            ini_set('session.cookie_secure', $secure);
+            ini_set('session.cookie_httponly', $httponly);
             $this->start();
-            setcookie(session_name(), session_id(), $session_timeout ? time() + $session_timeout : 0, $session_path, $domain, $secure, $httponly);
         }
     }
 


### PR DESCRIPTION
Because setting cookie twice bothers me. Now proper options are applied to first one, so no need to set it again.

`RocketTheme\Toolbox\Session` uses `ini_set()` internally anyway, so this should not be a problem, but it can be changed to full `session_set_cookie_params()` call.