### PR TITLE
Merge all theme config files together when inherited

### DIFF
--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -262,6 +262,12 @@ class Themes extends Iterator
             }
         }
 
+        // If theme is inherited, merge the theme config files
+        $paths = $config['prefixes'][''];
+        if (count($paths) > 1) {
+            $this->mergeConfiguration($name, $paths, $this->config);    
+        }
+
         // Load languages after streams has been properly initialized
         $this->loadLanguages($this->config);
     }
@@ -276,6 +282,24 @@ class Themes extends Iterator
     {
         $themeConfig = CompiledYamlFile::instance("themes://{$name}/{$name}" . YAML_EXT)->content();
         $config->joinDefaults("themes.{$name}", $themeConfig);
+    }
+
+    /**
+     * Merge theme configuration.
+     *
+     * @param string $name   Theme name
+     * @param array  $paths  Paths to inherited themes
+     * @param Config $config Configuration class
+     */
+    protected function mergeConfiguration($name, $paths, Config $config)
+    {
+        $merged = array();
+        foreach (array_reverse($paths) as $path) {
+            $nodename = end(explode(DS, $path));
+            $node = CompiledYamlFile::instance("themes://{$nodename}/{$nodename}" . YAML_EXT)->content();
+            $merged = array_replace_recursive($merged, $node);
+        }
+        $config->joinDefaults("themes.{$name}", $merged);
     }
 
     /**


### PR DESCRIPTION
Naive solution to PR #2140. I say "naive" because (a) I can only do so much testing and (b) it assumes Grav never uses prefixes in theme inheritance. The docs never mention it, so I assume it's true.

The code still merges `user/config/themes` files correctly. The change should be mostly backwards compatible. The only people affected will be those who both 
  * have inherited from a theme that uses the config file to affect behaviour AND
  * have relied on the nonexistence of a clobbered setting rather then copying the settings over and changing them.

Such scenarios are easily fixed by overriding the desired settings.

If accepted, I'd then submit a separate PR against `grav-learn` explaining how to inherit themes given this new behaviour.

I tested it as follows:
  * I added the setting `inherited: "No!"` to my root theme.
  * I then created a new child theme. In that theme's YAML I did the following:
    * Added the correct `streams` settings.
    * Added the setting `inherited: "Yes!"`.
    * Added the setting `uniqueRoot: true`.
  * I then created a new YAML file for the *child* theme in `user/config/themes` and did the following:
    * Added the setting `inherited: "Double!"`.
    * Added the setting `uniqueCustom: true`.
  * Then I went to my dev site, picked a demo page, and added the following: `{{ dump(grav.theme.config) }}`

Here's the result ([visible here](https://www.perlkonig.com/dev/demos/twig-extensions)):

```
array:6 [
  "enabled" => true
  "dropdown" => array:1 [
    "enabled" => true
  ]
  "inherited" => "Double!"
  "streams" => array:1 [
    "schemes" => array:1 [
      "theme" => array:2 [
        "type" => "ReadOnlyStream"
        "prefixes" => array:1 [
          "" => array:2 [
            0 => "user/themes/newtheme"
            1 => "user/themes/minimalist-blog"
          ]
        ]
      ]
    ]
  ]
  "uniqueRoot" => true
  "uniqueCustom" => true
]
```