### PR TITLE
Alternative representation

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -180,6 +180,41 @@ class Page implements PageInterface
     }
 
     /**
+     * Return a different representation of the same page.
+     * Place a new file named _<representation>.md next to the current
+     * markdown file.
+     *
+     * @param string $representation the name of the alternative representation.
+     *
+     * @return Page A new instance of Page or null if the representation does not
+     * exists or is not published.
+     */
+    public function alternativeRepresentation($representation)
+    {
+        $returnValue;
+
+        $path = $this->path . DS . $this->folder . DS . '_' . $representation . '.md';
+        if (file_exists($path)) {
+            $aPage = new Page();
+            $aPage->init(new \SplFileInfo($path), '.md');
+
+            if (!$aPage->published()) {
+                $returnValue = null;
+            }
+            else {
+                // Removes the '_'
+                $aPage->template(($this->modular() ? 'modular/' : '') . $representation);
+                $returnValue = $aPage;
+            }
+        }
+        else {
+            $returnValue = null;
+        }
+
+        return $returnValue;
+    }
+
+    /**
      * Return an array with the routes of other translated languages
      *
      * @param bool $onlyPublished only return published translations

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -1086,7 +1086,7 @@ class Pages
 
         // Build regular expression for all the allowed page extensions.
         $page_extensions = $language->getFallbackPageExtensions();
-        $regex = '/^[^\.]*(' . implode('|', array_map(
+        $regex = '/^[^\._]*(' . implode('|', array_map(
             function ($str) {
                 return preg_quote($str, '/');
             },


### PR DESCRIPTION
I've been fiddling with the idea for a while now. In many cases, I need to have different representations of the same page. There are _ways_ (namely headers) but those have limitations. They does not use the same pipeline as page content (so, no plugins).

Here comes what I called Alternative Representations. It's one or more _other_ markdown files next to the usual one. Its use cases are:
* Summaries but on steroïds
* Other kind-of-similar use-cases : having different representation of the page when displayed on the home page / search results page / …
* Complex content in classic or modular pages

Here's an super-simple illustration of the last use case. I need a two-columns page (or page module). Additionnally, I want to use the image-captions plugins. Here's what I get if I use a header:

![image](https://user-images.githubusercontent.com/9195926/80357693-a3484980-887b-11ea-8a06-df787a57fd56.png)

Now, using the alternative representation:

![image](https://user-images.githubusercontent.com/9195926/80357766-bb1fcd80-887b-11ea-951a-4c62c77f82bd.png)

Content pipeline (including plugins) processes the alternative MD file, caption is displayed.

My folder looks like this:
![image](https://user-images.githubusercontent.com/9195926/80357996-0e921b80-887c-11ea-8a3d-456bf1c1d759.png)

In my `left-column` template, I now use this:

```twig
{{ page.alternativeRepresentation('side-content').content | raw }}
```

As of now, implementation might have unexpected results in some cases (namely multi-language sites) and I may need some guidance there.