### PR TITLE
Refactoring tests

### DIFF
--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -477,9 +477,9 @@ class AssetsTest extends \Codeception\TestCase\Test
 
     public function testGetCollections()
     {
-        $this->assertTrue(is_array($this->assets->getCollections()));
-        $this->assertTrue(in_array('jquery', array_keys($this->assets->getCollections())));
-        $this->assertTrue(in_array('system://assets/jquery/jquery-2.x.min.js', $this->assets->getCollections()));
+        $this->assertInternalType('array', $this->assets->getCollections());
+        $this->assertContains('jquery', array_keys($this->assets->getCollections()));
+        $this->assertContains('system://assets/jquery/jquery-2.x.min.js', $this->assets->getCollections());
     }
 
     public function testExists()
@@ -492,107 +492,107 @@ class AssetsTest extends \Codeception\TestCase\Test
     {
         $this->assets->registerCollection('debugger', ['/system/assets/debugger.css']);
         $this->assertTrue($this->assets->exists('debugger'));
-        $this->assertTrue(in_array('debugger', array_keys($this->assets->getCollections())));
+        $this->assertContains('debugger', array_keys($this->assets->getCollections()));
     }
 
     public function testReset()
     {
         $this->assets->addInlineJs('alert("test")');
         $this->assets->reset();
-        $this->assertTrue(count($this->assets->js()) == 0);
+        $this->assertSame(0, count($this->assets->js()));
 
         $this->assets->addAsyncJs('jquery');
         $this->assets->reset();
 
-        $this->assertTrue(count($this->assets->js()) == 0);
+        $this->assertSame(0, count($this->assets->js()));
 
         $this->assets->addInlineCss('body { color: black }');
         $this->assets->reset();
 
-        $this->assertTrue(count($this->assets->css()) == 0);
+        $this->assertSame(0, count($this->assets->css()));
 
         $this->assets->add('/system/assets/debugger.css', null, true);
         $this->assets->reset();
 
-        $this->assertTrue(count($this->assets->css()) == 0);
+        $this->assertSame(0, count($this->assets->css()));
     }
 
     public function testResetJs()
     {
         $this->assets->addInlineJs('alert("test")');
         $this->assets->resetJs();
-        $this->assertTrue(count($this->assets->js()) == 0);
+        $this->assertSame(0, count($this->assets->js()));
 
         $this->assets->addAsyncJs('jquery');
         $this->assets->resetJs();
 
-        $this->assertTrue(count($this->assets->js()) == 0);
+        $this->assertSame(0, count($this->assets->js()));
     }
 
     public function testResetCss()
     {
-        $this->assertTrue(count($this->assets->js()) == 0);
+        $this->assertSame(0, count($this->assets->js()));
 
         $this->assets->addInlineCss('body { color: black }');
         $this->assets->resetCss();
 
-        $this->assertTrue(count($this->assets->css()) == 0);
+        $this->assertSame(0, count($this->assets->css()));
 
         $this->assets->add('/system/assets/debugger.css', null, true);
         $this->assets->resetCss();
 
-        $this->assertTrue(count($this->assets->css()) == 0);
+        $this->assertSame(0, count($this->assets->css()));
     }
 
     public function testAddDirCss()
     {
         $this->assets->addDirCss('/system');
 
-        $this->assertTrue(is_array($this->assets->getCss()));
-        $this->assertTrue(count($this->assets->getCss()) > 0);
-        $this->assertTrue(is_array($this->assets->getJs()));
-        $this->assertTrue(count($this->assets->getJs()) == 0);
+        $this->assertInternalType('array', $this->assets->getCss());
+        $this->assertGreaterThan(0, $this->assets->getCss());
+        $this->assertInternalType('array', $this->assets->getJs());
+        $this->assertCount(0, $this->assets->getJs());
 
         $this->assets->reset();
         $this->assets->addDirCss('/system/assets');
 
-        $this->assertTrue(is_array($this->assets->getCss()));
-        $this->assertTrue(count($this->assets->getCss()) > 0);
-        $this->assertTrue(is_array($this->assets->getJs()));
-        $this->assertTrue(count($this->assets->getJs()) == 0);
+        $this->assertInternalType('array', $this->assets->getCss());
+        $this->assertGreaterThan(0, $this->assets->getCss());
+        $this->assertInternalType('array', $this->assets->getJs());
+        $this->assertCount(0, $this->assets->getJs());
 
         $this->assets->reset();
         $this->assets->addDirJs('/system');
 
-        $this->assertTrue(is_array($this->assets->getCss()));
-        $this->assertTrue(count($this->assets->getCss()) == 0);
-        $this->assertTrue(is_array($this->assets->getJs()));
-        $this->assertTrue(count($this->assets->getJs()) > 0);
+        $this->assertInternalType('array', $this->assets->getCss());
+        $this->assertCount(0, $this->assets->getCss());
+        $this->assertInternalType('array', $this->assets->getJs());
+        $this->assertGreaterThan(0, $this->assets->getJs());
 
         $this->assets->reset();
         $this->assets->addDirJs('/system/assets');
 
-        $this->assertTrue(is_array($this->assets->getCss()));
-        $this->assertTrue(count($this->assets->getCss()) == 0);
-        $this->assertTrue(is_array($this->assets->getJs()));
-        $this->assertTrue(count($this->assets->getJs()) > 0);
+        $this->assertInternalType('array', $this->assets->getCss());
+        $this->assertCount(0, $this->assets->getCss());
+        $this->assertInternalType('array', $this->assets->getJs());
+        $this->assertGreaterThan(0, $this->assets->getJs());
 
         $this->assets->reset();
         $this->assets->addDir('/system/assets');
 
-        $this->assertTrue(is_array($this->assets->getCss()));
-        $this->assertTrue(count($this->assets->getCss()) > 0);
-        $this->assertTrue(is_array($this->assets->getJs()));
-        $this->assertTrue(count($this->assets->getJs()) > 0);
+        $this->assertInternalType('array', $this->assets->getCss());
+        $this->assertGreaterThan(0, $this->assets->getCss());
+        $this->assertInternalType('array', $this->assets->getJs());
+        $this->assertGreaterThan(0, $this->assets->getJs());
 
         //Use streams
         $this->assets->reset();
         $this->assets->addDir('system://assets');
 
-        $this->assertTrue(is_array($this->assets->getCss()));
-        $this->assertTrue(count($this->assets->getCss()) > 0);
-        $this->assertTrue(is_array($this->assets->getJs()));
-        $this->assertTrue(count($this->assets->getJs()) > 0);
+        $this->assertInternalType('array', $this->assets->getCss());
+        $this->assertGreaterThan(0, $this->assets->getCss());
+        $this->assertInternalType('array', $this->assets->getJs());
+        $this->assertGreaterThan(0, $this->assets->getJs());
 
     }
 }

