### PR TITLE
Remove the dependency with published() in routable() method of Page

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1410,7 +1410,7 @@ class Page
     /**
      * Gets and Sets whether or not this Page is routable, ie you can reach it
      * via a URL.
-     * The page must be *routable* and *published*
+     * The page must be *routable*
      *
      * @param  bool $var true if the page is routable
      *
@@ -1422,7 +1422,7 @@ class Page
             $this->routable = (bool)$var;
         }
 
-        return $this->routable && $this->published();
+        return $this->routable;
     }
 
     public function ssl($var = null)


### PR DESCRIPTION
Hello,

I propose this modification for the class Page.
The initial routable() method return a boolean depends on variable "routable" and result of method published(). I propose to remove the dependance with published().

In my project, I would to use the principle of "not published page" so for adjustment of the content, it is interesting for me to preview the final result. In the current version of Grav, a button "preview" is available (In edition mode) but only reachable when page is published, through the routable() method. So maybe I misunderstood anything on why result of routable() depends of published(), but I think a page can be routable and **not** published.

I propose this solution to resolve my issue, and in case of conflict with another feature unknown by me, tell me please.

Thank you,
Clem
