### PR TITLE
Fix nginx config for ddev

### DIFF
--- a/webserver-configs/nginx-ddev-site.conf
+++ b/webserver-configs/nginx-ddev-site.conf
@@ -101,7 +101,7 @@ server {
             root   /usr/share/nginx/html;
     }
 
-    location ~ ^/(fpmstatus|ping)$ {
+    location ~ ^/(fpmstatus|ping|phpstatus)$ {
         access_log off;
         stub_status     on;
         keepalive_timeout 0;    # Disable HTTP keepalive


### PR DESCRIPTION
In ddev, it is required to have a healthcheck available. 
This commit adds that functionality according to the latest ddev docs.

(ref https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/)