### PR TITLE
Encode routes to increase compatibility

### DIFF
--- a/system/src/Grav/Framework/Route/Route.php
+++ b/system/src/Grav/Framework/Route/Route.php
@@ -383,10 +383,10 @@ class Route
 
             $path = $parts['path'] ?? '/';
             if (isset($parts['params'])) {
-                $this->route = trim(rawurldecode($path), '/');
+                $this->route = rawurlencode(trim(rawurldecode($path), '/'));
                 $this->gravParams = $parts['params'];
             } else {
-                $this->route = trim(RouteFactory::stripParams($path, true), '/');
+                $this->route = rawurlencode(trim(RouteFactory::stripParams($path, true), '/'));
                 $this->gravParams = RouteFactory::getParams($path);
             }
             if (isset($parts['query'])) {


### PR DESCRIPTION
Currently, when routes are being built in Grav, the supplied paths are automatically decoded. Because of this, when they contain special characters, encoded to be used as ordinary parts of the paths, the resulting routes may function differently than expected.

The problem is particularly visible in the case of a question mark, encoded as `%3F`. For example, if `redirect_trailing_slash` is set to `true` in `system.yaml` in a Grav installation on localhost, trying to access http://localhost/test%3F/?foo=bar may be redirected to http://localhost/test??foo=bar, instead of http://localhost/test%3F?foo=bar, where `test%3F` refers to a page called `test?`. As a result, a page called `test` will be loaded.

This pull request aims to fix that by encoding the routes after work is done on them, although frankly, I am not entirely convinced that the change that I propose, even if free of problems on its own (FWIW, I haven't observed any), completely resolves the described underlying issue. Perhaps it'd be a good idea to take a deeper look into this, if time allows.