### PR TITLE
Update Parsedown Regex so it can accept HTML tags with dash in them.

### DIFF
--- a/system/src/Grav/Framework/Parsedown/Parsedown.php
+++ b/system/src/Grav/Framework/Parsedown/Parsedown.php
@@ -689,7 +689,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^<(\w*)(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*(\/)?>/', $Line['text'], $matches))
+        if (preg_match('/^<([\w|-]*)(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*(\/)?>/', $Line['text'], $matches))
         {
             $element = strtolower($matches[1]);
 


### PR DESCRIPTION
## What?
Every so often, the need comes to be able to use valid HTML tags in markdown files. This becomes ever so important when one wants to embed **[WebComponents](https://www.webcomponents.org/)** into a blog-post. 

I use WebComponents extensively in my blog-post. A good [example is here](https://einarvalur.co/blog/major-basic-music-theory) , where I use WebComponent to enrich the content with sound and animation.

The only problem is that the WebComponent [spec requires a `-` (dash) in the name](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name), but the the Parsedown parser only accepts `\w` (that is: letters and numbers). Because of this, the first time the Parsedown parser encounters a WebComponent, it will close all open tags and terminate.


## How?
This PR tweaks the Parsedown parser's RegEx so it accepts HTML tags with dashes in them as valid tags.

## Why?
To enrich the Parsedown Markup parser so it can parse and validate HTML's [WebComponents](https://www.webcomponents.org/) tags in markdown documents.