--- a/tests/unit/Grav/Common/ComposerTest.php
+++ b/tests/unit/Grav/Common/ComposerTest.php
@@ -16,18 +16,17 @@ class ComposerTest extends \Codeception\TestCase\Test
     public function testGetComposerLocation()
     {
         $composerLocation = Composer::getComposerLocation();
-        $this->assertTrue(is_string($composerLocation));
-        $this->assertTrue($composerLocation[0] == '/');
+        $this->assertInternalType('string', $composerLocation);
+        $this->assertSame('/', $composerLocation[0]);
     }
 
     public function testGetComposerExecutor()
     {
         $composerExecutor = Composer::getComposerExecutor();
-        $this->assertTrue(is_string($composerExecutor));
-        $this->assertTrue($composerExecutor[0] == '/');
-        $this->assertTrue(strstr($composerExecutor, 'php') !== null);
-        $this->assertTrue(strstr($composerExecutor, 'composer') !== null);
+        $this->assertInternalType('string', $composerExecutor);
+        $this->assertSame('/', $composerExecutor[0]);
+        $this->assertNotNull(strstr($composerExecutor, 'php'));
+        $this->assertNotNull(strstr($composerExecutor, 'composer'));
     }
 
 }
-

--- a/tests/unit/Grav/Common/GPM/GPMTest.php
+++ b/tests/unit/Grav/Common/GPM/GPMTest.php
@@ -80,12 +80,12 @@ class GpmTest extends \Codeception\TestCase\Test
 
         $dependencies = $this->gpm->calculateMergedDependenciesOfPackages($packages);
 
-        $this->assertTrue(is_array($dependencies));
-        $this->assertSame(5, count($dependencies));
+        $this->assertInternalType('array', $dependencies);
+        $this->assertCount(5, $dependencies);
 
