### PR TITLE
Fix for Saving Flex Pages on Windows

### DIFF
--- a/system/src/Grav/Common/Flex/Pages/PageObject.php
+++ b/system/src/Grav/Common/Flex/Pages/PageObject.php
@@ -108,7 +108,7 @@ class PageObject extends FlexPageObject
                 // TODO: this should not be template!
                 return $this->getProperty('template');
             case 'route':
-                $key = dirname($this->hasKey() ? '/' . $this->getKey() : '/');
+                $key = $this->hasKey() ? str_replace('\\', '/', dirname('/' . $this->getKey())) : '/';
                 return $key !== '/' ? $key : null;
             case 'full_route':
                 return $this->hasKey() ? '/' . $this->getKey() : '';

--- a/system/src/Grav/Common/Flex/Pages/PageStorage.php
+++ b/system/src/Grav/Common/Flex/Pages/PageStorage.php
@@ -260,8 +260,8 @@ class PageStorage extends FolderStorage
         } else {
             [$order, $folder] = ['', $objectKey];
         }
-        $parentKey = ltrim(dirname('/' . $key), '/');
-
+        $parentKey = ltrim(str_replace('\\', '/', dirname('/' . $key)), '/');
+        
         return [
             'key' => $key,
             'params' => $params,


### PR DESCRIPTION
This fixes an issue with Flex Pages on Windows where dirname returns backslashes and prevents the page from being saved.