### PR TITLE
Privilegiate HTTPS environement over REQUEST_SCHEME

### DIFF
--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -1154,7 +1154,7 @@ class Uri
             $this->scheme = $env['X-FORWARDED-PROTO'];
         } elseif (isset($env['HTTP_CLOUDFRONT_FORWARDED_PROTO'])) {
             $this->scheme = $env['HTTP_CLOUDFRONT_FORWARDED_PROTO'];
-        } elseif (isset($env['REQUEST_SCHEME'])) {
+        } elseif (isset($env['REQUEST_SCHEME']) && empty($env['HTTPS'])) {
            $this->scheme = $env['REQUEST_SCHEME'];
         } else {
             $https = $env['HTTPS'] ?? '';


### PR DESCRIPTION
When using Grav behind an HTTPS-endpoint, we would probably have either one of
* `HTTPS=on`
* `X-Forwarded-Proto https`

Still, the latest virtualhost would still provide `REQUEST_SCHEME` which, contrary to HTTPS environment, would not be overriden (eg: Apache only creates `REDIRECT_REQUEST_SCHEME` with the requested value).

This change gives priority to non-empty `HTTPS` over `REQUEST_SCHEME`.