### PR TITLE
Save usernames with uppercase characters in files

### DIFF
--- a/system/src/Grav/Common/User/DataUser/User.php
+++ b/system/src/Grav/Common/User/DataUser/User.php
@@ -99,7 +99,7 @@ class User extends Data implements UserInterface
     }
 
     /**
-     * Save user without the username
+     * Save user without the username, unless uppercase
      */
     public function save()
     {
@@ -125,7 +125,10 @@ class User extends Data implements UserInterface
             }
 
             $data = $this->items;
-            unset($data['username'], $data['authenticated'], $data['authorized']);
+            if ($username == mb_strtolower($username)) {
+                unset($data['username']);
+            }
+            unset($data['authenticated'], $data['authorized']);
 
             $file->save($data);
         }

--- a/system/src/Grav/Common/User/FlexUser/User.php
+++ b/system/src/Grav/Common/User/FlexUser/User.php
@@ -416,7 +416,7 @@ class User extends FlexObject implements UserInterface, MediaManipulationInterfa
     }
 
     /**
-     * Save user without the username
+     * Save user without the username, unless uppercase
      */
     public function save()
     {


### PR DESCRIPTION
Per #2160, this pull request aims to make the usernames that include uppercase characters get saved in the account files, in order to accurately represent the names chosen by users at the time of registration.