### PR TITLE
run route.php when grav is not at the root of the server

### DIFF
--- a/system/router.php
+++ b/system/router.php
@@ -17,11 +17,25 @@ if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_N
     return false;
 }
 
+$gravBasedir = getenv('GRAV_BASEDIR');
+if ($gravBasedir === false) {
+	$gravBasedir = '';
+} else {
+	$gravBasedir = DIRECTORY_SEPARATOR . trim($gravBasedir, DIRECTORY_SEPARATOR);
+	// tell system/defines.php not to use the default GRAV_ROOT
+    define('GRAV_ROOT', str_replace(DIRECTORY_SEPARATOR, '/', getcwd()). $gravBasedir);
+
+}
+
 $_SERVER = array_merge($_SERVER, $_ENV);
-$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
-$_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR . 'index.php';
-$_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . $gravBasedir .DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['SCRIPT_NAME'] = $gravBasedir . DIRECTORY_SEPARATOR . 'index.php';
+$_SERVER['PHP_SELF'] = $gravBasedir . DIRECTORY_SEPARATOR . 'index.php';
 
 error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);
 
-require 'index.php';
+if ($gravBasedir === '') {
+	require 'index.php';
+} else {
+	require ltrim($gravBasedir, '/') . DIRECTORY_SEPARATOR . 'index.php';
+}


### PR DESCRIPTION
Currently, if I want to use the `router.php` provided by Grav I need to start `php -S` in the Grav's root folder.

If on the production server, Grav is not installed at the documents root, this will make it slightly more complex to manage the assets.

This patch adds the option to start Grav as:

```sh
GRAV_BASEDIR="/grav" php -S localhost:8000 grav/system/router.php
```

(in this case it will also accept "grav" and "grav/" as the basedir values)