### PR TITLE
Fix uppercase and Unicode username handling

### DIFF
--- a/system/src/Grav/Common/User/User.php
+++ b/system/src/Grav/Common/User/User.php
@@ -34,7 +34,7 @@ class User extends Data
         $locator = $grav['locator'];
 
         // force lowercase of username
-        $username = strtolower($username);
+        $username = mb_strtolower($username);
 
         $blueprints = new Blueprints;
         $blueprint = $blueprints->get('user/account');
@@ -94,7 +94,7 @@ class User extends Data
      */
     public static function remove($username)
     {
-        $file_path = Grav::instance()['locator']->findResource('account://' . $username . YAML_EXT);
+        $file_path = Grav::instance()['locator']->findResource('account://' . mb_strtolower($username) . YAML_EXT);
 
         return $file_path && unlink($file_path);
     }
@@ -192,9 +192,9 @@ class User extends Data
         if ($file) {
             $username = $this->get('username');
 
-            if (!$file->filename()) {
+            if (!$file->filename() || $username != mb_strtolower($username)) {
                 $locator = Grav::instance()['locator'];
-                $file->filename($locator->findResource('account://') . DS . strtolower($username) . YAML_EXT);
+                $file->filename($locator->findResource('account://') . DS . mb_strtolower($username) . YAML_EXT);
             }
 
             // if plain text password, hash it and remove plain text
@@ -203,7 +203,9 @@ class User extends Data
                 unset($this->password);
             }
 
-            unset($this->username);
+            if ($username == mb_strtolower($username)) {
+                unset($this->username);
+            }
             $file->save($this->items);
             $this->set('username', $username);
         }

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -728,7 +728,7 @@ abstract class Utils
         $username = '';
         if (isset(Grav::instance()['user'])) {
             $user = Grav::instance()['user'];
-            $username = $user->username;
+            $username = mb_strtolower($user->username);
         }
 
         $token = session_id();


### PR DESCRIPTION
Here goes another attempt at getting #2138 merged.

This pull request differs from the previous one by ~having less messy commits and~ better improving how the filename is determined at the [line 195](https://github.com/getgrav/grav/blob/0b5c1dcfa792e9b7c22c89fcf87aa852b6a932b8/system/src/Grav/Common/User/User.php#L195) of `User.php`. According to my research, this is still needed because of the login plugin [not making the username lowercase on registration](https://github.com/getgrav/grav-plugin-login/blob/3a09d57c5318948acce84b0129d9500df7a504dd/classes/Login.php#L212-L242), while according to my tests on Arch Linux, no duplicate files get created as `$file->filename()` gets called on a `$file` that was already named, as long as that file hasn't been saved with the wrong name, which should never be the case there.

Nevertheless, I shall soon be sending a pull request to the login plugin as well, making it properly convert the usernames to lowercase for filenames. If there is still an important reason to omit the line 195 change that I haven't noticed, that change can perhaps be omitted by somehow lining up a version of the login plugin that would have said pull request merged with a Grav version with the functional rest of this.

Less controversially, this pull request also adds a `mb_strtolower()` call in `User::remove()`.