### PR TITLE
Small bugfix for responsive images

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -223,7 +223,7 @@ class ImageMedium extends Medium
         foreach ($this->alternatives as $ratio => $medium) {
             $srcset[] = $medium->url($reset) . ' ' . $medium->get('width') . 'w';
         }
-        $srcset[] = str_replace(' ','%20',$this->url($reset)) . ' ' . $this->get('width') . 'w';
+        $srcset[] = str_replace(' ', '%20', $this->url($reset)) . ' ' . $this->get('width') . 'w';
 
         return implode(', ', $srcset);
     }

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -223,7 +223,7 @@ class ImageMedium extends Medium
         foreach ($this->alternatives as $ratio => $medium) {
             $srcset[] = $medium->url($reset) . ' ' . $medium->get('width') . 'w';
         }
-        $srcset[] = $this->url($reset) . ' ' . $this->get('width') . 'w';
+        $srcset[] = str_replace(' ','%20',$this->url($reset)) . ' ' . $this->get('width') . 'w';
 
         return implode(', ', $srcset);
     }


### PR DESCRIPTION
Replaces any spaces in an image filename with %20 to avoid parse errors with the srcset attribute. i.e. changes:

srcset="image_path/grav_name320w.jpeg 320w, image_path/Original Name.jpg 2560w" to
srcset="image_path/grav_name320w.jpeg 320w, image_path/Original%20Name.jpg 2560w"