### PR TITLE
Allow to set SameSite from system.yaml

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -1223,6 +1223,12 @@ form:
                             label: PLUGIN_ADMIN.SESSION_PATH
                             help: PLUGIN_ADMIN.SESSION_PATH_HELP
 
+                        session.samesite:
+                            type: text
+                            size: small
+                            label: PLUGIN_ADMIN.SESSION_SAMESITE
+                            help: PLUGIN_ADMIN.SESSION_SAMESITE_HELP
+                            
                         session.split:
                             type: toggle
                             label: PLUGIN_ADMIN.SESSION_SPLIT

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -161,6 +161,7 @@ session:
   uniqueness: path                               # Should sessions be `path` based or `security.salt` based
   secure: false                                  # Set session secure. If true, indicates that communication for this cookie must be over an encrypted transmission. Enable this only on sites that run exclusively on HTTPS
   httponly: true                                 # Set session HTTP only. If true, indicates that cookies should be used only over HTTP, and JavaScript modification is not allowed.
+  samesite:                                      # Set session SameSite. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
   split: true                                    # Sessions should be independent between site and plugins (such as admin)
   path:
 

--- a/system/src/Grav/Common/Service/SessionServiceProvider.php
+++ b/system/src/Grav/Common/Service/SessionServiceProvider.php
@@ -36,6 +36,7 @@ class SessionServiceProvider implements ServiceProviderInterface
             $cookie_httponly = (bool)$config->get('system.session.httponly', true);
             $cookie_lifetime = (int)$config->get('system.session.timeout', 1800);
             $cookie_path = $config->get('system.session.path');
+            $cookie_samesite = $config->get('system.session.samesite');
             if (null === $cookie_path) {
                 $cookie_path = '/' . trim(Uri::filterPath($uri->rootUrl(false)), '/');
             }
@@ -87,7 +88,8 @@ class SessionServiceProvider implements ServiceProviderInterface
                 'cookie_path' => $cookie_path,
                 'cookie_domain' => $cookie_domain,
                 'cookie_secure' => $cookie_secure,
-                'cookie_httponly' => $cookie_httponly
+                'cookie_httponly' => $cookie_httponly,
+                'cookie_samesite' => $cookie_samesite                
             ] + (array) $config->get('system.session.options');
 
             $session = new Session($options);

--- a/system/src/Grav/Framework/Session/Session.php
+++ b/system/src/Grav/Framework/Session/Session.php
@@ -135,6 +135,7 @@ class Session implements SessionInterface
             'use_strict_mode' => true,
             'use_cookies' => true,
             'use_only_cookies' => true,
+            'cookie_samesite' => true,
             'referer_check' => true,
             'cache_limiter' => true,
             'cache_expire' => true,
@@ -211,14 +212,19 @@ class Session implements SessionInterface
         if ($sessionExists) {
             $params = session_get_cookie_params();
 
+            $cookie_options = array (
+                'expires'  => time() + $params['lifetime'],
+                'path'     => $params['path'],
+                'domain'   => $params['domain'],
+                'secure'   => $params['secure'],
+                'httponly' => $params['httponly'],
+                'samesite' => $params['samesite']
+            );
+
             setcookie(
                 $sessionName,
                 session_id(),
-                time() + $params['lifetime'],
-                $params['path'],
-                $params['domain'],
-                $params['secure'],
-                $params['httponly']
+                $cookie_options
             );
         }
 
@@ -231,14 +237,20 @@ class Session implements SessionInterface
     public function invalidate()
     {
         $params = session_get_cookie_params();
+
+        $cookie_options = array (
+            'expires'  => time() - 42000,
+            'path'     => $params['path'],
+            'domain'   => $params['domain'],
+            'secure'   => $params['secure'],
+            'httponly' => $params['httponly'],
+            'samesite' => $params['samesite']
+        );
+
         setcookie(
             session_name(),
             '',
-            time() - 42000,
-            $params['path'],
-            $params['domain'],
-            $params['secure'],
-            $params['httponly']
+            $cookie_options
         );
 
         if ($this->isSessionStarted()) {


### PR DESCRIPTION
This patch allow to set `config.session.samesite` from system.yaml.
It does not set any default value, hence do not change the current behavior.