### PR TITLE
Fix image memory use

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -301,6 +301,7 @@ class ImageMedium extends Medium
                 $derivative->set('width', $width);
                 $derivative->set('height', $height);
 
+                $derivative->resetImage();
                 $this->addAlternative($ratio, $derivative);
             }
         }
@@ -557,6 +558,14 @@ class ImageMedium extends Medium
             ->setPrettyName($this->getImagePrettyName());
 
         return $this;
+    }
+    
+    /**
+     * Frees the cached image file.
+     */
+    protected function resetImage()
+    {
+        $this->image = null;
     }
 
     /**

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -301,6 +301,7 @@ class ImageMedium extends Medium
                 $derivative->set('width', $width);
                 $derivative->set('height', $height);
 
+                $derivative->saveImage();
                 $derivative->resetImage();
                 $this->addAlternative($ratio, $derivative);
             }
@@ -559,7 +560,7 @@ class ImageMedium extends Medium
 
         return $this;
     }
-    
+
     /**
      * Frees the cached image file.
      */
@@ -596,7 +597,9 @@ class ImageMedium extends Medium
             $this->image->merge(ImageFile::open($overlay));
         }
 
-        return $this->image->cacheFile($this->format, $this->quality);
+        $cachedPath = $this->image->cacheFile($this->format, $this->quality);
+        $this->set('filepath', $cachedPath);
+        return $cachedPath;
     }
 
     /**


### PR DESCRIPTION
Creating image derivatives currently keeps all the images in memory until the PHP interpreter is finished. With a substantial number of files or large images this can cause out of memory errors. I attempted to fix the issue by saving the image on disk immediately after the derivative has been created and then freeing it.

Processing large images still takes time. Ideally, multiple threads could be used to create the derivatives, if there is enough memory.

Please note that currently Gregwar\Image\Adapter\GD does not free the associated image resource on deallocation. I've created a [pull request](https://github.com/Gregwar/Image/pull/154) to fix this, too. (The checks don't pass because of a configuration error.)