### PR TITLE
Do not remove trailing spaces on markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,7 @@ indent_size = 4
 # 2 space indentation
 [*.{yaml,yml}]
 indent_size = 2
+
+# Do not remove trailing spaces on markdown files
+[*.{md,markdown}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Using Jetbrains IDEA IDE like PHPStorm when you have the setting "strip trailing spaces on save" selected (which is useful for all but markdown files) it will always remove 3 spaces added deliberately to force a line break and mess up the output to have all on one line.

See also https://github.com/nicoulaj/idea-markdown/issues/138 (the linked plugin is outdated and replaces by vendor markdown plugin but the `.editorconfig` fix described and proposed with this PR fixes the problem for me. Not sure though as nobody seems to have that issue here. Afaik the mentioned setting causing it is disabled by default, so this could be why it rarely happens.