### PR TITLE
Use proper ellipsis for `summary()`.

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -608,7 +608,7 @@ class Page implements PageInterface
                 return $content;
             }
 
-            return mb_strimwidth($content, 0, $size, '...', 'UTF-8');
+            return mb_strimwidth($content, 0, $size, '…', 'UTF-8');
         }
 
         $summary = Utils::truncateHtml($content, $size);


### PR DESCRIPTION
I am working on a website with a monospace font.

Using an ellipsis is more meaningful in general and a lot better looking in my particular case.