### PR TITLE
Allow naive iterables in Taxonomy

### DIFF
--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -69,7 +69,13 @@ class Taxonomy
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
                 if (isset($page_taxonomy[$taxonomy])) {
                     foreach ((array)$page_taxonomy[$taxonomy] as $item) {
-                        $this->taxonomy_map[$taxonomy][(string)$item][$page->path()] = ['slug' => $page->slug()];
+                        if (is_iterable($item)) {
+                            foreach ($item as $value) {
+                                $this->taxonomy_map[$taxonomy][(string)$value][$page->path()] = ['slug' => $page->slug()];
+                            }
+                        } elseif (is_string($item)) {
+                            $this->taxonomy_map[$taxonomy][(string)$item][$page->path()] = ['slug' => $page->slug()];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Currently, Taxonomy only supports one-level arrays in a Page's Taxonomy, so this works:

```yaml
---
title: XMark Test
taxonomy:
  categories: academic
  tags: [xmark, link]
  author:
    - "Ole Vik"
    - "Ole Vik"
    - "Ole Vik"
---
```

But this does not:

```yaml
---
title: XMark Test
taxonomy:
  categories: academic
  tags: [xmark, link]
  author:
    - "Ole Vik"
    - "Ole Vik"
    - "Ole Vik"
    - name: "Ole Vik"
      email: "git@olevik.net"
      url: "https://olevik.me"
---
```

The change allows another level, to accommodate cases where the Taxonomy contains arrays of strings or hashes. This could potentially be expanded to recursively allow any amount of nesting of Taxonomies.

In both the naive and expanded case, are there implications for finding and filtering by Taxonomies? I've not checked if that recurses through values as I'm not currently at my desktop, but I imagine more changes would be necessary.