### PR TITLE
do NOT ignore "." dirs OR ignore "." dirs and all children

### DIFF
--- a/system/src/Grav/Common/Filesystem/Folder.php
+++ b/system/src/Grav/Common/Filesystem/Folder.php
@@ -235,7 +235,7 @@ abstract class Folder
         /** @var \RecursiveDirectoryIterator $file */
         foreach ($iterator as $file) {
             // Ignore hidden files.
-            if (strpos($file->getFilename(), '.') === 0) {
+            if (strpos($file->getFilename(), '.') === 0 && $file->isFile()) {
                 continue;
             }
             if (!$folders && $file->isDir()) {


### PR DESCRIPTION
If you ignore any "files" beginning with "." including directories, then the `all()` method will exclude `.somedir`, but not `.somedir/somefile`. Subsequently, when trying to copy all files returned from `all()`, it will fail when the `copy()` method tries to copy a file into a directory that has not yet been created because `.somedir` was omitted from the returned array of `all()`.

I found this bug when trying to install the admin plugin and `./tmp` was a mount and thus `rename()` failed and `self:copy()` was invoked instead (see lines 364-5).

Alternatively, the check at line 238 could be omitted altogether and all "." files and dirs would be copied. (I'm not familiar enough with the project to know why they were ignored in the first place.) 

Also, ignoring "." dirs and ALL their children is an option.