### PR TITLE
fixed typos in comments / API docs

### DIFF
--- a/system/src/Grav/Common/GPM/Licenses.php
+++ b/system/src/Grav/Common/GPM/Licenses.php
@@ -103,7 +103,7 @@ class Licenses
     }
 
     /**
-     * Get's the License File object
+     * Get the License File object
      *
      * @return \RocketTheme\Toolbox\File\FileInterface
      */

--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -234,7 +234,7 @@ class Language
     }
 
     /**
-     * Get's a URL prefix based on configuration
+     * Get a URL prefix based on configuration
      *
      * @param string|null $lang
      * @return string

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -232,7 +232,7 @@ class ImageMedium extends Medium
     }
 
     /**
-     * Allows the ability to override the Inmage's Pretty name stored in cache
+     * Allows the ability to override the image's pretty name stored in cache
      *
      * @param string $name
      */

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -455,7 +455,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     }
 
     /**
-     * Gets a human readable output for cron sytnax
+     * Gets a human readable output for cron syntax
      *
      * @param $at
      * @return string
@@ -1136,7 +1136,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     }
 
     /**
-     * Get's the Exif data for a file
+     * Get the Exif data for a file
      *
      * @param string $image
      * @param bool $raw

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -1286,7 +1286,7 @@ class Uri
     }
 
     /**
-     * Get's post from either $_POST or JSON response object
+     * Get post from either $_POST or JSON response object
      * By default returns all data, or can return a single item
      *
      * @param string $element

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -1297,7 +1297,7 @@ abstract class Utils
     }
 
     /**
-     * Get's path based on a token
+     * Get path based on a token
      *
      * @param string $path
      * @param PageInterface|null $page

--- a/system/src/Grav/Framework/Collection/AbstractIndexCollection.php
+++ b/system/src/Grav/Framework/Collection/AbstractIndexCollection.php
@@ -437,7 +437,7 @@ abstract class AbstractIndexCollection implements CollectionInterface
     }
 
     /**
-     * Implementes JsonSerializable interface.
+     * Implements JsonSerializable interface.
      *
      * @return array
      */

--- a/system/src/Grav/Framework/Collection/ArrayCollection.php
+++ b/system/src/Grav/Framework/Collection/ArrayCollection.php
@@ -84,7 +84,7 @@ class ArrayCollection extends BaseArrayCollection implements CollectionInterface
     }
 
     /**
-     * Implementes JsonSerializable interface.
+     * Implements JsonSerializable interface.
      *
      * @return array
      */


### PR DESCRIPTION
"Get's" would either be the possessive form or a contraction of "Get is". Neither makes sense. 

"Gets" without the apostrophe would be okay in some replacements but just "Get" is fine.

This change will also correct the API docs. Thanks.