### PR TITLE
Update default.md

### DIFF
--- a/user/pages/01.home/default.md
+++ b/user/pages/01.home/default.md
@@ -26,7 +26,7 @@ To edit this page, simply navigate to the folder you installed **Grav** into, an
 
 Creating a new page is a simple affair in **Grav**.  Simply follow these simple steps:
 
-1. Navigate to your pages folder: `user/pages/` and create a new folder.  In this example, we will use [explicit default ordering](http://learn.getgrav.org/content/content-pages) and call the folder `03.mypage`.
+1. Navigate to your pages folder: `user/pages/` and create a new folder.  In this example, we will use [explicit default ordering](http://learn.getgrav.org/content/content-pages) and call the folder `02.mypage`.
 2. Launch your text editor and paste in the following sample code:
 
         ---
@@ -36,7 +36,7 @@ Creating a new page is a simple affair in **Grav**.  Simply follow these simple 
 
         This is the body of **my new page** and I can easily use _Markdown_ syntax here.
 
-3. Save this file in the `user/pages/03.mypage/` folder as `default.md`. This will tell **Grav** to render the page using the **default** template.
+3. Save this file in the `user/pages/02.mypage/` folder as `default.md`. This will tell **Grav** to render the page using the **default** template.
 4. That is it! Reload your browser to see your new page in the menu.
 
 ! NOTE: The page will automatically show up in the Menu after the "Home" menu item. If you wish to change the name that shows up in the Menu, simple add: `menu: My Page` between the dashes in the page content. This is called the YAML front matter, and it is where you configure page-specific options.


### PR DESCRIPTION
Making documentation consistent between sources:  Issue Typo! #650

In (grav-learn/pages/01.basics/04.basic-tutorial/docs.md) the text under the heading Adding a New Page is 02.mypage 
In (grav/user/pages/01.home/default.md) the text under the heading Adding a New Page is 03.mypage