### PR TITLE
Add muted and playsinline attributes

### DIFF
--- a/system/src/Grav/Common/Page/Medium/VideoMedium.php
+++ b/system/src/Grav/Common/Page/Medium/VideoMedium.php
@@ -95,6 +95,40 @@ class VideoMedium extends Medium
     }
 
     /**
+     * Allows to set the playsinline attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function playsinline($status = false)
+    {
+        if($status) {
+            $this->attributes['playsinline'] = true;
+        } else {
+            unset($this->attributes['playsinline']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Allows to set the muted attribute
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function muted($status = false)
+    {
+        if($status) {
+            $this->attributes['muted'] = true;
+        } else {
+            unset($this->attributes['muted']);
+        }
+
+        return $this;
+    }
+
+    /**
      * Reset medium.
      *
      * @return $this


### PR DESCRIPTION
Fixes: #2099

To be able to add videos that behave as GIFs, two attributes are needed for the videos to be properly handled on iOS and in Chrome: muted and playsinline.

Muted
Chrome only allows videos to autoplay when the contain the muted attribute. Non-muted videos will not autoplay unless the user has interacted with the site. More details here:  https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#new-behaviors

Playsinline
The playsinline attribute allows developers to specify videos on iPhone should play inline and not automatically enter fullscreen mode when playback begins. More details here: https://webkit.org/blog/6784/new-video-policies-for-ios/