### PR TITLE
Fixed enviroment name mapping for localhost

### DIFF
--- a/system/src/Grav/Common/Config/Setup.php
+++ b/system/src/Grav/Common/Config/Setup.php
@@ -168,7 +168,7 @@ class Setup extends Data
         }
 
         // Resolve server aliases to the proper environment.
-        $environment = $this->environments[static::$environment] ?? static::$environment;
+        $environment = static::$environments[static::$environment] ?? static::$environment;
 
         // Pre-load setup.php which contains our initial configuration.
         // Configuration may contain dynamic parts, which is why we need to always load it.


### PR DESCRIPTION
This part should map the local ips to the name "localhost" to provide a single point for configurations. 

The feature was introduced in
https://github.com/getgrav/grav/commit/380b3be92812e71f9453d6ab15d100dd70588111

but should have never worked as the bug is already there.

Please check my change carefully as it seems to me as a potentially breaking change...