### PR TITLE
Flattr requires name instead property.

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1734,7 +1734,7 @@ class Page implements PageInterface
                                 'content' => htmlspecialchars($value, ENT_QUOTES, 'UTF-8')
                             ];
 
-                            if ($hasSeparator && !Utils::startsWith($key, 'twitter')) {
+                            if ($hasSeparator && !Utils::startsWith($key, ['twitter', 'flattr'])) {
                                 $entry['property'] = $key;
                             } else {
                                 $entry['name'] = $key;


### PR DESCRIPTION
Flattr requires the `name` property instead of the `property` property in the meta tag. Added flattr as needle in the if condition.