### PR TITLE
Add getter methods for original and action to the Page object.

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2955,4 +2955,26 @@ class Page
             return $route;
         }
     }
+
+    /**
+     * Gets the Page Unmodified (original) version of the page.
+     *
+     * @return Page
+     *   The original version of the page.
+     */
+    public function getOriginal()
+    {
+      return $this->_original;
+    }
+
+    /**
+     * Gets the action.
+     *
+     * @return string
+     *   The Action string.
+     */
+    public function getAction()
+    {
+      return $this->_action;
+    }
 }


### PR DESCRIPTION
First of all, I am pretty new to grav and I'm pretty exited working with it. I come from the Drupal world and I love Grav because it's so similar it its concepts but still lightweight and way better to work with for smaller sites.

So pls give me a hint if I don't do this right here, it's my first contribution!

I started building a Plugin for automatic redirects when changing the folder's name in order to keep SEO ranking. To do that, I need to compare the original version with the current one when Saving a Page. Additionally I found it useful to check for the move action at this point, this way I don't need to compare the objects to see if something changes.

However, the _original property is private and cannot be accessed onAdminSave event. 