### PR TITLE
Touch system.yaml to trigger cache update

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -490,6 +490,17 @@ form:
                         hash: All files timestamps
                         none: No timestamp checking
 
+                cache.autotouch:
+                    type: toggle
+                    label: PLUGIN_ADMIN.CACHE_AUTOTOUCH
+                    help: PLUGIN_ADMIN.CACHE_AUTOTOUCH_HELP
+                    highlight: 1
+                    options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                    validate:
+                        type: bool
+
                 cache.driver:
                     type: select
                     size: small

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -75,6 +75,7 @@ cache:
   check:
     method: file                                 # Method to check for updates in pages: file|folder|hash|none
   driver: auto                                   # One of: auto|file|apc|xcache|memcache|wincache
+  autotouch: false                               # Touch system.yaml triggering a cache refresh without file system impact in the case of volatile caches, e.g. memcached or apcu  
   prefix: 'g'                                    # Cache prefix string (prevents cache conflicts)
   clear_images_by_default: true                  # By default grav will include processed images in cache clear, this can be disabled
   cli_compatibility: false                       # Ensures only non-volatile drivers are used (file, redis, memcache, etc.)

--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -47,6 +47,8 @@ class Cache extends Getters
 
     protected $driver_setting;
 
+    protected $disable_auto_touch;
+    
     /**
      * @var bool
      */
@@ -138,6 +140,8 @@ class Cache extends Getters
 
         // Set the cache namespace to our unique key
         $this->driver->setNamespace($this->key);
+        
+        $this->disable_auto_touch = false;        
     }
 
     /**
@@ -446,6 +450,18 @@ class Cache extends Getters
     }
 
     /**
+     * Helper that allows to disable autotouch for bulk changes
+     * Once all changes have been done code implementations can
+     * call autotouch()
+     * 
+     * 
+     */
+    public function disableAutotouch()
+    {
+        $this->disable_auto_touch = true;
+    }
+    
+    /**
      * Helper that allows to re-fill caches when cache.method is set to none for speed
      * and volatile caches like memcached or apcu are used
      * 
@@ -453,7 +469,8 @@ class Cache extends Getters
     public function autotouch()
     {
         $user_config = USER_DIR . 'config/system.yaml';
-        if (Grav::instance()['config']->get('system.cache.enabled')
+        if (!$this->disable_auto_touch 
+            && Grav::instance()['config']->get('system.cache.enabled')
             && file_exists($user_config)
             && in_array(strtolower(Grav::instance()['config']->get('system.cache.check.method', 'file')), ['none', 'off'])
             && Grav::instance()['config']->get('system.cache.autotouch')) {    

--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -373,6 +373,9 @@ class Cache extends Getters
             case 'tmp-only':
                 $remove_paths = self::$tmp_remove;
                 break;
+            case 'touch-only':
+                $remove_paths = [];
+                break;                            
             default:
                 if (Grav::instance()['config']->get('system.cache.clear_images_by_default')) {
                     $remove_paths = self::$standard_remove;
@@ -422,19 +425,21 @@ class Cache extends Getters
 
         $output[] = '';
 
-        if (($remove == 'all' || $remove == 'standard') && file_exists($user_config)) {
+        if (($remove == 'all' || $remove == 'standard' || $remove == 'touch-only') && file_exists($user_config)) {
             touch($user_config);
 
             $output[] = '<red>Touched: </red>' . $user_config;
             $output[] = '';
-        }
+        }        
+        
+        if ($remove != 'touch-only') {
+            // Clear stat cache
+            @clearstatcache();
 
-        // Clear stat cache
-        @clearstatcache();
-
-        // Clear opcache
-        if (function_exists('opcache_reset')) {
-            @opcache_reset();
+            // Clear opcache
+            if (function_exists('opcache_reset')) {
+                @opcache_reset();
+            }
         }
 
         return $output;

--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -359,7 +359,8 @@ class Cache extends Getters
     {
         $locator = Grav::instance()['locator'];
         $output = [];
-        $user_config = USER_DIR . 'config/system.yaml';
+        //$user_config = USER_DIR . 'config/system.yaml';
+        $user_config = Grav::instance()['locator']->findResource('config://system.yaml');        
 
         switch ($remove) {
             case 'all':
@@ -463,18 +464,20 @@ class Cache extends Getters
     
     /**
      * Helper that allows to re-fill caches when cache.method is set to none for speed
-     * and volatile caches like memcached or apcu are used
+     * and volatile caches like memcached or apcu are used but works with file cache 
+     * as well
      * 
      */
     public function autotouch()
     {
-        $user_config = USER_DIR . 'config/system.yaml';
+        // Should find a valid system.yaml for the current instance
+        // I change this in clearCache as well
+        $user_config = Grav::instance()['locator']->findResource('config://system.yaml');        
         if (!$this->disable_auto_touch 
             && Grav::instance()['config']->get('system.cache.enabled')
             && file_exists($user_config)
             && in_array(strtolower(Grav::instance()['config']->get('system.cache.check.method', 'file')), ['none', 'off'])
             && Grav::instance()['config']->get('system.cache.autotouch')) {    
-                //if ($this->isVolatileDriver($this->driver_name)) {
                 touch($user_config);            
         }        
     }

