### PR TITLE
Allow capitalized usernames if the regex agrees

### DIFF
--- a/system/src/Grav/Common/User/User.php
+++ b/system/src/Grav/Common/User/User.php
@@ -33,6 +33,9 @@ class User extends Data
         /** @var UniformResourceLocator $locator */
         $locator = $grav['locator'];
 
+        // force lowercase of username
+        $username = mb_strtolower($username);
+
         $blueprints = new Blueprints;
         $blueprint = $blueprints->get('user/account');
 
@@ -189,10 +192,8 @@ class User extends Data
         if ($file) {
             $username = $this->get('username');
 
-            if (!$file->filename()) {
-                $locator = Grav::instance()['locator'];
-                $file->filename($locator->findResource('account://') . DS . $username . YAML_EXT);
-            }
+            $locator = Grav::instance()['locator'];
+            $file->filename($locator->findResource('account://') . DS . mb_strtolower($username) . YAML_EXT);
 
             // if plain text password, hash it and remove plain text
             if ($this->password) {
@@ -200,7 +201,9 @@ class User extends Data
                 unset($this->password);
             }
 
-            unset($this->username);
+            if ($username == mb_strtolower($username)) {
+                unset($this->username);
+            }
             $file->save($this->items);
             $this->set('username', $username);
         }

--- a/system/src/Grav/Common/User/User.php
+++ b/system/src/Grav/Common/User/User.php
@@ -33,9 +33,6 @@ class User extends Data
         /** @var UniformResourceLocator $locator */
         $locator = $grav['locator'];
 
-        // force lowercase of username
-        $username = strtolower($username);
-
         $blueprints = new Blueprints;
         $blueprint = $blueprints->get('user/account');
 
@@ -194,7 +191,7 @@ class User extends Data
 
             if (!$file->filename()) {
                 $locator = Grav::instance()['locator'];
-                $file->filename($locator->findResource('account://') . DS . strtolower($username) . YAML_EXT);
+                $file->filename($locator->findResource('account://') . DS . $username . YAML_EXT);
             }
 
             // if plain text password, hash it and remove plain text

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -732,8 +732,8 @@ abstract class Utils
         $token = session_id();
         $i = self::nonceTick();
 
-        if ($plusOneTick) {
-            $i++;
+        if ($previousTick) {
+            $i--;
         }
 
         return ($i . '|' . $action . '|' . $username . '|' . $token . '|' . Grav::instance()['config']->get('security.salt'));

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -726,7 +726,7 @@ abstract class Utils
         $username = '';
         if (isset(Grav::instance()['user'])) {
             $user = Grav::instance()['user'];
-            $username = $user->username;
+            $username = mb_strtolower($user->username);
         }
 
         $token = session_id();
@@ -744,7 +744,7 @@ abstract class Utils
     {
         if (isset(Grav::instance()['user'])) {
             $user = Grav::instance()['user'];
-            $username = $user->username;
+            $username = mb_strtolower($user->username);
             if (isset($_SERVER['REMOTE_ADDR'])) {
                 $username .= $_SERVER['REMOTE_ADDR'];
             }


### PR DESCRIPTION
I don't know the exact motivation behind these uses of `strtolower`, but I believe that the existence of the username regular expression in Grav's config clearly implies that the usernames don't just _have_ to be lowercase, hence this pull request.