### PR TITLE
[RFR] Iterable Taxonomy

### DIFF
--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -69,7 +69,7 @@ class Taxonomy
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
                 if (isset($page_taxonomy[$taxonomy])) {
                     foreach ((array)$page_taxonomy[$taxonomy] as $item) {
-                        $this->iterateTaxonomy($page, $item);
+                        $this->iterateTaxonomy($page, $taxonomy, '', $item);
                     }
                 }
             }
@@ -79,21 +79,31 @@ class Taxonomy
     /**
      * Iterate through taxonomy fields
      *
+     * Reduces [taxonomy_type] to dot-notation where necessary
+     *
      * @param PageInterface   $page     The Page to process
-     * @param iterable|string $taxonomy Taxonomy item to add or iterate
+     * @param string          $taxonomy Taxonomy type to add
+     * @param string          $key      Taxonomy type to concatenate
+     * @param iterable|string $value    Taxonomy value to add or iterate
      *
      * @return void
      */
-    public function iterateTaxonomy(PageInterface $page, $taxonomy)
+    public function iterateTaxonomy(PageInterface $page, string $taxonomy, string $key, $value)
     {
-        if (is_iterable($taxonomy)) {
-            foreach ($taxonomy as $value) {
-                if (is_iterable($value)) {
-                    $this->iterateTaxonomy($page, $value);
+        if (is_iterable($value)) {
+            foreach ($value as $identifier => $item) {
+                $identifier = $key . '.' . $identifier;
+                if (is_iterable($item)) {
+                    $this->iterateTaxonomy($page, $taxonomy, $identifier, $item);
+                } else {
+                    $this->iterateTaxonomy($page, $taxonomy, $identifier, $item);
                 }
             }
-        } elseif (is_string($taxonomy)) {
-            $this->taxonomy_map[$taxonomy][(string)$taxonomy][$page->path()] = ['slug' => $page->slug()];
+        } elseif (is_string($value)) {
+            if (!empty($key)) {
+                $taxonomy = $taxonomy . $key;
+            }
+            $this->taxonomy_map[$taxonomy][(string) $value][$page->path()] = ['slug' => $page->slug()];
         }
     }
 

--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -69,16 +69,31 @@ class Taxonomy
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
                 if (isset($page_taxonomy[$taxonomy])) {
                     foreach ((array)$page_taxonomy[$taxonomy] as $item) {
-                        if (is_iterable($item)) {
-                            foreach ($item as $value) {
-                                $this->taxonomy_map[$taxonomy][(string)$value][$page->path()] = ['slug' => $page->slug()];
-                            }
-                        } elseif (is_string($item)) {
-                            $this->taxonomy_map[$taxonomy][(string)$item][$page->path()] = ['slug' => $page->slug()];
-                        }
+                        $this->iterateTaxonomy($page, $item);
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Iterate through taxonomy fields
+     *
+     * @param PageInterface   $page     The Page to process
+     * @param iterable|string $taxonomy Taxonomy item to add or iterate
+     *
+     * @return void
+     */
+    public function iterateTaxonomy(PageInterface $page, $taxonomy)
+    {
+        if (is_iterable($taxonomy)) {
+            foreach ($taxonomy as $value) {
+                if (is_iterable($value)) {
+                    $this->iterateTaxonomy($page, $value);
+                }
+            }
+        } elseif (is_string($taxonomy)) {
+            $this->taxonomy_map[$taxonomy][(string)$taxonomy][$page->path()] = ['slug' => $page->slug()];
         }
     }
 

--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -93,11 +93,7 @@ class Taxonomy
         if (is_iterable($value)) {
             foreach ($value as $identifier => $item) {
                 $identifier = $key . '.' . $identifier;
-                if (is_iterable($item)) {
-                    $this->iterateTaxonomy($page, $taxonomy, $identifier, $item);
-                } else {
-                    $this->iterateTaxonomy($page, $taxonomy, $identifier, $item);
-                }
+				$this->iterateTaxonomy($page, $taxonomy, $identifier, $item);
             }
         } elseif (is_string($value)) {
             if (!empty($key)) {

--- a/system/src/Grav/Common/Taxonomy.php
+++ b/system/src/Grav/Common/Taxonomy.php
@@ -69,7 +69,13 @@ class Taxonomy
             foreach ((array)$config->get('site.taxonomies') as $taxonomy) {
                 if (isset($page_taxonomy[$taxonomy])) {
                     foreach ((array)$page_taxonomy[$taxonomy] as $item) {
-                        $this->taxonomy_map[$taxonomy][(string)$item][$page->path()] = ['slug' => $page->slug()];
+                        if (is_iterable($item)) {
+                            foreach ($item as $value) {
+                                $this->taxonomy_map[$taxonomy][(string)$value][$page->path()] = ['slug' => $page->slug()];
+                            }
+                        } elseif (is_string($item)) {
+                            $this->taxonomy_map[$taxonomy][(string)$item][$page->path()] = ['slug' => $page->slug()];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Improves the naive implementation in #2596 and solves #1304, by allowing nested/hierarchical taxonomies. A helper-method recursively iterates through taxonomy fields.

The current one-level taxonomy mapping is kept as standard, but this allows nested setups to work alongside by reducing the taxonomy type to a dot-notation where necessary, and thus does not break `taxonomy.findTaxonomy()`. For example, a Page with this taxonomy defined in FrontMatter:

```yaml
taxonomy:
  categories: academic
  tags: [article, tufte, bogus]
  author:
    - name: "Helmut W. M. Sargeant"
      email: "hwms@bogus.tld"
      url: "https://www.stanford.edu/"
      affiliation:
        department: "Department of Literature"
        organization: "Stanford University"
    - name: "L. Agnes Prinn"
      email: "lap@bogus.tld"
      url: "https://www.yale.edu/"
      affiliation: "Department of Sociology, Yale University"
```

Yields:

```php
array:10 [
  "categories" => array:2 [
    "academic" => array:2 []
    "fiction" => array:1 []
  ]
  "tags" => array:4 [
    "article" => array:2 []
    "bogus" => array:2 []
    "book" => array:1 []
    "tufte" => array:1 []
  ]
  "category" => array:1 [
    "Idea" => array:7 []
  ]
  "tag" => array:1 [
    "Lorem Ipsum" => array:1 []
  ]
  "author.name" => array:2 [
    "Helmut W. M. Sargeant" => array:1 []
    "L. Agnes Prinn" => array:1 []
  ]
  "author.email" => array:2 [
    "hwms@bogus.tld" => array:1 []
    "lap@bogus.tld" => array:1 []
  ]
  "author.url" => array:2 [
    "https://www.stanford.edu/" => array:1 []
    "https://www.yale.edu/" => array:1 []
  ]
  "author.affiliation.department" => array:1 [
    "Department of Literature" => array:1 []
  ]
  "author.affiliation.organization" => array:1 [
    "Stanford University" => array:1 []
  ]
  "author.affiliation" => array:1 [
    "Department of Sociology, Yale University" => array:1 []
  ]
]
```

And so `taxonomy.findTaxonomy({'author.email':'hwms@bogus.tld'})` in Twig and `$this->grav['taxonomy']->findTaxonomy(['author.email' => 'hwms@bogus.tld'])` in PHP are valid. The normal logic of accessing FrontMatter in Twig is still available, eg. `{{ page.taxonomy.author[0].affiliation.organization }}`.