-        $this->assertTrue($dependencies['grav'] == '>=1.0.10');
-        $this->assertTrue(isset($dependencies['errors']));
-        $this->assertTrue(isset($dependencies['problems']));
+        $this->assertSame('>=1.0.10', $dependencies['grav']);
+        $this->assertArrayHasKey('errors', $dependencies);
+        $this->assertArrayHasKey('problems', $dependencies);
 
         //////////////////////////////////////////////////////////////////////////////////////////
         // Second working example
@@ -93,9 +93,9 @@ class GpmTest extends \Codeception\TestCase\Test
         $packages = ['admin', 'form'];
 
         $dependencies = $this->gpm->calculateMergedDependenciesOfPackages($packages);
-        $this->assertTrue(is_array($dependencies));
-        $this->assertSame(5, count($dependencies));
-        $this->assertTrue($dependencies['errors'] == '>=3.2');
+        $this->assertInternalType('array', $dependencies);
+        $this->assertCount(5, $dependencies);
+        $this->assertSame('>=3.2', $dependencies['errors']);
 
         //////////////////////////////////////////////////////////////////////////////////////////
         // Third working example
@@ -124,9 +124,9 @@ class GpmTest extends \Codeception\TestCase\Test
 
 
         $dependencies = $this->gpm->calculateMergedDependenciesOfPackages($packages);
-        $this->assertTrue(is_array($dependencies));
-        $this->assertSame(1, count($dependencies));
-        $this->assertTrue($dependencies['errors'] == '>=4.0');
+        $this->assertInternalType('array', $dependencies);
+        $this->assertCount(1, $dependencies);
+        $this->assertSame('>=4.0', $dependencies['errors']);
 
 
 
@@ -161,10 +161,10 @@ class GpmTest extends \Codeception\TestCase\Test
 
 
         $dependencies = $this->gpm->calculateMergedDependenciesOfPackages($packages);
-        $this->assertTrue($dependencies['package1'] == '>=4.0.0-rc2');
-        $this->assertTrue($dependencies['package2'] == '>=3.2.0-beta.11');
-        $this->assertTrue($dependencies['package3'] == '>=3.2.0-alpha.2');
-        $this->assertTrue($dependencies['package4'] == '>=3.2.0');
+        $this->assertSame('>=4.0.0-rc2', $dependencies['package1']);
+        $this->assertSame('>=3.2.0-beta.11', $dependencies['package2']);
+        $this->assertSame('>=3.2.0-alpha.2', $dependencies['package3']);
+        $this->assertSame('>=3.2.0', $dependencies['package4']);
 
 
         //////////////////////////////////////////////////////////////////////////////////////////
@@ -253,14 +253,14 @@ class GpmTest extends \Codeception\TestCase\Test
 
         $dependencies = $this->gpm->calculateMergedDependenciesOfPackages($packages);
 
-        $this->assertTrue(is_array($dependencies));
-        $this->assertSame(7, count($dependencies));
+        $this->assertInternalType('array', $dependencies);
+        $this->assertCount(7, $dependencies);
 
         $this->assertSame('>=1.0.10', $dependencies['grav']);
-        $this->assertTrue(isset($dependencies['errors']));
-        $this->assertTrue(isset($dependencies['problems']));
-        $this->assertTrue(isset($dependencies['antimatter']));
-        $this->assertTrue(isset($dependencies['something']));
+        $this->assertArrayHasKey('errors', $dependencies);
+        $this->assertArrayHasKey('problems', $dependencies);
+        $this->assertArrayHasKey('antimatter', $dependencies);
+        $this->assertArrayHasKey('something', $dependencies);
         $this->assertSame('>=3.2', $dependencies['something']);
     }
 
@@ -316,8 +316,8 @@ class GpmTest extends \Codeception\TestCase\Test
         $this->assertSame('2.0.2', $this->gpm->calculateVersionNumberFromDependencyVersion('>=2.0.2'));
         $this->assertSame('2.0.2', $this->gpm->calculateVersionNumberFromDependencyVersion('~2.0.2'));
         $this->assertSame('1', $this->gpm->calculateVersionNumberFromDependencyVersion('~1'));
-        $this->assertSame(null, $this->gpm->calculateVersionNumberFromDependencyVersion(''));
-        $this->assertSame(null, $this->gpm->calculateVersionNumberFromDependencyVersion('*'));
+        $this->assertNull($this->gpm->calculateVersionNumberFromDependencyVersion(''));
+        $this->assertNull($this->gpm->calculateVersionNumberFromDependencyVersion('*'));
         $this->assertSame('2.0.2', $this->gpm->calculateVersionNumberFromDependencyVersion('2.0.2'));
     }
 }

