### PR TITLE
added optional options to noprocess

### DIFF
--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -104,12 +104,18 @@ class Excerpts
             // Valid attributes supported.
             $valid_attributes = Grav::instance()['config']->get('system.pages.markdown.valid_link_attributes');
 
+            $noprocess = [];
             // Unless told to not process, go through actions.
             if (array_key_exists('noprocess', $actions)) {
+                if (!is_bool($actions['noprocess'])) {
+                    $noprocess = explode(',', $actions['noprocess']);
+                }
                 unset($actions['noprocess']);
-            } else {
-                // Loop through actions for the image and call them.
-                foreach ($actions as $attrib => $value) {
+            }
+
+            // Loop through actions for the image and call them.
+            foreach ($actions as $attrib => $value) {
+                if (!empty($noprocess) && !in_array($attrib, $noprocess)) {
                     $key = $attrib;
 
                     if (in_array($attrib, $valid_attributes, true)) {

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -104,18 +104,16 @@ class Excerpts
             // Valid attributes supported.
             $valid_attributes = Grav::instance()['config']->get('system.pages.markdown.valid_link_attributes');
 
-            $noprocess = [];
+            $skip = [];
             // Unless told to not process, go through actions.
             if (array_key_exists('noprocess', $actions)) {
-                if (!is_bool($actions['noprocess'])) {
-                    $noprocess = explode(',', $actions['noprocess']);
-                }
+                $skip = is_bool($actions['noprocess']) ? $actions : explode(',', $actions['noprocess']);
                 unset($actions['noprocess']);
             }
 
             // Loop through actions for the image and call them.
             foreach ($actions as $attrib => $value) {
-                if (!empty($noprocess) && !in_array($attrib, $noprocess)) {
+                if (!in_array($attrib, $skip)) {
                     $key = $attrib;
 
                     if (in_array($attrib, $valid_attributes, true)) {

--- a/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
+++ b/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
@@ -87,4 +87,28 @@ class ExcerptsTest extends \Codeception\TestCase\Test
             Excerpts::processImageHtml('<img src="sample-image.jpg?classes=foo" alt="Sample Image" />', $this->page)
         );
     }
+
+    public function testNoProcess()
+    {
+        $this->assertStringStartsWith(
+            '<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank',
+            Excerpts::processLinkHtml('<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank&noprocess">noprocess</a>')
+        );
+        $this->assertStringStartsWith(
+            '<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de',
+            Excerpts::processLinkHtml('<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank&noprocess=id">noprocess=id</a>')
+        );
+    }
+
+    public function testTarget()
+    {
+        $this->assertStringStartsWith(
+            '<a href="https://play.google.com/store/apps/details" target="_blank"',
+            Excerpts::processLinkHtml('<a href="https://play.google.com/store/apps/details?target=_blank">only target</a>')
+        );
+        $this->assertStringStartsWith(
+            '<a href="https://meet.weikamp.biz/Support" rel="nofollow" target="_blank"',
+            Excerpts::processLinkHtml('<a href="https://meet.weikamp.biz/Support?rel=nofollow&target=_blank">target and rel</a>')
+        );
+    }
 }

--- a/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
+++ b/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
@@ -91,11 +91,17 @@ class ExcerptsTest extends \Codeception\TestCase\Test
     public function testNoProcess()
     {
         $this->assertStringStartsWith(
-            '<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank',
+            '<a href="https://play.google.com/store/apps/details?hl=de" id="org.jitsi.meet" target="_blank"',
+            Excerpts::processLinkHtml('<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank">regular process</a>')
+        );
+
+        $this->assertStringStartsWith(
+            '<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank"',
             Excerpts::processLinkHtml('<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank&noprocess">noprocess</a>')
         );
+
         $this->assertStringStartsWith(
-            '<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de',
+            '<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de" target="_blank"',
             Excerpts::processLinkHtml('<a href="https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank&noprocess=id">noprocess=id</a>')
         );
     }


### PR DESCRIPTION
This enables the option &noprocess to be expanded to &noprocess=id,hl

Example:

`[PlayStore](https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank&noprocess)`

Current result link: `https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank` - not opening in new tab


This will work as intended by not processing the `id`, however the target also gets no processed.

Using 

`[PlayStore](https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de&target=_blank&noprocess=id)`

Will skip the `id` processing, and still process the target. Resulting in a better end result link.

New result link: `https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=de` - opening in new tab successfully

This is in reference to the following issues:

https://github.com/getgrav/grav/issues/2839 - FIXED

https://github.com/getgrav/grav/issues/2882

https://discordapp.com/channels/501836936584101899/501854266873348112/729728029063905345