### PR TITLE
Temporarily fix for using multisites  advanced

### DIFF
--- a/system/src/Grav/Common/GPM/Remote/AbstractPackageCollection.php
+++ b/system/src/Grav/Common/GPM/Remote/AbstractPackageCollection.php
@@ -54,11 +54,15 @@ class AbstractPackageCollection extends BaseCollection
         $this->raw        = $this->cache->fetch(md5($this->repository));
 
         $this->fetch($refresh, $callback);
+		//Get schemes defined in setup.php -> To make possiblity to use different multisite setups
+		$schemes = Grav::instance()['locator']->getSchemes();
         foreach (json_decode($this->raw, true) as $slug => $data) {
             // Temporarily fix for using multisites
             if (isset($data['install_path'])) {
-                $path = preg_replace('~^user/~i', 'user://', $data['install_path']);
-                $data['install_path'] = Grav::instance()['locator']->findResource($path, false, true);
+				$path = preg_replace('~^user/~i', 'user://', $data['install_path']);
+				if (!in_array("pluginupdates", $schemes)) {
+					$data['install_path'] = Grav::instance()['locator']->findResource($path, false, true);
+				}
             }
             $this->items[$slug] = new Package($data, $this->type);
         }


### PR DESCRIPTION
There are 2 way to setup multisites in Grav CMS. 
The first way: with different plugins set for every sites - it was supported already with earlier temporarily fix
The second way: COMMON plugins set for all domains in multisite was unsupported.
With this modification you can use a stream definition in your setup.php like this
            'pluginupdates' => [
                'type' => 'ReadOnlyStream',
                'paths' => [
                    'user/plugins',
                ],
                'prefixes' => [
                    '' => ['user/plugins'],
                ]
            ],
And if this stream definition exists, the plugin install path will not be modified and will be suitable for the common use in 'user/plugins' folder.