### PR TITLE
Fix removing inclusive filters in getCollection

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -449,12 +449,20 @@ class Pages
             }
         }
 
-        // Remove any inclusive sets from filter.
         $filters = $params['filter'] ?? [];
 
         // Assume published=true if not set.
         if (!isset($filters['published']) && !isset($filters['non-published'])) {
             $filters['published'] = true;
+        }
+
+        // Remove any inclusive sets from filter.
+        $sets = ['published', 'visible', 'modular', 'routable'];
+        foreach ($sets as $type) {
+            $var = "non-{$type}";
+            if (isset($filters[$type], $filters[$var]) && $filters[$type] && $filters[$var]) {
+                unset($filters[$type], $filters[$var]);
+            }
         }
 
         // Filter the collection


### PR DESCRIPTION
In Grav 1.6.31, a collection like this:
```
items:
  - '@root.descendants'
filter:
  published: true
  non-published: true
```
...catches all pages, published or not. This is thanks to the removal of inclusive sets before they are parsed.

It seems that sometime during the refactoring done in Grav 1.7, this removal of inclusive sets had gone missing. As a result, a collection like above first filters out non-published pages, then the published ones, and ends up empty. This pull request aims to fix that.

Bottom line, I think that this issue deserves a fairly high-priority fixing, as I'd imagine that [this](https://github.com/newbthenewbd/grav-plugin-tinymce-editor/issues/25) isn't the only workflow around that it is capable of breaking...

Thank You!