### PR TITLE
preserve accents in fields containing Twig expr. using unicode

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -168,7 +168,7 @@ class Page implements PageInterface
                     unset($process_fields[$field]);
                 }
             }
-            $text_header = Grav::instance()['twig']->processString(json_encode($process_fields), ['page' => $this]);
+            $text_header = Grav::instance()['twig']->processString(json_encode($process_fields, JSON_UNESCAPED_UNICODE), ['page' => $this]);
             $this->header((object)(json_decode($text_header, true) + $ignored_fields));
         }
     }


### PR DESCRIPTION
When a field contain accentuated characters, reduce the risk of messing with it by passing unicode characters unescaped.
Twig will deal with them. And fewer backslash-escaping problems will arise.

In order to allow blueprints fields to contain Twig expression, `processString()` is used.
Ideally it would deal with object/array by processing (= Twig-rendering) inner elements recursively.
But what it instead does, in order to flatten the value, is `json_decode(Twig::render(json_encode($value)))`

If someone use such a field value: `{{ url.uri ~ 'é' }}`, it will be transformed to `{{ url.uri ~ '\u00e9' }}`.
And `Grav\Common\Twig::processString` calling `$this->twig->render()` with that string returns `localhostu00e9` whose accent won't be restored after `json_decode()`.

I don't know why Twig calls seems broken. But using at least `JSON_UNESCAPED_UNICODE` is a safe enough solution that quickly reduces problem's surface.