### PR TITLE
[RFR] Fix cache image generation on parsedown assert

### DIFF
--- a/tests/unit/Grav/Common/Markdown/ParsedownTest.php
+++ b/tests/unit/Grav/Common/Markdown/ParsedownTest.php
@@ -110,6 +110,7 @@ class ParsedownTest extends \Codeception\TestCase\Test
 
     public function testImagesSubDir()
     {
+        $this->config->set('system.images.cache_all', false);
         $this->uri->initializeWithUrlAndRootPath('http://testing.dev/subdir/item2/item2-2', '/subdir')->init();
 
         $this->assertRegexp('|<p><img alt="" src="\/subdir\/images\/.*-home-cache-image.jpe?g" \/><\/p>|',


### PR DESCRIPTION
When image cache is enable and you are trying to assert image from parsedown, the path is not the same as original but it's a generated one from cache

```
$this->assertSame('<p><img alt="" src="/subdir/tests/fake/nestedsite/user/pages/02.item2/02.item2-2/sample-image.jpg" /></p>',
            $this->parsedown->text('![](sample-image.jpg)'))
```