### PR TITLE
Check exact extension in checkFilename utility

### DIFF
--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -859,11 +859,7 @@ abstract class Utils
     public static function checkFilename($filename)
     {
         $dangerous_extensions = Grav::instance()['config']->get('security.uploads_dangerous_extensions', []);
-        array_walk($dangerous_extensions, function(&$val) {
-            $val = '.' . $val;
-        });
-
-        $extension = '.' . pathinfo($filename, PATHINFO_EXTENSION);
+        $extension = pathinfo($filename, PATHINFO_EXTENSION);
 
         return !(
             // Empty filenames are not allowed.

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -872,8 +872,8 @@ abstract class Utils
             || strtr($filename, "\t\v\n\r\0\\/", '_______') !== $filename
             // Filename should not start or end with dot or space.
             || trim($filename, '. ') !== $filename
-            // Filename should not contain .php in it.
-            || static::contains($extension, $dangerous_extensions)
+            // File extension should not be part of configured dangerous extensions
+            || in_array($extension, $dangerous_extensions)
         );
     }
 

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -523,4 +523,20 @@ class UtilsTest extends \Codeception\TestCase\Test
         $this->assertSame('//foo.com', Utils::url('//foo.com'));
         $this->assertSame('//foo.com?param=x', Utils::url('//foo.com?param=x'));
     }
+
+    public function testCheckFilename()
+    {
+        // configure extension for consistent results
+        /** @var \Grav\Common\Config\Config $config */
+        $config = $this->grav['config'];
+        $config->set('security.uploads_dangerous_extensions', ['php', 'html', 'htm', 'exe', 'js']);
+
+        $this->assertFalse(Utils::checkFilename('foo.php'));
+        $this->assertFalse(Utils::checkFilename('bar.js'));
+
+        $this->assertTrue(Utils::checkFilename('foo.json'));
+        $this->assertTrue(Utils::checkFilename('foo.xml'));
+        $this->assertTrue(Utils::checkFilename('foo.yaml'));
+        $this->assertTrue(Utils::checkFilename('foo.yml'));
+    }
 }


### PR DESCRIPTION
As described in #3060 I changed the `checkFilename` function to check the exact extension.