### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:7-apache
+
+# install gd
+RUN apt-get update && apt-get install -y \
+		libfreetype6-dev \
+		libjpeg62-turbo-dev \
+		libpng-dev \
+	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
+	&& docker-php-ext-install -j$(nproc) gd
+
+# install zip
+RUN apt-get install -y libzip-dev && pecl install zip && docker-php-ext-enable zip
+
+# install git
+RUN apt-get install -y git unzip
+
+# enable rewrite module
+RUN a2enmod rewrite
+
+# copy user data
+COPY . /var/www/html/
+WORKDIR /var/www/html
+
+# install dependencies
+RUN bin/grav install
+
+# install plugins
+ARG INSTALL_PLUGINS=""
+RUN bin/gpm install $INSTALL_PLUGINS
+
+# change owner to www-data
+RUN chown -R www-data:www-data .
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ $ composer create-project getgrav/grav ~/webroot/grav
 
 Check out the [install procedures](https://learn.getgrav.org/basics/installation) for more information.
 
+### With Docker
+1. Clone the Grav repository from [https://github.com/getgrav/grav]():
+   ```
+   git clone https://github.com/getgrav/grav.git
+   ```
+2. Build a Docker image with your selection of plugins: `docker build --build-args NSTALL_PLUGINS="admin g5_helium map-marker-leaflet highlight" -t grav`
+3. Run the image `docker run -p 8080:80 grav` and visit the website at [`http://localhost:8080`]()
+
 # Adding Functionality
 
 You can download [plugins](https://getgrav.org/downloads/plugins) or [themes](https://getgrav.org/downloads/themes) manually from the appropriate tab on the [Downloads page on https://getgrav.org](https://getgrav.org/downloads), but the preferred solution is to use the [Grav Package Manager](https://learn.getgrav.org/advanced/grav-gpm) or `GPM`:


### PR DESCRIPTION
I noticed this repository is missing a dockerfile, and [this old pr](https://github.com/getgrav/grav/pull/844) tried to fix that but did not succeed.

I have not tested this Dockerfile with many plugins, maybe some dependencies are still missing, but it'll provide a nice base for future expansions. It allows building of images with preinstalled addons via the `--build-args NSTALL_PLUGINS="..."` flag.