### PR TITLE
Make yaml_decode only return array, again

### DIFF
--- a/system/src/Grav/Framework/File/Formatter/YamlFormatter.php
+++ b/system/src/Grav/Framework/File/Formatter/YamlFormatter.php
@@ -97,7 +97,7 @@ class YamlFormatter extends AbstractFormatter
             @ini_set('yaml.decode_php', $saved);
 
             if ($decoded !== false) {
-                return $decoded;
+                return (array) $decoded;
             }
         }
 


### PR DESCRIPTION
After tweaking my PHP configuration so that it would use the native YAML extension, I found out that `$decoded` can happen to be a string as well, causing the problems already mentioned in #2494. This ~~tiny, annoying and repetitive~~ pull request aims to correct that, hopefully for good this time. ¯\\\_(ツ)\_/¯