### PR TITLE
Redirect regex pattern to match entire $source_url

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -501,7 +501,7 @@ class Pages
                     $site_redirects = $config->get("site.redirects");
                     if (is_array($site_redirects)) {
                         foreach ((array)$site_redirects as $pattern => $replace) {
-                            $pattern = '#^' . str_replace('/', '\/', ltrim($pattern, '^')) . '#';
+                            $pattern = '#^' . str_replace('/', '\/', ltrim($pattern, '^')) . '$#';
                             try {
                                 $found = preg_replace($pattern, $replace, $source_url);
                                 if ($found != $source_url) {


### PR DESCRIPTION
**Problem**
The regex checking for redirects defined in site.yaml, allows and passes on just a part of the path. 

**Example site.yaml**
```yaml
redirects:
  /this-is-my-url: '/somepath'
  /this-is-sparta: '/some-other-path'
  /this: '/some-different-path'
```

With this configuration, when hitting /this, I would get redirected to /somepath because it matches on the first redirects entry. 

This happens because the current regex only checks start of string until found:

`#^\/this#`

Adding an end of string check in the regex, will not match on the first two redirects, but continue on until it matches on the last entry:

`#^\/this$#`