### PR TITLE
Use @example.com in default email addresses.

### DIFF
--- a/system/config/site.yaml
+++ b/system/config/site.yaml
@@ -3,7 +3,7 @@ default_lang: en                            # Default language for site (potenti
 
 author:
   name: John Appleseed                      # Default author name
-  email: 'john@email.com'                   # Default author email
+  email: 'john@example.com'                 # Default author email
 
 taxonomies: [category,tag]                  # Arbitrary list of taxonomy types
 

--- a/user/config/site.yaml
+++ b/user/config/site.yaml
@@ -1,7 +1,7 @@
 title: Grav
 author:
   name: Joe Bloggs
-  email: 'joe@test.com'
+  email: 'joe@example.com'
 metadata:
     description: 'Grav is an easy to use, yet powerful, open source flat-file CMS'
 


### PR DESCRIPTION
It could be a bad idea to use default email addresses that could really
exist. Instead, use example.com, which RFC2606 defines as one of the
domains reserved for examples.