--- a/tests/unit/Grav/Common/Page/PagesTest.php
+++ b/tests/unit/Grav/Common/Page/PagesTest.php
@@ -41,19 +41,19 @@ class PagesTest extends \Codeception\TestCase\Test
         $this->pages->base('/test');
         $this->assertSame('/test', $this->pages->base());
         $this->pages->base('');
-        $this->assertSame(null, $this->pages->base());
+        $this->assertNull($this->pages->base());
     }
 
     public function testLastModified()
     {
-        $this->assertSame(null, $this->pages->lastModified());
+        $this->assertNull($this->pages->lastModified());
         $this->pages->lastModified('test');
         $this->assertSame('test', $this->pages->lastModified());
     }
 
     public function testInstances()
     {
-        $this->assertTrue(is_array($this->pages->instances()));
+        $this->assertInternalType('array', $this->pages->instances());
         foreach($this->pages->instances() as $instance) {
             $this->assertInstanceOf('Grav\Common\Page\Page', $instance);
         }
@@ -64,7 +64,7 @@ class PagesTest extends \Codeception\TestCase\Test
         /** @var UniformResourceLocator $locator */
         $locator = $this->grav['locator'];
 
-        $this->assertTrue(is_array($this->pages->routes()));
+        $this->assertInternalType('array', $this->pages->routes());
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/01.home', $this->pages->routes()['/']);
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/01.home', $this->pages->routes()['/home']);
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog', $this->pages->routes()['/blog']);
@@ -84,7 +84,7 @@ class PagesTest extends \Codeception\TestCase\Test
 
         $this->pages->addPage($aPage, '/new-page');
 
-        $this->assertTrue(in_array('/new-page', array_keys($this->pages->routes())));
+        $this->assertContains('/new-page', array_keys($this->pages->routes()));
         $this->assertSame($locator->findResource('tests://') . '/fake/single-pages/01.simple-page', $this->pages->routes()['/new-page']);
     }
 
@@ -96,28 +96,28 @@ class PagesTest extends \Codeception\TestCase\Test
         $aPage = $this->pages->dispatch('/blog');
         $subPagesSorted = $this->pages->sort($aPage);
 
