### PR TITLE
Fix insecure session cookie initialization

### DIFF
--- a/system/src/Grav/Common/Session.php
+++ b/system/src/Grav/Common/Session.php
@@ -83,6 +83,8 @@ class Session extends BaseSession
               $session_name .= '-admin';
             }
             $this->setName($session_name);
+            ini_set('session.cookie_secure', $secure);
+            ini_set('session.cookie_httponly', $httponly);
             $this->start();
             setcookie(session_name(), session_id(), $session_timeout ? time() + $session_timeout : 0, $session_path, $domain, $secure, $httponly);
         }


### PR DESCRIPTION
While, as pull request #1634 has proven, it's not the best idea around to get rid of the duplicate session cookie, I still consider it a good idea to ensure that the initial cookie has properly configured security. Doing so not only prevents the so-far-distant scenario where a ~~poor JavaScript interpreter programmer~~ _mastermind visionaire_ makes the Set-Cookie HTTP headers visible to JavaScript unless they're set to HTTP only (or, worse yet, makes the Set-Cookie headers get processed alongside JavaScript, effectively making Grav suspectible to a while loop checking document.cookie), but also the imminent spread of FUD (which is probably happening yet behind our backs, see the first Google result for "Web Server Security Test", especially the grading penalty it gives for "missing secure flags or attributes" on cookies) once website security checkers figure out that _there are insecure sessions_ and pass that information to users.