### PR TITLE
Set twig_first setting to the correct default

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -676,7 +676,7 @@ class Page implements PageInterface
             $cache_enable = $this->header->cache_enable ?? $config->get('system.cache.enabled',
                 true);
             $twig_first = $this->header->twig_first ?? $config->get('system.pages.twig_first',
-                true);
+                false);
 
             // never cache twig means it's always run after content
             $never_cache_twig = $this->header->never_cache_twig ?? $config->get('system.pages.never_cache_twig',


### PR DESCRIPTION
I've also verified this via code, the correct default is `false`. It is also documented here:
https://learn.getgrav.org/16/basics/grav-configuration#pages