### PR TITLE
Theme language.yaml unable to override fixes #2372 solution 1

### DIFF
--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -308,6 +308,11 @@ class Themes extends Iterator
                 }
                 $this->grav['languages']->mergeRecursive($languages);
             }
+            $language_override_file = $locator->findResource("user://languages/theme" . YAML_EXT);
+            if ($language_override_file) {
+                $language = CompiledYamlFile::instance($language_override_file)->content();
+                $this->grav['languages']->mergeRecursive($language);
+            }
         }
     }
 


### PR DESCRIPTION
1. Store the theme override translations in user://languages/theme.yaml and load them after the initial theme://languages.yaml file