### PR TITLE
add custom attribute to medium

### DIFF
--- a/system/src/Grav/Common/Page/Medium/Medium.php
+++ b/system/src/Grav/Common/Page/Medium/Medium.php
@@ -474,6 +474,21 @@ class Medium extends Data implements RenderableInterface, MediaObjectInterface
     }
 
     /**
+     * Add custom attribute to medium.
+     *
+     * @param string $attribute
+     * @param string $value
+     * @return $this
+     */
+    public function attribute($attribute = '', $value = '')
+    {
+        if (!empty($attribute)) {
+            $this->attributes[$attribute] = $value;
+        }
+        return $this;
+    }
+
+    /**
      * Switch display mode.
      *
      * @param string $mode


### PR DESCRIPTION
This pull request adds the ability adding custom attributes to medium instances.
Eg. `page.media[...].attribute('data-section', 'my-data').html()` would generate `<img src="..." data-section="my-data">`

Empty `.attribute()` does nothing, `.attribute('key')` adds only the key without value.