### PR TITLE
Fixed `|safe_email` filter to return safe and escaped UTF-8 HTML [#3072]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.6.32
+## mm/dd/2021
+
+1. [](#bugfix)
+    * Fixed `|safe_email` filter to return safe and escaped UTF-8 HTML [#3072](https://github.com/getgrav/grav/issues/3072)
+
 # v1.6.31
 ## 12/14/2020
 

--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -98,7 +98,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             new \Twig_SimpleFilter('rtrim', [$this, 'rtrimFilter']),
             new \Twig_SimpleFilter('pad', [$this, 'padFilter']),
             new \Twig_SimpleFilter('regex_replace', [$this, 'regexReplace']),
-            new \Twig_SimpleFilter('safe_email', [$this, 'safeEmailFilter']),
+            new \Twig_SimpleFilter('safe_email', [$this, 'safeEmailFilter'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('safe_truncate', ['\Grav\Common\Utils', 'safeTruncate']),
             new \Twig_SimpleFilter('safe_truncate_html', ['\Grav\Common\Utils', 'safeTruncateHTML']),
             new \Twig_SimpleFilter('sort_by_key', [$this, 'sortByKeyFilter']),
@@ -232,14 +232,23 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
      */
     public function safeEmailFilter($str)
     {
-        $email   = '';
-        for ($i = 0, $len = strlen($str); $i < $len; $i++) {
-            $j = random_int(0, 1);
+        static $list = [
+            '"' => '&#34;',
+            "'" => '&#39;',
+            '&' => '&amp;',
+            '<' => '&lt;',
+            '>' => '&gt;',
+            '@' => '&#64;'
+        ];
 
-            $email .= $j === 0 ? '&#' . ord($str[$i]) . ';' : $str[$i];
+        $characters = mb_str_split($str, 1, 'UTF-8');
+
+        $encoded = '';
+        foreach ($characters as $chr) {
+            $encoded .= $list[$chr] ?? (random_int(0, 1) ? '&#' . mb_ord($chr) . ';' : $chr);
         }
 
-        return str_replace('@', '&#64;', $email);
+        return $encoded;
     }
 
     /**


### PR DESCRIPTION
Backported from 1.7:
https://github.com/getgrav/grav/commit/068de42e833af8baeb96fe31c170964fa2df0d4b