### PR TITLE
Preliminary tests for CsvFormatter::encode + minor fix for empty data

### DIFF
--- a/system/src/Grav/Framework/File/Formatter/CsvFormatter.php
+++ b/system/src/Grav/Framework/File/Formatter/CsvFormatter.php
@@ -43,6 +43,9 @@ class CsvFormatter extends AbstractFormatter
      */
     public function encode($data, $delimiter = null): string
     {
+        if (count($data) === 0) {
+            return '';
+        }
         $delimiter = $delimiter ?? $this->getDelimiter();
         $header = array_keys(reset($data));
 

--- a/tests/unit/Grav/Framework/File/Formatter/CsvFormatterTest.php
+++ b/tests/unit/Grav/Framework/File/Formatter/CsvFormatterTest.php
@@ -36,7 +36,6 @@ class CsvFormatterTest extends \Codeception\TestCase\Test
 
         self::assertCount(2, $lines);
         self::assertEquals('0,1,2', $lines[0]);
-
     }
 
     public function testEncodeEmptyData()

--- a/tests/unit/Grav/Framework/File/Formatter/CsvFormatterTest.php
+++ b/tests/unit/Grav/Framework/File/Formatter/CsvFormatterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Grav\Framework\File\Formatter\CsvFormatter;
+
+class CsvFormatterTest extends \Codeception\TestCase\Test
+{
+    public function testEncodeWithAssocColumns()
+    {
+        $data = [
+            ['col1' => 1, 'col2' => 2, 'col3' => 3],
+            ['col1' => 'aaa', 'col2' => 'bbb', 'col3' => 'ccc'],
+        ];
+
+        $encoded = (new CsvFormatter())->encode($data);
+
+        $lines = array_filter(explode(PHP_EOL, $encoded));
+
+        self::assertCount(3, $lines);
+        self::assertEquals('col1,col2,col3', $lines[0]);
+
+    }
+
+    /**
+     * TBD - If indexes are all numeric, what's the purpose
+     * of displaying header
+     */
+    public function testEncodeWithIndexColumns()
+    {
+        $data = [
+            [0 => 1, 1 => 2, 2 => 3],
+        ];
+
+        $encoded = (new CsvFormatter())->encode($data);
+
+        $lines = array_filter(explode(PHP_EOL, $encoded));
+
+        self::assertCount(2, $lines);
+        self::assertEquals('0,1,2', $lines[0]);
+
+    }
+
+    public function testEncodeEmptyData()
+    {
+        $encoded = (new CsvFormatter())->encode([]);
+        self::assertEquals('', $encoded);
+    }
+
+}


### PR DESCRIPTION
Haven't changed the original behaviour...

One thing that can be discussed, do we display header if they actually are numeric ? (I think for now yes, this is enforced by the test, but can be changed later)