### PR TITLE
Fix setting default <img> 'loading' attribute in Markdown

### DIFF
--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -278,7 +278,7 @@ class Excerpts
             );
         }
 
-        $defaults = $config['images']['defaults'] ?? [];
+        $defaults = $this->config['images']['defaults'] ?? [];
         if (count($defaults)) {
             foreach ($defaults as $method => $params) {
                 if (!array_search($method, array_column($actions, 'method'))) {


### PR DESCRIPTION
Commit [148117e](https://github.com/pamtbaau/grav/commit/148117edcbbe57c0567889e3a24dae2259834387#diff-3fe51af60458d36da946068baa26a3285b819117e90f0a393ccfbff77e58d9b4) is supposed to add default `loading` attribute to images using the value from config `system.images.defaults.loading`

A fix has already been applied for the application in Twig, but it appears the commit also contains an issue for Markdown. When parsing ![](), code now references non existing variable `$config['images']['defaults']`, and should be `$this->config['images']['defaults']`