### PR TITLE
Change minimal port number to 0 (unix socket)

### DIFF
--- a/system/src/Grav/Framework/Uri/UriPartsFilter.php
+++ b/system/src/Grav/Framework/Uri/UriPartsFilter.php
@@ -84,11 +84,11 @@ class UriPartsFilter
      */
     public static function filterPort($port = null)
     {
-        if (null === $port || (\is_int($port) && ($port >= 1 && $port <= 65535))) {
+        if (null === $port || (\is_int($port) && ($port >= 0 && $port <= 65535))) {
             return $port;
         }
 
-        throw new \InvalidArgumentException('Uri port must be null or an integer between 1 and 65535');
+        throw new \InvalidArgumentException('Uri port must be null or an integer between 0 and 65535');
     }
 
     /**


### PR DESCRIPTION
Listening on an unix socket reports port number 0, which is interpreted as an invalid argument.

Same issue exists in vendor libraries used by Grav.
https://github.com/guzzle/psr7/pull/270
https://github.com/Nyholm/psr7/pull/115

One of them caused whole website to crash with HTTP 503 error, after updating from 1.5.8 to 1.6.3.
```
2019/04/15 12:06:33 [error] 22644#0: *15185375 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught InvalidArgumentException: Invalid port: 0. Must be between 1 and 65535 in /var/www/grav/html/vendor/nyholm/psr7/src/Uri.php:282
Stack trace:
#0 /var/www/grav/html/vendor/nyholm/psr7/src/Uri.php(178): Nyholm\Psr7\Uri->filterPort(0)
#1 /var/www/grav/html/vendor/kodus/psr7-server/src/ServerRequestCreator.php(252): Nyholm\Psr7\Uri->withPort('')
#2 /var/www/grav/html/vendor/kodus/psr7-server/src/ServerRequestCreator.php(141): Nyholm\Psr7Server\ServerRequestCreator->createUriFromArray(Array)
#3 /var/www/grav/html/vendor/kodus/psr7-server/src/ServerRequestCreator.php(63): Nyholm\Psr7Server\ServerRequestCreator->getUriFromEnvWithHTTP(Array)
#4 /var/www/grav/html/vendor/kodus/psr7-server/src/ServerRequestCreator.php(54): Nyholm\Psr7Server\ServerRequestCreator->fromArrays(Array, Array, Array, Array, Array, Array, Resource id #5)
#5 /var/www/grav/html/system/src/Grav/Common/Service/RequestServiceProvider.php(31): Nyholm\" while reading response header from upstream, client: unix:, server: , request: "HEAD / HTTP/1.0", upstream: "fastcgi://unix:/var/run/php/grav.sock:"
```