### PR TITLE
Correct the evaluation of the non-published collection filter

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2855,9 +2855,9 @@ class Page implements PageInterface
             $result = [];
             foreach ((array)$value as $key => $val) {
                 if (is_int($key)) {
-                    $result = $result + $this->evaluate($val)->toArray();
+                    $result = $result + $this->evaluate($val, $only_published)->toArray();
                 } else {
-                    $result = $result + $this->evaluate([$key => $val])->toArray();
+                    $result = $result + $this->evaluate([$key => $val], $only_published)->toArray();
                 }
 
             }


### PR DESCRIPTION
Currently, when a collection is being parsed by `collection()`, it checks the filters, and based on them determines the value of the `$only_published` variable, which is then passed as the second argument to `evaluate()`. However, the mentioned `evaluate()` recursively calls itself, without passing the value of `$only_published`.

Because of this, every collection (or at least, every of them that I've tested with `collection()`) ends up being parsed as if the `non-published: false` filter had been applied, which might not be the case, drastically affecting the result of the evaluation. I therefore believe that the issue, hopefully correctly resolved in this pull request, should be assigned a fairly high priority.