### PR TITLE
Fix compatibility with Symfony 4.2 and up.

### DIFF
--- a/system/src/Grav/Common/Scheduler/Job.php
+++ b/system/src/Grav/Common/Scheduler/Job.php
@@ -298,8 +298,11 @@ class Job
         if (is_callable($this->command)) {
             $this->output = $this->exec();
         } else {
-            $args = \is_string($this->args) ? $this->args : implode(' ', $this->args);
-            $command = $this->command . ' ' . $args;
+            if (\is_string($this->args)) {
+                $command = array_merge([$this->command], explode(' ', $this->args));
+            } else {
+                $command = array_merge([$this->command], $this->args);
+            }
             $process = new Process($command);
 
             $this->process = $process;


### PR DESCRIPTION
This enables running scheduled *shell* commands again because Symfony 4.2 deprecated passing commands as a string to the Process component: https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-process-commands-as-strings

One also needs to catch all possible exceptions from the Process component, though. These exceptions are never displayed or sent to any of the logs and I've spent hours trying to debug why my scheduled tasks are failing.

Fix should be applied to 1.6 and 1.7 branches.