### PR TITLE
Set twig autoescaping to true

### DIFF
--- a/user/config/system.yaml
+++ b/user/config/system.yaml
@@ -22,7 +22,7 @@ twig:
   cache: true
   debug: true
   auto_reload: true
-  autoescape: false
+  autoescape: true
 
 assets:
   css_pipeline: false


### PR DESCRIPTION
I think this value get overwritten anyways. Maybe we should remove it completely?