### PR TITLE
Update Media.php

### DIFF
--- a/system/src/Grav/Common/Page/Media.php
+++ b/system/src/Grav/Common/Page/Media.php
@@ -86,7 +86,7 @@ class Media extends AbstractMedia
         /** @var \DirectoryIterator $info */
         foreach ($iterator as $path => $info) {
             // Ignore folders and Markdown files.
-            if (!$info->isFile() || $info->getExtension() === 'md' || $info->getBasename()[0] === '.') {
+            if (!$info->isFile() || $info->getExtension() === 'md' || $info->getFilename()[0] === '.') {
                 continue;
             }
 


### PR DESCRIPTION
Fixes getgrav/grav-plugin-admin#1330. Media with Unicode filenames are not detected because `SplFileInfo::getBasename` ignores names which don't match the locale. `SplFileInfo::getFilename` does the same thing as `SplFileInfo::getBasename` without this issue.