### PR TITLE
Add overriding of setup.php config file, via constants

### DIFF
--- a/system/src/Grav/Common/Config/Setup.php
+++ b/system/src/Grav/Common/Config/Setup.php
@@ -137,7 +137,8 @@ class Setup extends Data
 
         // Pre-load setup.php which contains our initial configuration.
         // Configuration may contain dynamic parts, which is why we need to always load it.
-        $file = GRAV_ROOT . '/setup.php';
+        // If "GRAVE_SETUP_PATH" has been defined, use it, otherwise use defaults.
+        $file = defined('GRAV_SETUP_PATH') ? GRAV_SETUP_PATH :  GRAV_ROOT . '/setup.php';
         $setup = is_file($file) ? (array) include $file : [];
 
         // Add default streams defined in beginning of the class.


### PR DESCRIPTION
I'm working on a custom install of Grav, where being able to dynamically swap setup files was required. I've modified the $file assignment to permit overriding it's value via a defined constant, "GRAV_SETUP_PATH".

And I thought that might be useful to others, so I'm submitting a pull request.