### PR TITLE
[1.6] add return types for user/authentication

### DIFF
--- a/system/src/Grav/Common/User/Authentication.php
+++ b/system/src/Grav/Common/User/Authentication.php
@@ -16,9 +16,9 @@ abstract class Authentication
      * @param string $password Plaintext password.
      *
      * @throws \RuntimeException
-     * @return string|bool
+     * @return string
      */
-    public static function create($password)
+    public static function create($password): string
     {
         if (!$password) {
             throw new \RuntimeException('Password hashing failed: no password provided.');
@@ -41,7 +41,7 @@ abstract class Authentication
      *
      * @return int              Returns 0 if the check fails, 1 if password matches, 2 if hash needs to be updated.
      */
-    public static function verify($password, $hash)
+    public static function verify($password, $hash): int
     {
         // Fail if hash doesn't match
         if (!$password || !$hash || !password_verify($password, $hash)) {


### PR DESCRIPTION
PR targets 1.6 branch because there is php 7.1 which support return tpyes.