### PR TITLE
Taxonomy Filtering - space characters

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2486,7 +2486,7 @@ class Page
 
         if ($process_taxonomy) {
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
-                if ($uri->param($taxonomy)) {
+                if ($uri->param(rawurlencode($taxonomy))) {
                     $items = explode(',', $uri->param($taxonomy));
                     $collection->setParams(['taxonomies' => [$taxonomy => $items]]);
 


### PR DESCRIPTION
Taxonomies with spaces were not recognized because they are encoded in the uri, but the taxonomy collection was not encoded.  So, they never matched.  It seems like a simple rawurlencode of the taxonomy string should allow them to be found.
