### PR TITLE
Add additional controls to HTML5 audio attributes

### DIFF
--- a/system/src/Grav/Common/Page/Medium/AudioMedium.php
+++ b/system/src/Grav/Common/Page/Medium/AudioMedium.php
@@ -31,6 +31,114 @@ class AudioMedium extends Medium
     }
 
     /**
+     * Allows to set or remove the HTML5 default controls
+     *
+     * @param bool $display
+     * @return $this
+     */
+    public function controls($display = true)
+    {
+        if($display)
+        {
+            $this->attributes['controls'] = true;
+        }
+        else
+        {
+            unset($this->attributes['controls']);
+        }
+        return $this;
+    }
+
+    /**
+     * Allows to set the preload behaviour
+     *
+     * @param $preload
+     * @return $this
+     */
+    public function preload($preload)
+    {
+        $validPreloadAttrs = array('auto','metadata','none');
+        
+        if (in_array($preload, $validPreloadAttrs))
+        {
+            $this->attributes['preload'] = $preload;
+        }
+        return $this;
+    }
+
+    /**
+     * Allows to set the controlsList behaviour
+     * Separate multiple values with a hyphen
+     *
+     * @param $controlsList
+     * @return $this
+     */
+    public function controlsList($controlsList)
+    {
+        $controlsList = str_replace('-', ' ', $controlsList);
+        $this->attributes['controlsList'] = $controlsList;
+        return $this;
+    }
+
+    /**
+     * Allows to set the mute attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function mute($status = false)
+    {
+        if($status)
+        {
+            $this->attributes['mute'] = true;
+        }
+        else
+        {
+            unset($this->attributes['mute']);
+        }
+        return $this;
+    }
+
+    /**
+     * Allows to set the loop attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function loop($status = false)
+    {
+        if($status)
+        {
+            $this->attributes['loop'] = true;
+        }
+        else
+        {
+            unset($this->attributes['loop']);
+        }
+        return $this;
+    }
+
+    /**
+     * Allows to set the autoplay attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function autoplay($status = false)
+    {
+        if($status)
+        {
+            $this->attributes['autoplay'] = true;
+        }
+        else
+        {
+            unset($this->attributes['autoplay']);
+        }
+        return $this;
+    }
+
+
+    /**
      * Reset medium.
      *
      * @return $this


### PR DESCRIPTION
Adds support for `autoplay`, `controls`, `loop`, and `preload` attributes of `audio` elements, with rudimentary validation for `preload`.

Functions for `autoplay`, `controls`, and `loop` are copied directly from pfcloutier-druide@aaa3f82

See also #1442.