### PR TITLE
use lowercase comparison for taxonomy terms

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2498,7 +2498,7 @@ class Page
                         foreach ($items as $item) {
                             $item = rawurldecode($item);
                             if (empty($page->taxonomy[$taxonomy]) || !in_array(htmlspecialchars_decode($item,
-                                    ENT_QUOTES), $page->taxonomy[$taxonomy])
+                                    ENT_QUOTES), array_map('strtolower', $page->taxonomy[$taxonomy]))
                             ) {
                                 $collection->remove($page->path());
                             }


### PR DESCRIPTION
Since the URI params only get returned lowercase in 1.3.8, the comparison for the use of the terms of the taxonomy should search in a lowercase version of the pages taxonomy maps.

This will result in a loss of the case sensitivity of taxonomy terms.

Term1 and term1 will be the same.

fixes: #1729