### PR TITLE
Register theme prefixes as namespaces in twig

### DIFF
--- a/system/src/Grav/Common/Twig/Twig.php
+++ b/system/src/Grav/Common/Twig/Twig.php
@@ -102,6 +102,28 @@ class Twig
 
             $this->loader = new \Twig_Loader_Filesystem($this->twig_paths);
 
+            // Register all other prefixes as namespaces in twig
+            foreach ($locator->getPaths('theme') as $prefix => $_) {
+                if ($prefix === '') {
+                    continue;
+                }
+
+                $twig_paths = [];
+
+                // handle language templates if available
+                if ($language->enabled()) {
+                    $lang_templates = $locator->findResource('theme://'.$prefix.'templates/' . ($active_language ? $active_language : $language->getDefault()));
+                    if ($lang_templates) {
+                        $twig_paths[] = $lang_templates;
+                    }
+                }
+
+                $twig_paths = array_merge($twig_paths, $locator->findResources('theme://'.$prefix.'templates'));
+
+                $namespace = trim($prefix, '/');
+                $this->loader->setPaths($twig_paths, $namespace);
+            }
+
             $this->grav->fireEvent('onTwigLoader');
 
             $this->loaderArray = new \Twig_Loader_Array([]);


### PR DESCRIPTION
When creating a theme that inherit from another theme one common thing is that you want to change a tiny thing in an existing twig file.

I couldn't find a good way to do that without copy the whole twig-file over to my theme. Which means that if the base theme update that twig-file I will never get the changes. And I couldn't figure out a way to reference the base theme twig file and override it at the same time.

So with this change I can change my theme config to something like this:
```
streams:
  schemes:
    theme:
      type: ReadOnlyStream
      prefixes:
        '':
          - user/themes/mytheme
          - user/themes/quark
        'quark/':
          - user/themes/quark
```

And then if I want to update the footer in base.html.twig I can just create a base.html.twig file in mytheme that looks something like this:
```
{% extends '@quark/partials/base.html.twig' %}

{% block footer %}
    My footer text
{% endblock %}
```

When I first implemented it I just had one foreach that handled the empty prefix also. But because when `$this->grav->fireEvent('onTwigTemplatePaths'); ` some stuff goes in and touches `$this->twig_paths` that didn't work.