### PR TITLE
Add Grav version to PHPdebugbar

### DIFF
--- a/system/src/Grav/Common/Debugger.php
+++ b/system/src/Grav/Common/Debugger.php
@@ -60,6 +60,7 @@ class Debugger
         if ($this->enabled()) {
             $this->debugbar->addCollector(new ConfigCollector((array)$this->config->get('system'), 'Config'));
             $this->debugbar->addCollector(new ConfigCollector((array)$this->config->get('plugins'), 'Plugins'));
+            $this->addMessage('Grav v' . GRAV_VERSION);
         }
 
         return $this;


### PR DESCRIPTION
Adds "Grav vx.y.z" as first line info to Messages tab on debug bar.

Second crack at passing PR, first was https://github.com/getgrav/grav/pull/2103