### PR TITLE
Make 'Default Language' a consistent width

### DIFF
--- a/system/blueprints/config/site.yaml
+++ b/system/blueprints/config/site.yaml
@@ -19,7 +19,7 @@ form:
                 default_lang:
                     type: text
                     label: PLUGIN_ADMIN.SITE_DEFAULT_LANG
-                    size: x-small
+                    size: large
                     placeholder: PLUGIN_ADMIN.SITE_DEFAULT_LANG_PLACEHOLDER
                     help: PLUGIN_ADMIN.SITE_DEFAULT_LANG_HELP
 


### PR DESCRIPTION
Make 'Default Language' the same width as the other inputs.

Before:
<img width="777" alt="before" src="https://user-images.githubusercontent.com/819940/34794318-4899c8f4-f61c-11e7-936b-94d82e62b4a0.png">

After:
<img width="771" alt="after" src="https://user-images.githubusercontent.com/819940/34794317-48802534-f61c-11e7-9180-79dd2dbfabc4.png">


