### PR TITLE
Updates donatj/phpuseragentparser to 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "~1.0",
         "gregwar/image": "2.*",
-        "donatj/phpuseragentparser": "~0.10",
+        "donatj/phpuseragentparser": "~1.0",
         "pimple/pimple": "~3.2",
         "rockettheme/toolbox": "~1.4.0",
         "maximebf/debugbar": "~1.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cf8d58f86543809e5b922b12962484d",
+    "content-hash": "40dbb242443086c99aa47ea8ca366d67",
     "packages": [
         {
             "name": "antoligy/dom-string-iterators",
@@ -260,23 +260,23 @@
         },
         {
             "name": "donatj/phpuseragentparser",
-            "version": "v0.15.0",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/donatj/PhpUserAgent.git",
-                "reference": "283e5812d3a3f2deb62377c14b0d24191aba1595"
+                "reference": "1431382850017ac017d194f2a6f6cacb35212888"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/donatj/PhpUserAgent/zipball/283e5812d3a3f2deb62377c14b0d24191aba1595",
-                "reference": "283e5812d3a3f2deb62377c14b0d24191aba1595",
+                "url": "https://api.github.com/repos/donatj/PhpUserAgent/zipball/1431382850017ac017d194f2a6f6cacb35212888",
+                "reference": "1431382850017ac017d194f2a6f6cacb35212888",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "camspiers/json-pretty": "0.1.*",
+                "camspiers/json-pretty": "~1.0",
                 "donatj/drop": "*",
                 "phpunit/phpunit": "~4.8"
             },
@@ -284,7 +284,10 @@
             "autoload": {
                 "files": [
                     "src/UserAgentParser.php"
-                ]
+                ],
+                "psr-4": {
+                    "donatj\\UserAgent\\": "src/UserAgent"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -294,7 +297,7 @@
                 {
                     "name": "Jesse G. Donat",
                     "email": "donatj@gmail.com",
-                    "homepage": "http://donatstudios.com",
+                    "homepage": "https://donatstudios.com",
                     "role": "Developer"
                 }
             ],
@@ -307,7 +310,17 @@
                 "user agent",
                 "useragent"
             ],
-            "time": "2020-01-21T17:51:39+00:00"
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/donatj/15",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/donatj",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-24T18:07:07+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",

--- a/system/src/Grav/Common/Browser.php
+++ b/system/src/Grav/Common/Browser.php
@@ -9,6 +9,8 @@
 
 namespace Grav\Common;
 
+use function donatj\UserAgent\parse_user_agent;
+
 /**
  * Internally uses the PhpUserAgent package https://github.com/donatj/PhpUserAgent
  */


### PR DESCRIPTION
I maintain `donatj/phpuseragentparser` and recently released v1.0.0 😄 

It's entirely backwards compatible, but also adds a namespaced variant which is the prefered use. I have changed the code to point to that.

Everything else should continue to work as expected.

I have also added an object oriented wrapper should you wish to change to that. As is, this was simply the clearest route forward.

I am happy to answer any questions.