### PR TITLE
Update InitializeProcessor.php

### DIFF
--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -47,7 +47,7 @@ class InitializeProcessor extends ProcessorBase implements ProcessorInterface
         // Redirect pages with trailing slash if configured to do so.
         $path = $uri->path() ?: '/';
         if ($path !== '/' && $config->get('system.pages.redirect_trailing_slash', false) && Utils::endsWith($path, '/')) {
-            $this->container->redirect(rtrim($path, '/'));
+            $this->container->redirectLangSafe(rtrim($path, '/'));
         }
 
         $this->container->setLocale();


### PR DESCRIPTION
if redirect_trailing_slash is enabled and you are on a translated page and add a trailing slash, the redirect will redirect you to the default language version of this page