### PR TITLE
Change getBasename to getFilename where possible

### DIFF
--- a/system/src/Grav/Common/Config/ConfigFileFinder.php
+++ b/system/src/Grav/Common/Config/ConfigFileFinder.php
@@ -207,7 +207,7 @@ class ConfigFileFinder
                     continue;
                 }
 
-                $name = $directory->getBasename();
+                $name = $directory->getFilename();
                 $find = ($lookup ?: $name) . '.yaml';
                 $filename = "{$path}/{$name}/{$find}";
 

--- a/system/src/Grav/Common/GPM/Installer.php
+++ b/system/src/Grav/Common/GPM/Installer.php
@@ -296,17 +296,17 @@ class Installer
     {
         foreach (new \DirectoryIterator($source_path) as $file) {
 
-            if ($file->isLink() || $file->isDot() || in_array($file->getBasename(),$ignores)) {
+            if ($file->isLink() || $file->isDot() || in_array($file->getFilename(), $ignores)) {
                 continue;
             }
 
-            $path = $install_path . DS . $file->getBasename();
+            $path = $install_path . DS . $file->getFilename();
 
             if ($file->isDir()) {
                 Folder::delete($path);
                 Folder::move($file->getPathname(), $path);
 
-                if ($file->getBasename() == 'bin') {
+                if ($file->getFilename() === 'bin') {
                     foreach (glob($path . DS . '*') as $bin_file) {
                         @chmod($bin_file, 0755);
                     }

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -1041,7 +1041,7 @@ class Pages
             }
 
             // Ignore all files in ignore list.
-            if (\in_array($file->getBasename(), $this->ignore_files, true)) {
+            if (\in_array($filename, $this->ignore_files, true)) {
                 continue;
             }
 

--- a/system/src/Grav/Common/Plugins.php
+++ b/system/src/Grav/Common/Plugins.php
@@ -33,7 +33,7 @@ class Plugins extends Iterator
             if (!$directory->isDir()) {
                 continue;
             }
-            $plugins[] = $directory->getBasename();
+            $plugins[] = $directory->getFilename();
         }
 
         natsort($plugins);

--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -98,7 +98,7 @@ class Themes extends Iterator
                 continue;
             }
 
-            $theme = $directory->getBasename();
+            $theme = $directory->getFilename();
             $result = self::get($theme);
 
             if ($result) {


### PR DESCRIPTION
`SplFileInfo::getFilename` returns the same value as `SplFileInfo::getBasename` (no arguments) while being locale safe (See #2083). For situations where `SplFileInfo::getBasename` needs to accept an argument, I would suggest implementing a `basename` helper function ([Good Example](https://github.com/cakephp/cakephp/blob/659a25db6d8013d5e187aec5bcfea47cdafa418f/src/Filesystem/File.php#L355)).