### PR TITLE
gpm: Plugins containing "theme" should not be installed as themes

### DIFF
--- a/system/src/Grav/Common/GPM/GPM.php
+++ b/system/src/Grav/Common/GPM/GPM.php
@@ -575,10 +575,10 @@ class GPM extends Iterator
 
         // either theme or plugin
         $name = basename($source);
-        if (Utils::contains($name, 'theme')) {
+        if (Utils::contains($name, 'theme-')) {
             return 'theme';
         }
-        if (Utils::contains($name, 'plugin')) {
+        if (Utils::contains($name, 'plugin-')) {
             return 'plugin';
         }
         foreach (glob($source . '*.php') as $filename) {


### PR DESCRIPTION
https://github.com/Sommerregen/grav-plugin-themer/issues/6
`./bin/gpm -vvv direct-install https://github.com/Sommerregen/grav-plugin-themer/archive/v1.1.0.zip`

Up to you to evaluate the pattern themes must match, but I felt that `theme-` would be reasonable... until all this could be replaced by composer (or a composer plugin like symfony flex).