### PR TITLE
Feature/taxonomy filtering spaces

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2487,7 +2487,7 @@ class Page
         if ($process_taxonomy) {
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
                 if ($uri->param(rawurlencode($taxonomy))) {
-                    $items = explode(',', $uri->param($taxonomy));
+                    $items = explode(',', $uri->param(rawurlencode($taxonomy)));
                     $collection->setParams(['taxonomies' => [$taxonomy => $items]]);
 
                     foreach ($collection as $page) {

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2486,7 +2486,7 @@ class Page
 
         if ($process_taxonomy) {
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
-                if ($uri->param($taxonomy)) {
+                if ($uri->param(rawurlencode($taxonomy))) {
                     $items = explode(',', $uri->param($taxonomy));
                     $collection->setParams(['taxonomies' => [$taxonomy => $items]]);
 

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -123,8 +123,8 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('vardump', [$this, 'vardumpFunc']),
             new \Twig_SimpleFunction('print_r', 'print_r'),
             new \Twig_SimpleFunction('http_response_code', 'http_response_code'),
-            new \Twig_SimpleFunction('evaluate', [$this, 'evaluateStringFunc'], ['needs_context' => true, 'needs_environment' => true]),
-            new \Twig_SimpleFunction('evaluate_twig', [$this, 'evaluateTwigFunc'], ['needs_context' => true, 'needs_environment' => true]),
+            new \Twig_SimpleFunction('evaluate', [$this, 'evaluateStringFunc'], ['needs_context' => true]),
+            new \Twig_SimpleFunction('evaluate_twig', [$this, 'evaluateTwigFunc'], ['needs_context' => true]),
             new \Twig_SimpleFunction('gist', [$this, 'gistFunc']),
             new \Twig_SimpleFunction('nonce_field', [$this, 'nonceFieldFunc']),
             new \Twig_SimpleFunction('pathinfo', 'pathinfo'),
@@ -703,47 +703,32 @@ class TwigExtension extends \Twig_Extension
     /**
      * This function will evaluate Twig $twig through the $environment, and return its results.
      *
-     * @param \Twig_Environment $environment
      * @param array $context
      * @param string $twig
      * @return mixed
      */
-    public function evaluateTwigFunc( \Twig_Environment $environment, $context, $twig ) {
-        $loader = $environment->getLoader( );
+    public function evaluateTwigFunc($context, $twig ) {
 
-        $parsed = $this->parseString( $environment, $context, $twig );
+        $loader = new \Twig_Loader_Filesystem('.');
+        $env = new \Twig_Environment($loader);
 
-        $environment->setLoader( $loader );
-        return $parsed;
+        $template = $env->createTemplate($twig);
+        return $template->render($context);
+;
     }
 
     /**
      * This function will evaluate a $string through the $environment, and return its results.
      *
-     * @param \Twig_Environment $environment
      * @param $context
      * @param $string
      * @return mixed
      */
-    public function evaluateStringFunc(\Twig_Environment $environment, $context, $string )
+    public function evaluateStringFunc($context, $string )
     {
-        $parsed = $this->evaluateTwigFunc($environment, $context, "{{ $string }}");
+        $parsed = $this->evaluateTwigFunc($context, "{{ $string }}");
         return $parsed;
     }
-
-    /**
-     * Sets the parser for the environment to Twig_Loader_String, and parsed the string $string.
-     *
-     * @param \Twig_Environment $environment
-     * @param array $context
-     * @param string $string
-     * @return string
-     */
-    protected function parseString( \Twig_Environment $environment, $context, $string ) {
-        $environment->setLoader( new \Twig_Loader_String( ) );
-        return $environment->render( $string, $context );
-    }
-
 
 
     /**


### PR DESCRIPTION
Sorry, there was one additional change that is necessary for the spaces to work in the taxonomy filtering.  I had tested, but forgot to clear the cache, so I saw an item filtered that wasn't actually valid.  Once I continued working and refreshed again, all items disappeared...  As you can see with the small change below, the rawurlencode is also needed in the following $uri->param call.