### PR TITLE
Fixed issue #1742 where the creation of GPM object tried to connect t…

### DIFF
--- a/system/src/Grav/Common/GPM/GPM.php
+++ b/system/src/Grav/Common/GPM/GPM.php
@@ -17,6 +17,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class GPM extends Iterator
 {
+    /** @var  callable */
+    private $callback;
+
     /**
      * Local installed Packages
      * @var Local\Packages
@@ -28,6 +31,9 @@ class GPM extends Iterator
      * @var Remote\Packages
      */
     private $repository;
+
+    /** @var  bool */
+    private $shouldRefresh;
 
     /**
      * @var Remote\GravCore
@@ -47,18 +53,33 @@ class GPM extends Iterator
     ];
 
     /**
-     * Creates a new GPM instance with Local and Remote packages available
+     * Loads Remote Packages available
+     */
+    private function retrieveRemoteRepository()
+    {
+        if (!$this->repository) {
+            $this->repository = new Remote\Packages($this->shouldRefresh, $this->callback);
+        }
+    }
+
+    /**
+     * Creates a new GPM instance with Local packages available
      * @param boolean $refresh Applies to Remote Packages only and forces a refetch of data
      * @param callable $callback Either a function or callback in array notation
      */
     public function __construct($refresh = false, $callback = null)
     {
         $this->installed = new Local\Packages();
-        try {
-            $this->repository = new Remote\Packages($refresh, $callback);
-            $this->grav = new Remote\GravCore($refresh, $callback);
-        } catch (\Exception $e) {
-        }
+        $this->shouldRefresh = $refresh;
+        $this->callback = $callback;
+    }
+
+    /**
+     * Loads Remote Grav package available
+     */
+    public function loadRemoteGrav()
+    {
+        $this->grav = new Remote\GravCore($this->refresh, $this->callback);
     }
 
     /**
@@ -268,6 +289,7 @@ class GPM extends Iterator
      */
     public function getLatestVersionOfPackage($package_name)
     {
+        $this->retrieveRemoteRepository();
         $repository = $this->repository['plugins'];
         if (isset($repository[$package_name])) {
             return $repository[$package_name]->available ?: $repository[$package_name]->version;
@@ -310,6 +332,7 @@ class GPM extends Iterator
     public function getUpdatableThemes()
     {
         $items = [];
+        $this->retrieveRemoteRepository();
         $repository = $this->repository['themes'];
 
         // local cache to speed things up
@@ -357,6 +380,7 @@ class GPM extends Iterator
      */
     public function getReleaseType($package_name)
     {
+        $this->retrieveRemoteRepository();
         $repository = $this->repository['plugins'];
         if (isset($repository[$package_name])) {
             return $repository[$package_name]->release_type;
@@ -405,6 +429,7 @@ class GPM extends Iterator
      */
     public function getRepositoryPlugin($slug)
     {
+        $this->retrieveRemoteRepository();
         return @$this->repository['plugins'][$slug];
     }
 
@@ -443,6 +468,7 @@ class GPM extends Iterator
      */
     public function getRepository()
     {
+        $this->retrieveRemoteRepository();
         return $this->repository;
     }
 

--- a/tests/unit/Grav/Common/GPM/GPMTest.php
+++ b/tests/unit/Grav/Common/GPM/GPMTest.php
@@ -320,4 +320,47 @@ class GpmTest extends \Codeception\TestCase\Test
         $this->assertSame(null, $this->gpm->calculateVersionNumberFromDependencyVersion('*'));
         $this->assertSame('2.0.2', $this->gpm->calculateVersionNumberFromDependencyVersion('2.0.2'));
     }
+
+    public function testRemoteRepositoryIsEmptyAfterConstruct()
+    {
+        $gpm = new GPM();
+        $reflection = new \ReflectionClass(get_class($gpm));
+        $repository = $reflection->getProperty('repository');
+        $repository->setAccessible(true);
+
+        $this->assertSame(null, $repository->getValue($gpm));
+    }
+
+    public function testLocalRepositoryIsNotEmptyAfterConstruct()
+    {
+        $gpm = new GPM();
+        $reflection = new \ReflectionClass(get_class($gpm));
+        $repository = $reflection->getProperty('installed');
+        $repository->setAccessible(true);
+
+        $this->assertInstanceOf( '\Grav\Common\GPM\Local\Packages', $repository->getValue($gpm));
+    }
+
+    public function testGetRepository()
+    {
+        $this->assertInstanceOf('\Grav\Common\GPM\Remote\Packages', $this->gpm->getRepository());
+    }
+
+    public function testLatestVersionOfPackage()
+    {
+        $gpm = new GPM();
+        $this->assertNotNull($gpm->getLatestVersionOfPackage('admin'));
+    }
+
+    public function testReleaseType()
+    {
+        $gpm = new GPM();
+        $this->assertNotNull($gpm->getReleaseType('admin'));
+    }
+
+    public function testGetRepositoryPlugin()
+    {
+        $gpm = new GPM();
+        $this->assertNotNull($gpm->getRepositoryPlugin('admin'));
+    }
 }


### PR DESCRIPTION
…o Remote repositories even if only Local package was needed

Now, it only tries to connect to the outside world when really required and not when just creating a new GPM object.
This could break client classes with the following code:
```
$gpm = new GPM();
$gpm->grav->getVersion(); //or any other grav method
```
The above code must be replaced with:
```
$gpm = new GPM();
$gpm->loadRemoteGrav();
$gpm->grav->getVersion(); //or any other grav method
```