### PR TITLE
gpm selfupgrade: unzip error fix ...

### DIFF
--- a/system/src/Grav/Common/GPM/Installer.php
+++ b/system/src/Grav/Common/GPM/Installer.php
@@ -219,7 +219,7 @@ class Installer
                 break;
 
             case \ZipArchive::ER_NOZIP:
-                $error = "Not a zip archive.";
+                $error = "Not a zip archive. (Download failed or incomplete?)";
                 break;
 
             case \ZipArchive::ER_OPEN:

--- a/system/src/Grav/Console/Gpm/SelfupgradeCommand.php
+++ b/system/src/Grav/Console/Gpm/SelfupgradeCommand.php
@@ -220,7 +220,7 @@ class SelfupgradeCommand extends ConsoleCommand
         $errorCode = Installer::lastErrorCode();
         Folder::delete($this->tmp);
 
-        if ($errorCode & (Installer::ZIP_OPEN_ERROR | Installer::ZIP_EXTRACT_ERROR)) {
+      if ($errorCode) {
             $this->output->write("\x0D");
             // extra white spaces to clear out the buffer properly
             $this->output->writeln("  |- Installing upgrade...    <red>error</red>                             ");


### PR DESCRIPTION
**Error**:

The zip error handling was broken, it caused the commandline installer to show an upgrade success if the extraction fails.

**Changes:**

That the getZipError function returns strings & integers wasn't the problem. The bitwise operators in the `SelfupgradeCommand.php` where causing the condition to fail, where it should be true. So removed the bitwise operators from the condition.

And: Added a hint, what could be causing the "Not a zip archive."-Error.

**Questions:**

Why using bitwise operators at all? Isn't that bad coding style? I don't even understand what it exactly does. Can someone explain the reasoning behind this for me, would like to understand this. Thanks!