### PR TITLE
Fix failing example custom job.

### DIFF
--- a/system/blueprints/config/scheduler.yaml
+++ b/system/blueprints/config/scheduler.yaml
@@ -39,12 +39,13 @@ form:
             .command:
               type: text
               label: PLUGIN_ADMIN.COMMAND
-              placeholder: 'cd ~;ls -lah;'
+              placeholder: 'ls'
               validate:
                   required: true
             .args:
               type: text
               label: PLUGIN_ADMIN.EXTRA_ARGUMENTS
+              placeholder: '-lah'
             .at:
               type: cron
               label: PLUGIN_ADMIN.SCHEDULER_RUNAT

--- a/system/src/Grav/Common/Scheduler/Scheduler.php
+++ b/system/src/Grav/Common/Scheduler/Scheduler.php
@@ -246,7 +246,7 @@ class Scheduler
      */
     public function isCrontabSetup()
     {
-        $process = new Process('crontab -l');
+        $process = new Process(['crontab', '-l']);
         $process->run();
 
         if ($process->isSuccessful()) {


### PR DESCRIPTION
Since Symfony 4.2 passing chained shell commands to the Process component is not supported anymore and a working directory needs to be set by passing it as a completely separate parameter.

Unless somebody finds a way to use Process() for this and fixes it in the code, rework example custom job.

Related info: https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-process-commands-as-strings