### PR TITLE
fix .webm typo

### DIFF
--- a/system/config/media.yaml
+++ b/system/config/media.yaml
@@ -53,7 +53,7 @@ types:
     thumb: media/thumb-flv.png
     mime: video/x-flv
   webm:
-    type: file
+    type: video
     thumb: media/thumb-webm.png
     mime: video/webm
   ogv:


### PR DESCRIPTION
Media type should be 'video' not file!

Have tested this on a local install and changing this line allows .webm files to successfully play.