### PR TITLE
Fixed CSS Pipeline failing with Google remote fonts if the file was minified (#1261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     * Remove support for `config.user`, it was broken and bad practise
     * Make sure that `clean cache` uses valid path [#1745](https://github.com/getgrav/grav/pull/1745)
     * Fixed token creation issue with `Uri` params like `/id:3`
+    * Fixed CSS Pipeline failing with Google remote fonts if the file was minified [#1261](https://github.com/getgrav/grav-plugin-admin/issues/1261)
     
 # v1.3.8
 ## 10/26/2017

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -35,12 +35,12 @@ class Assets
     const CSS_URL_REGEX = '{url\(([\'\"]?)(.*?)\1\)}';
 
     /** @const Regex to match CSS sourcemap comments */
-    const CSS_SOURCEMAP_REGEX = '{\/\*# (.*) \*\/}';
+    const CSS_SOURCEMAP_REGEX = '{\/\*# (.*?) \*\/}';
 
     /** @const Regex to match CSS import content */
-    const CSS_IMPORT_REGEX = '{@import(.*);}';
+    const CSS_IMPORT_REGEX = '{@import(.*?);}';
 
-    const HTML_TAG_REGEX = '#(<([A-Z][A-Z0-9]*)>)+(.*)(<\/\2>)#is';
+    const HTML_TAG_REGEX = '#(<([A-Z][A-Z0-9]*)>)+(.*?)(<\/\2>)#is';
 
 
     /**

--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -40,7 +40,11 @@ class Assets
     /** @const Regex to match CSS import content */
     const CSS_IMPORT_REGEX = '{@import(.*?);}';
 
-    const HTML_TAG_REGEX = '#(<([A-Z][A-Z0-9]*)>)+(.*?)(<\/\2>)#is';
+    /**
+     * @const Regex to match <script> or <style> tag when adding inline style/script. Note that this only supports a
+     * single tag, so the check is greedy to avoid issues in JS.
+     */
+    const HTML_TAG_REGEX = '#(<([A-Z][A-Z0-9]*)>)+(.*)(<\/\2>)#is';
 
 
     /**


### PR DESCRIPTION
Had to make regex'es ungreedy. I think the same issue is in 

CSS_SOURCEMAP_REGEX
CSS_IMPORT_REGEX
HTML_TAG_REGEX (well, this seems to be used with a single `<script>` or `<style>` tag, but...