### PR TITLE
Provides plugin INSTANCES from Grav instance

### DIFF
--- a/system/src/Grav/Common/Plugins.php
+++ b/system/src/Grav/Common/Plugins.php
@@ -126,6 +126,16 @@ class Plugins extends Iterator
     }
 
     /**
+     * Return the real plugin instance.
+     *
+     * @return array
+     */
+    public function item($name)
+    {
+        return $this->items[$name];
+    }
+
+    /**
      * Return list of all plugin data with their blueprints.
      *
      * @return array


### PR DESCRIPTION
Don't consider users babies, save them digging stacktraces to find the data they need : Just provide a way to access currently initialized plugins INSTANCES.

Sample use-case:
* I want to modify a form in PHP.
* The hooks provided by `form` (`onFormPageHeaderProcessed`) does not make it because I want to know whether or not to add assets according to the form.
(There would have many other legitimate use-case for accessing instance data)

Without this patch, `form` plugin `forms` are **unavailable**. With it, there **are just here:**
```
public function onTwigSiteVariables(Event $event) {
        dump(Grav::instance()['plugins']->item('Grav\Plugin\FormPlugin')->getForm());
}
```