### PR TITLE
Added system option to enable case insensitive urls.

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -1163,6 +1163,17 @@ form:
                     validate:
                         type: bool
 
+                case_insensitive_urls:
+                    type: toggle
+                    label: PLUGIN_ADMIN.CASE_INSENSITIVE_URLS
+                    highlight: 0
+                    help: PLUGIN_ADMIN.CASE_INSENSITIVE_URLS_HELP
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    validate:
+                        type: bool
+
                 param_sep:
                     type: select
                     size: medium

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -286,6 +286,11 @@ class Uri
 
         $this->url = $this->base . $this->uri;
 
+        // if case insensitive urls is enabled, lowercase the url
+        if( $grav['config']->get('system.case_insensitive_urls') ){
+            $this->url = strtolower($this->url);
+        }
+
         // get any params and remove them
         $uri = str_replace($this->root, '', $this->url);
 


### PR DESCRIPTION
Simple adjustment to allow case insensitive urls. 
The toggle shows up in the advanced section of the system options of a Grav site. 
I understand the admin plugin will also need an update to provide the label and help text.
Please let me know if this change requires additional development. I'm unsure if there are wider repercussions for this change. 