### PR TITLE
Make yaml_decode only return array to avoid errors

### DIFF
--- a/system/src/Grav/Framework/File/Formatter/YamlFormatter.php
+++ b/system/src/Grav/Framework/File/Formatter/YamlFormatter.php
@@ -102,7 +102,7 @@ class YamlFormatter extends AbstractFormatter
         }
 
         try {
-            return YamlParser::parse($data);
+            return (array) YamlParser::parse($data);
         } catch (ParseException $e) {
             if ($this->useCompatibleDecoder()) {
                 return (array) FallbackYamlParser::parse($data);


### PR DESCRIPTION
With the recent updates, the `decode()` PHP function, used for the `yaml_decode` twig filter, has been given the return type of `array`. Despite of that, the function may actually return a string. This pull request aims to correct that.

Despite of how small the change is, I believe that the issue should be assigned a high priority, as it may cause many current usecases of `yaml_decode` to return a cryptic server error.