### PR TITLE
Fix multilang redirects and routes

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -533,20 +533,14 @@ class Pages
                 if ($site_route) {
                     $page = $this->dispatch($site_route, $all);
                 } else {
-
-                    /** @var Uri $uri */
-                    $uri = $this->grav['uri'];
-                    /** @var \Grav\Framework\Uri\Uri $source_url */
-                    $source_url = $uri->uri(false);
-
                     // Try Regex style redirects
                     $site_redirects = $config->get('site.redirects');
                     if (is_array($site_redirects)) {
                         foreach ((array)$site_redirects as $pattern => $replace) {
                             $pattern = '#^' . str_replace('/', '\/', ltrim($pattern, '^')) . '#';
                             try {
-                                $found = preg_replace($pattern, $replace, $source_url);
-                                if ($found !== $source_url) {
+                                $found = preg_replace($pattern, $replace, $route);
+                                if ($found !== $route) {
                                     $this->grav->redirectLangSafe($found);
                                 }
                             } catch (ErrorException $e) {
@@ -561,8 +555,8 @@ class Pages
                         foreach ((array)$site_routes as $pattern => $replace) {
                             $pattern = '#^' . str_replace('/', '\/', ltrim($pattern, '^')) . '#';
                             try {
-                                $found = preg_replace($pattern, $replace, $source_url);
-                                if ($found !== $source_url) {
+                                $found = preg_replace($pattern, $replace, $route);
+                                if ($found !== $route) {
                                     $page = $this->dispatch($found, $all);
                                 }
                             } catch (ErrorException $e) {


### PR DESCRIPTION
Multilang redirects and routes were not working as per the documentation ("All redirect rules apply on the slug-path beginning after the language part (if you use multi-language pages)") due to language prefixes being included in URL when trying to match source URL and redirect/route source pattern.

Using `$route` parameter fixes the issue as given route does not include language prefixes (coming from `$uri->path()` in `PagesServiceProvider`).

Fixes #2435.