### PR TITLE
Theme language.yaml unable to override fixes #2372 solution 2

### DIFF
--- a/system/src/Grav/Common/Config/Languages.php
+++ b/system/src/Grav/Common/Config/Languages.php
@@ -13,6 +13,8 @@ use Grav\Common\Utils;
 
 class Languages extends Data
 {
+    const INVERSE = true;
+
     public function checksum($checksum = null)
     {
         if ($checksum !== null) {
@@ -48,8 +50,8 @@ class Languages extends Data
         }
     }
 
-    public function mergeRecursive(array $data)
+    public function mergeRecursive(array $data, $inverse = false)
     {
-        $this->items = Utils::arrayMergeRecursiveUnique($this->items, $data);
+        $this->items = $inverse ? Utils::arrayMergeRecursiveUnique($data, $this->items) : Utils::arrayMergeRecursiveUnique($this->items, $data);
     }
 }

--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -9,6 +9,7 @@
 namespace Grav\Common;
 
 use Grav\Common\Config\Config;
+use Grav\Common\Config\Languages;
 use Grav\Common\File\CompiledYamlFile;
 use Grav\Common\Data\Blueprints;
 use Grav\Common\Data\Data;
@@ -292,7 +293,7 @@ class Themes extends Iterator
             $language_file = $locator->findResource("theme://languages" . YAML_EXT);
             if ($language_file) {
                 $language = CompiledYamlFile::instance($language_file)->content();
-                $this->grav['languages']->mergeRecursive($language);
+                $this->grav['languages']->mergeRecursive($language, Languages::INVERSE);
             }
             $languages_folder = $locator->findResource("theme://languages/");
             if (file_exists($languages_folder)) {
@@ -306,7 +307,7 @@ class Themes extends Iterator
                     }
                     $languages[$file->getBasename('.yaml')] = CompiledYamlFile::instance($file->getPathname())->content();
                 }
-                $this->grav['languages']->mergeRecursive($languages);
+                $this->grav['languages']->mergeRecursive($languages, Languages::INVERSE);
             }
         }
     }


### PR DESCRIPTION
Add unexisting keys from theme://languages.yaml to the language cache by adding an "inverse" parameter to the mergeRecursive function.