### PR TITLE
fix exception array_merge() when $this->header->metadata is not array

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1696,7 +1696,7 @@ class Page implements PageInterface
             // Get initial metadata for the page
             $metadata = array_merge($metadata, Grav::instance()['config']->get('site.metadata'));
 
-            if (isset($this->header->metadata)) {
+            if (isset($this->header->metadata) && is_array($this->header->metadata)) {
                 // Merge any site.metadata settings in with page metadata
                 $metadata = array_merge($metadata, $this->header->metadata);
             }


### PR DESCRIPTION
Exception gets thrown when $this->header->metadata is not an array, added extra verification in order to make sure it is and array before doing array_merge()