### PR TITLE
Do not crash when generating URLs with arrays as parameters

### DIFF
--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -536,7 +536,12 @@ class Medium extends Data implements RenderableInterface
     {
         $qs = $method;
         if (count($args) > 1 || (count($args) == 1 && !empty($args[0]))) {
-            $qs .= '=' . implode(',', array_map(function ($a) { return rawurlencode($a); }, $args));
+            $qs .= '=' . implode(',', array_map(function ($a) {
+                if (is_array($a)) {
+                    $a = '[' . implode(',', $a) . ']';
+                }
+                return rawurlencode($a);
+            }, $args));
         }
 
         if (!empty($qs)) {


### PR DESCRIPTION
When using a default image derivatives (#1979) setting like

    images:
      defaults:
        derivatives: [300,600]

then Grav crashes when a video gets embedded.
The following error occurs:

    rawurlencode() expects parameter 1 to be string, array given
    system/src/Grav/Common/Page/Medium/Medium.php:521

This patch encodes array URL parameters correctly.