### PR TITLE
Remove hardcoded 302 when redirecting trailing slash

### DIFF
--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -47,7 +47,7 @@ class InitializeProcessor extends ProcessorBase implements ProcessorInterface
         // Redirect pages with trailing slash if configured to do so.
         $path = $uri->path() ?: '/';
         if ($path !== '/' && $config->get('system.pages.redirect_trailing_slash', false) && Utils::endsWith($path, '/')) {
-            $this->container->redirect(rtrim($path, '/'), 302);
+            $this->container->redirect(rtrim($path, '/'));
         }
 
         $this->container->setLocale();


### PR DESCRIPTION
 When `system.pages.redirect_trailing_slash` is enabled, it's always a 302 even though `redirect_default_code` is set to something else. 

By removing it, it works as intended.