### PR TITLE
read all language files from theme stream

### DIFF
--- a/system/src/Grav/Common/Themes.php
+++ b/system/src/Grav/Common/Themes.php
@@ -318,6 +318,7 @@ class Themes extends Iterator
 
     /**
      * Load theme languages.
+     * Reads ALL language files from theme stream and merges them.
      *
      * @param Config $config Configuration class
      * @return void
@@ -328,13 +329,13 @@ class Themes extends Iterator
         $locator = $this->grav['locator'];
 
         if ($config->get('system.languages.translations', true)) {
-            $language_file = $locator->findResource('theme://languages' . YAML_EXT);
-            if ($language_file) {
+            $language_files = array_reverse($locator->findResources('theme://languages' . YAML_EXT));
+            foreach ($language_files as $language_file) {
                 $language = CompiledYamlFile::instance($language_file)->content();
                 $this->grav['languages']->mergeRecursive($language);
             }
-            $languages_folder = $locator->findResource('theme://languages');
-            if (file_exists($languages_folder)) {
+            $languages_folders = array_reverse($locator->findResources('theme://languages'));
+            foreach ($languages_folders as $languages_folder) {
                 $languages = [];
                 $iterator = new DirectoryIterator($languages_folder);
                 foreach ($iterator as $file) {


### PR DESCRIPTION
Currently when inheriting a theme and creating language files in the child theme, they will override the language files of the base theme. There is no chance to extend from the base theme language files other than copying them. This leads to a lot of manual syncing effort when updating the base theme.
```
themes
- child-theme
-- languages.yaml

- base-theme
-- languages.yaml <- content never loaded
```

I changed the language file loading to read language files from all themes in `theme://`.

This might be interesting for @lazybadger.