### PR TITLE
Propagate error code if between 400 and 600 for production sites

### DIFF
--- a/system/src/Grav/Common/Errors/BareHandler.php
+++ b/system/src/Grav/Common/Errors/BareHandler.php
@@ -18,6 +18,13 @@ class BareHandler extends Handler
      */
     public function handle()
     {
+        $inspector = $this->getInspector();
+        $code = $inspector->getException()->getCode();
+        if ( ($code >= 400) && ($code < 600) )
+        {
+            $this->getRun()->sendHttpCode($code);    
+        }
+
         return Handler::QUIT;
     }
 

--- a/system/src/Grav/Common/Errors/SimplePageHandler.php
+++ b/system/src/Grav/Common/Errors/SimplePageHandler.php
@@ -35,6 +35,10 @@ class SimplePageHandler extends Handler
         $cssFile      = $this->getResource("error.css");
 
         $code = $inspector->getException()->getCode();
+        if ( ($code >= 400) && ($code < 600) )
+        {
+            $this->getRun()->sendHttpCode($code);    
+        }
         $message = $inspector->getException()->getMessage();
 
         if ($inspector->getException() instanceof \ErrorException) {


### PR DESCRIPTION
Fix for issue #2164.

Only works if both of the following are true:

* `system:errors:display` is `0` or `-1`
* The error code is between 400 and 599

The first condition is necessary because [when verbosity is `1`, it uses the built-in Whoops handler](https://github.com/getgrav/grav/blob/develop/system/src/Grav/Common/Errors/Errors.php#L36-L50). The only way to override (that I can find) is to create our own `PrettyPageHandler` that inherits from the built-in one and that contains the propagation code. But I wanted a minimal solution for now. I am happy to take the next step if this approach is acceptable.

I tested this by throwing a new `RuntimeException` in `Grav\Common\Twig\Twig::processSite`. Certainly more tests are necessary, but I don't know enough about the possible repercussions.

Let me know if you'd like me to make further changes.