### PR TITLE
Sub-page redirect with code fails

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -320,7 +320,7 @@ class Grav extends Container
         $route = preg_replace("#^\/[\\\/]+\/#", '/', $route);
 
          // Check for code in route
-        $regex = '/.*(\[(30[1-7])\])$/';
+        $regex = '/.*(\[(30[1-7])\]).*/';
         preg_match($regex, $route, $matches);
         if ($matches) {
             $route = str_replace($matches[1], '', $matches[0]);


### PR DESCRIPTION
## Situation

Having a redirect set-up with a 3xx code

```
redirects:
  '/old_path': '/new_path[301]'
```

And accessing *http://my.site/old_path* the response is a *301* to *http://my.site/new_path*, as expected

## Issue

But when accessing *http://my.site/old_path/sub-page* the response is a *302* to *http://my.site/new_path[301]/sub-page*, which in turn respond another *302* to *http://my.site/new_path[301]/new_path[301]/sub-page* and so on and so forth until "TooManyRedirect" error is raised by the client.

## Solution

This PR intend to fix it and provide the following behavior : when accessing *http://my.site/old_path/sub-page* the response is a *301* to *http://my.site/new_path/sub-page*