### PR TITLE
Modular template extension follows the master page extension

### DIFF
--- a/system/src/Grav/Common/Twig/Twig.php
+++ b/system/src/Grav/Common/Twig/Twig.php
@@ -238,7 +238,9 @@ class Twig
             // Process Modular Twig
             if ($item->modularTwig()) {
                 $twig_vars['content'] = $content;
-                $template = $item->template() . TEMPLATE_EXT;
+                $extension = $this->grav['uri']->extension();
+                $extension = $extension ? ".{$extension}.twig" : TEMPLATE_EXT;
+                $template = $item->template() . $extension;
                 $output = $content = $local_twig->render($template, $twig_vars);
             }
 


### PR DESCRIPTION
This PR is related to the issue #1818.
This builds the modular template extension from the URI's extension (i.e. `http://examp.le/my-page.amp` or `http://examp.le/other-page.docx`).
It fallbacks to `TEMPLATE_EXT` const if URI extension is `null` or empty.

---
 
For my project : 

I'm creating an [AMP](https://www.ampproject.org) version of my website in the same theme.

my custom `system.yaml`
```yaml
...
pages:
  ...
  types:
    - html
    - amp
  ...
```

So I have two template extensions : `.html.twig` for the regular pages and `.amp.twig` for the AMP pages.

I'm using the same content for the two versions.

If I create a modular page with the `.amp.twig`, Twig will load modular templates with the extension `.html.twig` (which will be wrong formated for AMP framework and not validated).