### PR TITLE
Handle multibyte strings in Truncator (truncateLetters method)

### DIFF
--- a/system/src/Grav/Common/Helpers/Truncator.php
+++ b/system/src/Grav/Common/Helpers/Truncator.php
@@ -104,7 +104,7 @@ class Truncator {
             if ($letters->key() >= $limit) {
 
                 $currentText = $letters->currentTextPosition();
-                $currentText[0]->nodeValue = substr($currentText[0]->nodeValue, 0, $currentText[1] + 1);
+                $currentText[0]->nodeValue = mb_substr($currentText[0]->nodeValue, 0, $currentText[1] + 1);
                 self::removeProceedingNodes($currentText[0], $body);
 
                 if (!empty($ellipsis)) {


### PR DESCRIPTION
truncateLetters now takes into account multibyte strings.

truncateWords doesn't seem to be affected : it correctly determines where word ends, taking utf-8 encoding into account.

Found 2 issues related : https://github.com/getgrav/grav/issues/1365 (closed) and https://github.com/getgrav/grav/issues/1737 (open).