### PR TITLE
add Utils::htmlGermanCharacter

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -688,6 +688,8 @@ class Page
 
         }
 
+        // htmlGermanCharacter
+        $this->content = Utils::htmlGermanCharacter($this->content);
         return $this->content;
     }
 

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -1029,4 +1029,27 @@ abstract class Utils
 
         return $parts;
     }
+
+    /**
+    * Replace german characters
+    *
+    * @param $subject
+    * @return string with replaced german char
+    */
+    public static function htmlGermanCharacter($subject)
+    {
+        $replace = array(
+            'Ä' => '&Auml;',
+            'ä' => '&auml;',
+            'Ö' => '&Ouml;',
+            'ö' => '&ouml;',
+            'Ü' => '&Uuml;',
+            'ü' => '&uuml;',
+            'ß' => '&szlig;',
+            '»' => '&raquo;',
+            '«' => '&laquo;',
+            '€' => '&euro;'
+        );
+        return str_replace(array_keys($replace), array_values($replace), $subject);
+    }
 }


### PR DESCRIPTION
Add an small function to replace german characters to the corresponding html entities.
Maybe this will be useful for others.

(My md-files contains a lot of german chars :-))

>  Grüße aus Köln :-)