-        $this->assertTrue(is_array($subPagesSorted));
-        $this->assertTrue(count($subPagesSorted) === 2);
+        $this->assertInternalType('array', $subPagesSorted);
+        $this->assertCount(2, $subPagesSorted);
 
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)[0]);
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)[1]);
 
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)));
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted));
 
         $this->assertSame(["slug" => "post-one"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one']);
         $this->assertSame(["slug" => "post-two"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two']);
 
         $subPagesSorted = $this->pages->sort($aPage, null, 'desc');
 
-        $this->assertTrue(is_array($subPagesSorted));
-        $this->assertTrue(count($subPagesSorted) === 2);
+        $this->assertInternalType('array', $subPagesSorted);
+        $this->assertCount(2, $subPagesSorted);
 
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)[0]);
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)[1]);
 
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)));
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted));
 
         $this->assertSame(["slug" => "post-one"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one']);
         $this->assertSame(["slug" => "post-two"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two']);
@@ -131,28 +131,28 @@ class PagesTest extends \Codeception\TestCase\Test
         $aPage = $this->pages->dispatch('/blog');
         $subPagesSorted = $this->pages->sortCollection($aPage->children(), $aPage->orderBy());
 
-        $this->assertTrue(is_array($subPagesSorted));
-        $this->assertTrue(count($subPagesSorted) === 2);
+        $this->assertInternalType('array', $subPagesSorted);
+        $this->assertCount(2, $subPagesSorted);
 
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)[0]);
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)[1]);
 
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)));
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted));
 
         $this->assertSame(["slug" => "post-one"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one']);
         $this->assertSame(["slug" => "post-two"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two']);
 
         $subPagesSorted = $this->pages->sortCollection($aPage->children(), $aPage->orderBy(), 'desc');
 
-        $this->assertTrue(is_array($subPagesSorted));
-        $this->assertTrue(count($subPagesSorted) === 2);
+        $this->assertInternalType('array', $subPagesSorted);
+        $this->assertCount(2, $subPagesSorted);
 
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)[0]);
         $this->assertSame($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)[1]);
 
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted)));
-        $this->assertTrue(in_array($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted)));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one', array_keys($subPagesSorted));
+        $this->assertContains($locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two', array_keys($subPagesSorted));
 
         $this->assertSame(["slug" => "post-one"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-one']);
         $this->assertSame(["slug" => "post-two"], $subPagesSorted[$locator->findResource('tests://') . '/fake/simple-site/user/pages/02.blog/post-two']);
@@ -165,12 +165,12 @@ class PagesTest extends \Codeception\TestCase\Test
 
         //Page existing
         $aPage = $this->pages->get($locator->findResource('tests://') . '/fake/simple-site/user/pages/03.about');
-        $this->assertTrue(is_object($aPage));
+        $this->assertInternalType('object', $aPage);
         $this->assertInstanceOf('Grav\Common\Page\Page', $aPage);
 
         //Page not existing
         $anotherPage = $this->pages->get($locator->findResource('tests://') . '/fake/simple-site/user/pages/03.non-existing');
-        $this->assertFalse(is_object($anotherPage));
+        $this->assertNotInternalType('object', $anotherPage);
         $this->assertNull($anotherPage);
     }
 
@@ -218,8 +218,8 @@ class PagesTest extends \Codeception\TestCase\Test
 
     public function testAll()
     {
-        $this->assertTrue(is_object($this->pages->all()));
-        $this->assertTrue(is_array($this->pages->all()->toArray()));
+        $this->assertInternalType('object', $this->pages->all());
+        $this->assertInternalType('array', $this->pages->all()->toArray());
         foreach($this->pages->all() as $page) {
             $this->assertInstanceOf('Grav\Common\Page\Page', $page);
         }
@@ -228,7 +228,7 @@ class PagesTest extends \Codeception\TestCase\Test
     public function testGetList()
     {
         $list = $this->pages->getList();
-        $this->assertTrue(is_array($list));
+        $this->assertInternalType('array', $list);
         $this->assertSame('&mdash;-&rtrif; Home', $list['/']);
         $this->assertSame('&mdash;-&rtrif; Blog', $list['/blog']);
     }

--- a/tests/unit/Grav/Common/UriTest.php
+++ b/tests/unit/Grav/Common/UriTest.php
@@ -900,23 +900,23 @@ class UriTest extends \Codeception\TestCase\Test
                 foreach ($queryParams as $key => $value) {
                     $this->assertSame($value, $this->uri->{$method}($key), "Test \$url->{$method}('{$key}') for {$url}");
                 }
-                $this->assertSame(null, $this->uri->{$method}('non-existing'), "Test \$url->{$method}('non-existing') for {$url}");
+                $this->assertNull($this->uri->{$method}('non-existing'), "Test \$url->{$method}('non-existing') for {$url}");
             }
         }
     }
 
     public function testValidatingHostname()
     {
-        $this->assertSame(true, $this->uri->validateHostname('localhost'));
-        $this->assertSame(true, $this->uri->validateHostname('google.com'));
-        $this->assertSame(true, $this->uri->validateHostname('google.it'));
-        $this->assertSame(true, $this->uri->validateHostname('goog.le'));
-        $this->assertSame(true, $this->uri->validateHostname('goog.wine'));
-        $this->assertSame(true, $this->uri->validateHostname('goog.localhost'));
+        $this->assertTrue($this->uri->validateHostname('localhost'));
+        $this->assertTrue($this->uri->validateHostname('google.com'));
+        $this->assertTrue($this->uri->validateHostname('google.it'));
+        $this->assertTrue($this->uri->validateHostname('goog.le'));
+        $this->assertTrue($this->uri->validateHostname('goog.wine'));
+        $this->assertTrue($this->uri->validateHostname('goog.localhost'));
 
-        $this->assertSame(false, $this->uri->validateHostname('localhost:80') );
-        $this->assertSame(false, $this->uri->validateHostname('http://localhost'));
-        $this->assertSame(false, $this->uri->validateHostname('localhost!'));
+        $this->assertFalse($this->uri->validateHostname('localhost:80') );
+        $this->assertFalse($this->uri->validateHostname('http://localhost'));
+        $this->assertFalse($this->uri->validateHostname('localhost!'));
     }
 
     public function testToString()
@@ -999,23 +999,23 @@ class UriTest extends \Codeception\TestCase\Test
         $this->assertSame('/ueper:xxx++', $this->uri->params('ueper'));
         $this->assertSame('/test:yyy', $this->uri->params('test'));
         $this->uri->initializeWithURL('http://localhost:8080/grav/it/ueper?test=x')->init();
