### PR TITLE
Update to Caddyfile using Caddy 2 changes.

### DIFF
--- a/webserver-configs/Caddyfile
+++ b/webserver-configs/Caddyfile
@@ -1,33 +1,24 @@
 :8080
-gzip
-fastcgi / 127.0.0.1:9000 php
+encode gzip
+root * /path/to/grav/root
+php_fastcgi unix//run/php/php7.3-fpm.sock
+file_server
 
 # Begin - Security
 # deny all direct access for these folders
-rewrite {
-    r       /(\.git|cache|bin|logs|backups|tests)/.*$
-    to  	/403
-}
-# deny running scripts inside core system folders
-rewrite {
-    r       /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
-    to  	/403
-}
-# deny running scripts inside user folder
-rewrite {
-    r       /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
-    to  	/403
-}
-# deny access to specific files in the root folder
-rewrite {
-    r       /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess)
-    to  	/403
-}
+rewrite /(\.git|cache|bin|logs|backups|tests)/.* /403
 
-status 403 /403
+# deny running scripts inside core system folders
+rewrite /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ /403
+
+# deny running scripts inside user folder
+rewrite /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ /403
+
+# deny access to specific files in the root folder
+rewrite /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) /403
+
+respond /403 403
 ## End - Security
 
 # global rewrite should come last.
-rewrite {
-    to  {path} {path}/ /index.php?_url={uri}&{query}
-}
+try_files {path} {path}/ /index.php?_url={uri}&{query}


### PR DESCRIPTION
Caddy 1 is officially deprecated in favor of Caddy 2. With that there are some changes to directives and such. I'm in the process of updating my blog site to use Caddy 2 over Lighttpd and the following changes seem to be OK. I'm not seeing any server-side or client warnings and/or errors but perhaps other users can confirm.

Official documentation on steps to upgrade, which I followed, are available [here](https://caddyserver.com/docs/v2-upgrade).

I noticed the original configuration listened on a network port vs. a unix socket in regards to `fastcgi` (I'm not sure if you want to keep this.)