### PR TITLE
Check if GRAV_USER_INSTANCE constants are already defined

### DIFF
--- a/system/src/Grav/Common/Service/AccountsServiceProvider.php
+++ b/system/src/Grav/Common/Service/AccountsServiceProvider.php
@@ -46,7 +46,9 @@ class AccountsServiceProvider implements ServiceProviderInterface
 
     protected function dataAccounts(Container $container)
     {
-        define('GRAV_USER_INSTANCE', 'DATA');
+        if (!defined('GRAV_USER_INSTANCE')) {
+            define('GRAV_USER_INSTANCE', 'DATA');
+        }
 
         // Use User class for backwards compatibility.
         return new DataUser\UserCollection(User::class);
@@ -54,7 +56,9 @@ class AccountsServiceProvider implements ServiceProviderInterface
 
     protected function flexAccounts(Container $container)
     {
-        define('GRAV_USER_INSTANCE', 'FLEX');
+        if (!defined('GRAV_USER_INSTANCE')) {
+            define('GRAV_USER_INSTANCE', 'FLEX');
+        }
 
         /** @var Config $config */
         $config = $container['config'];


### PR DESCRIPTION
Closes #2620 

Small check to allow accounts to prevent a constant being defined again. This allows `$grav['accounts']`  to be accessed multiple times when new `Grav::instance()` are created, for example when unit testing.