### PR TITLE
Correct download argument annotation

### DIFF
--- a/system/src/Grav/Console/Gpm/SelfupgradeCommand.php
+++ b/system/src/Grav/Console/Gpm/SelfupgradeCommand.php
@@ -177,7 +177,7 @@ class SelfupgradeCommand extends ConsoleCommand
     }
 
     /**
-     * @param Package $package
+     * @param array $package
      *
      * @return string
      */


### PR DESCRIPTION
Functions expects an array and not an package (was a bug before and annotation wasn't changed in the bugfix)