### PR TITLE
Add cookie domain configuration under system.session

### DIFF
--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -138,6 +138,7 @@ session:
   secure: false                                  # Set session secure. If true, indicates that communication for this cookie must be over an encrypted transmission. Enable this only on sites that run exclusively on HTTPS
   httponly: true                                 # Set session HTTP only. If true, indicates that cookies should be used only over HTTP, and JavaScript modification is not allowed.
   split: true                                    # Sessions should be independent between site and plugins (such as admin)
+  domain: ''                                     # The domain used in the cookie.
   path:
 
 gpm:

--- a/system/src/Grav/Common/Service/SessionServiceProvider.php
+++ b/system/src/Grav/Common/Service/SessionServiceProvider.php
@@ -35,11 +35,9 @@ class SessionServiceProvider implements ServiceProviderInterface
             if (null === $session_path) {
                 $session_path = '/' . ltrim(Uri::filterPath($uri->rootUrl(false)), '/');
             }
-            $domain = $uri->host();
-            if ($domain === 'localhost') {
-                $domain = '';
-            }
 
+            $domain = $config->get('system.session.domain', '');
+            
             // Get session options.
             $secure = (bool)$config->get('system.session.secure', false);
             $httponly = (bool)$config->get('system.session.httponly', true);


### PR DESCRIPTION
I have added a new config under "system.session" called "domain".

The current implementation is 

```php
$domain = $uri->host();
if ($domain === 'localhost') {
    $domain = '';
}
```

This is problematic under docker-compose because the hostname is the name of the container/service. In our case, it was forcing the cookie domain to be "domain=grav-site;".

Basically, under docker, the only way to make it work would be to use "localhost", but that would break a lot of stuff. 

This setting allows override of the domain, and it shouldn't break existing applications. 