### PR TITLE
Added 'format' to magic actions for images - this will allow conversion and caching of webp images

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -53,7 +53,7 @@ class ImageMedium extends Medium
         'resize', 'forceResize', 'cropResize', 'crop', 'zoomCrop',
         'negate', 'brightness', 'contrast', 'grayscale', 'emboss',
         'smooth', 'sharp', 'edge', 'colorize', 'sepia', 'enableProgressive',
-        'rotate', 'flip', 'fixOrientation', 'gaussianBlur'
+        'rotate', 'flip', 'fixOrientation', 'gaussianBlur', 'format'
     ];
 
     /**


### PR DESCRIPTION
A very simple change that would make it possible to set the output format of an image from Twig / Markdown.

This would be particularly useful for being able to serve automatically generated webp images, created from jpegs.

Related to issue #1168 