--- a/system/src/Grav/Common/Cache.php
+++ b/system/src/Grav/Common/Cache.php
@@ -445,6 +445,22 @@ class Cache extends Getters
         return $output;
     }
 
+    /**
+     * Helper that allows to re-fill caches when cache.method is set to none for speed
+     * and volatile caches like memcached or apcu are used
+     * 
+     */
+    public function autotouch()
+    {
+        $user_config = USER_DIR . 'config/system.yaml';
+        if (Grav::instance()['config']->get('system.cache.enabled')
+            && file_exists($user_config)
+            && in_array(strtolower(Grav::instance()['config']->get('system.cache.check.method', 'file')), ['none', 'off'])
+            && Grav::instance()['config']->get('system.cache.autotouch')) {    
+                //if ($this->isVolatileDriver($this->driver_name)) {
+                touch($user_config);            
+        }        
+    }
 
     /**
      * Set the cache lifetime programmatically

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -950,6 +950,8 @@ class Page
         }
 
         $this->_original = null;
+        $cache = Grav::instance()['cache'];
+        $cache->autotouch();        
     }
 
     /**


### PR DESCRIPTION
This is related with issue #2093.

Background for this PR:
A site that is configured to use cache but disallowing detection of changes to obtain the maximum speed, faces some drawbacks:

* if using and working with admin plugin changing content implies clearing the caches manually
* if a site implements automated updates, e.g. within a store implementation handling the update of stocks, this won't show up till the next manual cache clearance
* if the site uses a volatile memory cache, e.g. memcached or apcu, a selective or partial cache update won't clear the volatile cache

Solution:
This pull request proposal tries to solve these problems adding

* a configuration option to the system configuration called autotouch
* adds a call to the new autotouch function in the cache class inside of the page class in the save function
* adds a parameter option to the clearCache method which allows to add the new "touch-only" option in the admin plugin interface or to call this in code

Update:
To allow better support for bulk updates and to avoid touching system.yaml with every save / change plugins and other code implementations can now emit a ``$this->grav['cache']->disableAutotouch();`` before starting with bulk operations and once finalized they can add two lines of code to trigger the behavior:

```
        $user_config = USER_DIR . 'config/system.yaml';
        touch($user_config);
```
(that's better and failsave this way as we don't need an additional function to activate autotouch again. As this is developers only, probably the best way to fix this all...)

P.S.: And optimized as a 4-liner:

```
$user_config = USER_DIR . 'config/system.yaml';
if (file_exists($user_config)) {
    touch($user_config);
}
```
