### PR TITLE
pointing fastcgi_pass path to match php7.0-fpm (on debian stretch)

### DIFF
--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -30,7 +30,8 @@ server {
     ## Begin - PHP
     location ~ \.php$ {
         # Choose either a socket or TCP/IP address
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        # fastcgi_pass unix:/var/run/php5-fpm.sock; #legacy
         # fastcgi_pass 127.0.0.1:9000;
 
         fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
nginx config offered in /webserver-configs does not work in recent distros. I have changed it to match the path of php7-fpm in Debian Stretch.