-        $this->assertSame(null, $this->uri->params());
-        $this->assertSame(null, $this->uri->params('ueper'));
+        $this->assertNull($this->uri->params());
+        $this->assertNull($this->uri->params('ueper'));
         $this->uri->initializeWithURL('http://localhost:8080/grav/it/ueper?test=x&test2=y')->init();
-        $this->assertSame(null, $this->uri->params());
-        $this->assertSame(null, $this->uri->params('ueper'));
+        $this->assertNull($this->uri->params());
+        $this->assertNull($this->uri->params('ueper'));
         $this->uri->initializeWithURL('http://localhost:8080/grav/it/ueper?test=x&test2=y&test3=x&test4=y')->init();
-        $this->assertSame(null, $this->uri->params());
-        $this->assertSame(null, $this->uri->params('ueper'));
+        $this->assertNull($this->uri->params());
+        $this->assertNull($this->uri->params('ueper'));
         $this->uri->initializeWithURL('http://localhost:8080/grav/it/ueper?test=x&test2=y&test3=x&test4=y/test')->init();
-        $this->assertSame(null, $this->uri->params());
-        $this->assertSame(null, $this->uri->params('ueper'));
+        $this->assertNull($this->uri->params());
+        $this->assertNull($this->uri->params('ueper'));
         $this->uri->initializeWithURL('http://localhost:8080/a/b/c/d')->init();
-        $this->assertSame(null, $this->uri->params());
-        $this->assertSame(null, $this->uri->params('ueper'));
+        $this->assertNull($this->uri->params());
+        $this->assertNull($this->uri->params('ueper'));
         $this->uri->initializeWithURL('http://localhost:8080/a/b/c/d/e/f/a/b/c/d/e/f/a/b/c/d/e/f')->init();
-        $this->assertSame(null, $this->uri->params());
-        $this->assertSame(null, $this->uri->params('ueper'));
+        $this->assertNull($this->uri->params());
+        $this->assertNull($this->uri->params('ueper'));
     }
 
     public function testParam()

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -90,13 +90,13 @@ class UtilsTest extends \Codeception\TestCase\Test
     public function testDateFormats()
     {
         $dateFormats = Utils::dateFormats();
-        $this->assertTrue(is_array($dateFormats));
+        $this->assertInternalType('array', $dateFormats);
         $this->assertContainsOnly('string', $dateFormats);
 
         $default_format = $this->grav['config']->get('system.pages.dateformat.default');
 
         if ($default_format !== null) {
-            $this->assertTrue(isset($dateFormats[$default_format]));
+            $this->assertArrayHasKey($default_format, $dateFormats);
         }
     }
 
@@ -208,7 +208,7 @@ class UtilsTest extends \Codeception\TestCase\Test
     {
         $timezones = Utils::timezones();
 
-        $this->assertTrue(is_array($timezones));
+        $this->assertInternalType('array', $timezones);
         $this->assertContainsOnly('string', $timezones);
     }
 
@@ -224,8 +224,8 @@ class UtilsTest extends \Codeception\TestCase\Test
         });
 
         $this->assertContainsOnly('string', $array);
-        $this->assertFalse(isset($array['test']));
-        $this->assertTrue(isset($array['test2']));
+        $this->assertArrayNotHasKey('test', $array);
+        $this->assertArrayHasKey('test2', $array);
         $this->assertEquals('test2', $array['test2']);
     }
 
@@ -320,8 +320,8 @@ class UtilsTest extends \Codeception\TestCase\Test
 
     public function testGetNonce()
     {
-        $this->assertTrue(is_string(Utils::getNonce('test-action')));
-        $this->assertTrue(is_string(Utils::getNonce('test-action', true)));
+        $this->assertInternalType('string', Utils::getNonce('test-action'));
+        $this->assertInternalType('string', Utils::getNonce('test-action', true));
         $this->assertSame(Utils::getNonce('test-action'), Utils::getNonce('test-action'));
         $this->assertNotSame(Utils::getNonce('test-action'), Utils::getNonce('test-action2'));
     }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType` and `assertNotInternalType` instead of `is_*` functions;
- `assertContains` instead of `in_array` function;
- `assertGreaterThan` for mathematical comparisons;
- `assertNull` and `assertNotNull` instead of strict comparison with `null` keyword;
- `assertTrue` instead of strict comparison with `true` keyword;
- `assertFalse` instead of strict comparison with `false` keyword;
- `assertArrayHasKey` instead of `isset` function;
- `assertSame` instead of comparisons `==` and strict comparisons `===`.