### PR TITLE
Fix Markdown image attr. 'loading'

### DIFF
--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -278,10 +278,10 @@ class Excerpts
             );
         }
 
-        $defaults = $config['images']['defaults'] ?? [];
+        $defaults = $this->config['images']['defaults'] ?? [];
         if (count($defaults)) {
             foreach ($defaults as $method => $params) {
-                if (!array_search($method, array_column($actions, 'method'))) {
+                if (array_search($method, array_column($actions, 'method')) === false) {
                     $actions[] = [
                         'method' => $method,
                         'params' => $params,

--- a/tests/unit/Grav/Common/Markdown/ParsedownTest.php
+++ b/tests/unit/Grav/Common/Markdown/ParsedownTest.php
@@ -240,6 +240,46 @@ class ParsedownTest extends \Codeception\TestCase\Test
         );
     }
 
+    public function testImagesDefaults(): void
+    {
+        /**
+         * Testing default 'loading'
+        */
+
+        $this->setImagesDefaults(['loading' => 'auto']);
+
+        // loading should NOT be added to image by default
+        self::assertSame(
+            '<p><img alt="" src="/tests/fake/nested-site/user/pages/02.item2/02.item2-2/sample-image.jpg" /></p>',
+            $this->parsedown->text('![](sample-image.jpg)')
+        );
+
+        // loading="lazy" should be added when default is overridden by ?loading=lazy
+        self::assertSame(
+            '<p><img loading="lazy" alt="" src="/tests/fake/nested-site/user/pages/02.item2/02.item2-2/sample-image.jpg" /></p>',
+            $this->parsedown->text('![](sample-image.jpg?loading=lazy)')
+        );
+
+        $this->setImagesDefaults(['loading' => 'lazy']);
+
+        // loading="lazy" should be added by default
+        self::assertSame(
+            '<p><img loading="lazy" alt="" src="/tests/fake/nested-site/user/pages/02.item2/02.item2-2/sample-image.jpg" /></p>',
+            $this->parsedown->text('![](sample-image.jpg)')
+        );
+
+        // loading should not be added when default is overridden by ?loading=auto
+        self::assertSame(
+            '<p><img alt="" src="/tests/fake/nested-site/user/pages/02.item2/02.item2-2/sample-image.jpg" /></p>',
+            $this->parsedown->text('![](sample-image.jpg?loading=auto)')
+        );
+
+        // loading="eager" should be added when default is overridden by ?loading=eager
+        self::assertSame(
+            '<p><img loading="eager" alt="" src="/tests/fake/nested-site/user/pages/02.item2/02.item2-2/sample-image.jpg" /></p>',
+            $this->parsedown->text('![](sample-image.jpg?loading=eager)')
+        );
+    }
 
     public function testRootImages(): void
     {
@@ -1125,5 +1165,16 @@ class ParsedownTest extends \Codeception\TestCase\Test
     private function stripLeadingWhitespace($string)
     {
         return preg_replace('/^\s*(.*)/', '', $string);
+    }
+
+    private function setImagesDefaults($defaults) {
+        $defaults = [
+            'images' => [
+                'defaults' => $defaults
+            ],
+        ];
+        $page = $this->pages->find('/item2/item2-2');
+        $excerpts = new Excerpts($page, $defaults);
+        $this->parsedown = new Parsedown($excerpts);
     }
 }


### PR DESCRIPTION
There are 2 issues in `grav/common/page/markdown/Excerpts::processMediaActions()` that prevents the `loading` attribute for images to be set properly in Markdown.

1. Line 281: `$defaults = $config['images']['defaults'] ?? [];`
   Config settings are not picked up.
   - Should be `$defaults = $this->config['images']['defaults'] ?? [];`
2.  Line 284: `if (!array_search($method, array_column($actions, 'method'))) {`
   `array_search` returns (in above use) an `int`, or `false`. When value is found at position `0` the negation will return `true` and hence, explicit value set in Markdown will be overridden by value from config.
    - Should use strict comparison: `if (array_search($method, array_column($actions, 'method')) === false) {`