### PR TITLE
make sure find resource return valid path before clean the cache

### DIFF
--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -390,6 +390,7 @@ class Cache extends Getters
             // Convert stream to a real path
             try {
                 $path = $locator->findResource($stream, true, true);
+                if($path === false) continue;
 
                 $anything = false;
                 $files = glob($path . '/*');


### PR DESCRIPTION
Hello, i currently encounter a issue which are super danger if user accidentally remove assets folder. and run 'gpm install' on their machine. 
The findResource method will return false and `glob($path . '/*')` will return the whole directory of user's root disk, which will remove everything on your current disk. 

Here is a screen shot show how it looks like.
<img width="1150" alt="cache_php_-_holiday-gift-guide_-____htdocs_holiday-gift-guide_" src="https://user-images.githubusercontent.com/6547291/32677578-f78eb308-c62c-11e7-874a-47c5c614cb81.png">

I know it's my fault, but it shouldn't broken my computer. 