### PR TITLE
Fix: case-insensitive search of location header

### DIFF
--- a/system/src/Grav/Common/GPM/Response.php
+++ b/system/src/Grav/Common/GPM/Response.php
@@ -409,7 +409,7 @@ class Response
             } else {
                 $code = (int)curl_getinfo($rch, CURLINFO_HTTP_CODE);
                 if ($code === 301 || $code === 302 || $code === 303) {
-                    preg_match('/Location:(.*?)\n/', $header, $matches);
+                    preg_match('/(?:^|\n)Location:(.*?)\n/i', $header, $matches);
                     $uri = trim(array_pop($matches));
                 } else {
                     $code = 0;


### PR DESCRIPTION
We had problems installing a plugin (devtools) because when GitHub is redirected internally, "location" is written in lower case in the header.

According to RFC headers are case insensitive. So it's a bug in Grav.

See: https://code-examples.net/en/q/503ee1

I've adjusted the regex so that the installation works again with GitHub redirection.

See also:
https://regex101.com/r/R6AFdV/1