### PR TITLE
Add translation hook for metadata content

### DIFF
--- a/system/templates/partials/metadata.html.twig
+++ b/system/templates/partials/metadata.html.twig
@@ -1,3 +1,3 @@
 {% for meta in page.metadata %}
-    <meta {% if meta.name %}name="{{ meta.name }}" {% endif %}{% if meta.http_equiv %}http-equiv="{{ meta.http_equiv }}" {% endif %}{% if meta.charset %}charset="{{ meta.charset }}" {% endif %}{% if meta.property %}property="{{ meta.property }}" {% endif %}{% if meta.content %}content="{{ meta.content }}" {% endif %}/>
+    <meta {% if meta.name %}name="{{ meta.name }}" {% endif %}{% if meta.http_equiv %}http-equiv="{{ meta.http_equiv }}" {% endif %}{% if meta.charset %}charset="{{ meta.charset }}" {% endif %}{% if meta.property %}property="{{ meta.property }}" {% endif %}{% if meta.content %}content="{{ ('GRAV.METADATA.'~meta.name)|t != 'GRAV.METADATA.'~meta.name ? ('GRAV.METADATA.'~meta.name)|t : meta.content }}" {% endif %}/>
 {% endfor %}

--- a/system/templates/partials/metadata.html.twig
+++ b/system/templates/partials/metadata.html.twig
@@ -1,3 +1,3 @@
 {% for meta in page.metadata %}
-    <meta {% if meta.name %}name="{{ meta.name }}" {% endif %}{% if meta.http_equiv %}http-equiv="{{ meta.http_equiv }}" {% endif %}{% if meta.charset %}charset="{{ meta.charset }}" {% endif %}{% if meta.property %}property="{{ meta.property }}" {% endif %}{% if meta.content %}content="{{ ('GRAV.METADATA.'~meta.name)|t != 'GRAV.METADATA.'~meta.name ? ('GRAV.METADATA.'~meta.name)|t : meta.content }}" {% endif %}/>
+    <meta {% if meta.name %}name="{{ meta.name }}" {% endif %}{% if meta.http_equiv %}http-equiv="{{ meta.http_equiv }}" {% endif %}{% if meta.charset %}charset="{{ meta.charset }}" {% endif %}{% if meta.property %}property="{{ meta.property }}" {% endif %}{% if meta.content %}content="{{ meta.name not in page.header.metadata|keys and ('GRAV.METADATA.'~meta.name)|t != 'GRAV.METADATA.'~meta.name ? ('GRAV.METADATA.'~meta.name)|t : meta.content }}" {% endif %}/>
 {% endfor %}


### PR DESCRIPTION
Problem: I wanted to localize the `description` metadata, but couldn't find a way to localize `site.yaml`.
I settled on using `languages.yaml` as a way to localize `site.yaml` metadata keys from `metadata.html.twig`, when they exist in both.

Users can override `site.yaml` metadata keys by providing a corresponding `GRAV.METADATA.key` via `languages.yaml`.

This is a working PR, but I don't believe this solution is elegant, even if it works fine. Input is welcome. Ideas?