### PR TITLE
Add grav twig extensions to its own `evaluate` and `evaluate_twig` fi…

### DIFF
--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -837,6 +837,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
 
         $loader = new \Twig_Loader_Filesystem('.');
         $env = new \Twig_Environment($loader);
+        $env->addExtension($this);
 
         $template = $env->createTemplate($twig);
 


### PR DESCRIPTION
…lters

I wanted to use `evaluate_twig()` with a template the uses `theme_var()` or also a simpler twig function `string`. I made them available with this simple call.