### PR TITLE
Added support for AWS Cloudfront forwarded scheme header

### DIFF
--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -1140,6 +1140,8 @@ class Uri
             $this->scheme = $env['HTTP_X_FORWARDED_PROTO'];
         } elseif (isset($env['X-FORWARDED-PROTO'])) {
             $this->scheme = $env['X-FORWARDED-PROTO'];
+        } elseif (isset($env['HTTP_CLOUDFRONT_FORWARDED_PROTO'])) {
+            $this->scheme = $env['HTTP_CLOUDFRONT_FORWARDED_PROTO'];
         } elseif (isset($env['REQUEST_SCHEME'])) {
            $this->scheme = $env['REQUEST_SCHEME'];
         } else {
@@ -1168,6 +1170,10 @@ class Uri
            $this->port = (int)$env['HTTP_X_FORWARDED_PORT'];
         } elseif (isset($env['X-FORWARDED-PORT'])) {
            $this->port = (int)$env['X-FORWARDED-PORT'];
+        } elseif (isset($env['HTTP_CLOUDFRONT_FORWARDED_PROTO'])) {
+           // Since AWS Cloudfront does not provide a forwarded port header,
+           // we have to build the port using the scheme.
+           $this->port = $this->port();
         } elseif (isset($env['SERVER_PORT'])) {
            $this->port = (int)$env['SERVER_PORT'];
         } else {


### PR DESCRIPTION
# Added support for AWS Cloudfront forwarded scheme header

## Description

* **What went wrong?**
I host some Grav websites in AWS EC2 instances behind AWS Cloudfront (to provide free SSL and caching). I do not have any ssl certificates installed in the EC2 instances (since Cloudfront handle it for us, such as a loadbalancer), so I actually have Cloudfront that handle HTTPS but communicates internally with the EC2 instance over HTTP. But, I recently figured out that Cloudfront does not provide the standard HTTP_X_FORWARDED_PROTO header but provide a HTTP_CLOUDFRONT_FORWARDED_PROTO header instead.

* **Resolution**
Adding the support of this header prior to REQUEST_SCHEME because Cloudfront provide it but with the value of the internal communication scheme (in my case http).
Auto build the port from the scheme when we are in this situation because Cloudfront does not provide any kind of HTTP_X_FORWARDED_PORT header...

* **Extra notes**
I don't know if there is any unit tests for this function, so let me know if there is some to implement or edit.