### PR TITLE
Update robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -9,3 +9,4 @@ Disallow: /vendor/
 Disallow: /user/
 Allow: /user/pages/
 Allow: /user/themes/
+Allow: /user/images/


### PR DESCRIPTION
When using "Fetch and Render as Google" in Google Search console it will report "partial" rendering due to the blocked images in /user/images directory which is blocked because of the Disallow /user/ rule. Proposing this small change as it improves google rendering of the page.