### PR TITLE
Update Assets.php

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -663,14 +663,18 @@ class Assets
 
         // Render Inline JS
         foreach ($this->inline_js as $inline) {
-            if ($group && $inline['group'] == $group) {
+            if (($group && $inline['group'] == $group) && ($inline['type'] == '')) {
+                // concatenate inlined js if type is empty
                 $inline_js .= $inline['asset'] . "\n";
+            } else {
+                // build a script tag if inline type is set
+                $attributeString = " type=\"" . $inline['type'] . "\""; 
+                $output .= "\n<script" . $attributeString . ">\n" . $inline['asset'] . "\n</script>\n";
             }
         }
 
         if ($inline_js) {
-            $attribute_string = isset($inline) && $inline['type'] ? " type=\"" . $inline['type'] . "\"" : '';
-            $output .= "\n<script" . $attribute_string . ">\n" . $inline_js . "\n</script>\n";
+             $output .= "\n<script>\n" . $inline_js . "\n</script>\n";
         }
 
         return $output;

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -663,7 +663,7 @@ class Assets
 
         // Render Inline JS
         foreach ($this->inline_js as $inline) {
-            if (($group && $inline['group'] == $group) && ($inline['type'] == '')) {
+           if ($group && $inline['group'] === $group && $inline['type'] === '') {
                 // concatenate inlined js if type is empty
                 $inline_js .= $inline['asset'] . "\n";
             } else {

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -487,7 +487,7 @@ class Assets
             'priority' => intval($priority ?: 10),
             'order'    => count($this->js),
             'group'    => $group ?: 'head',
-            'type'     => $attributes ?: '',
+            'type'     => $attributes ?: 'text/javascript',
         ];
 
         // check for dynamic array and merge with defaults
@@ -663,20 +663,11 @@ class Assets
 
         // Render Inline JS
         foreach ($this->inline_js as $inline) {
-           if ($group && $inline['group'] === $group && $inline['type'] === '') {
-                // concatenate inlined js if type is empty
-                $inline_js .= $inline['asset'] . "\n";
-            } else {
-                // build a script tag if inline type is set
+           if ($group && $inline['group'] === $group) {
                 $attributeString = " type=\"" . $inline['type'] . "\""; 
                 $output .= "\n<script" . $attributeString . ">\n" . $inline['asset'] . "\n</script>\n";
-            }
+            } 
         }
-
-        if ($inline_js) {
-             $output .= "\n<script>\n" . $inline_js . "\n</script>\n";
-        }
-
         return $output;
     }
 


### PR DESCRIPTION
This is a small addition to the previous change. 
This allows to have multiple type on inlined js. Without this change, if you have something like
```
{% do assets.addInlineJs('Hello', 100,'', "somespecialtype") %}
{% do assets.addInlineJs('Good Morning', 100,'', "anothertype") %}
{% do assets.addInlineJs('Goodbye', 100,'') %} // regular inlined js
{% do assets.addInlineJs('Bonjour', 100,'') %} // regular inlined js
```

It will be rendered like this:

```
<script type="somespecialtype">
Hello 
Good Morning
Goodbye
Bonjour
</script>
```

With this fix, it should display 
```
<script type="anothertype">
Good Morning
</script>

<script type="somespecialtype">
Hello
</script>

// These two inlined js has no type specified, so we can group them on the same tag
<script>
Bonjour 
Goodbye
</script>
```