### PR TITLE
Add SRI integrity hash to assets

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -1005,6 +1005,17 @@ form:
                 0: PLUGIN_ADMIN.NO
               validate:
                 type: bool
+                
+            assets.enable_asset_sri:
+              type: toggle
+              label: PLUGIN_ADMIN.ENABLED_SRI_ON_ASSETS
+              help: PLUGIN_ADMIN.ENABLED_SRI_ON_ASSETS_HELP
+              highlight: 0
+              options:
+                1: PLUGIN_ADMIN.YES
+                0: PLUGIN_ADMIN.NO
+              validate:
+                type: bool
 
             assets.collections:
               type: multilevel

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -127,6 +127,7 @@ assets:                                          # Configuration for Assets Mana
   js_pipeline_before_excludes: true              # Render the pipeline before any excluded files
   js_minify: true                                # Minify the JS during pipelining
   enable_asset_timestamp: false                  # Enable asset timestamps
+  enable_asset_sri: false                        # Enable asset SRI
   collections:
     jquery: system://assets/jquery/jquery-2.x.min.js
 

--- a/system/src/Grav/Common/Assets/BaseAsset.php
+++ b/system/src/Grav/Common/Assets/BaseAsset.php
@@ -180,7 +180,7 @@ abstract class BaseAsset extends PropertyObject
      *
      * @return string
      */
-    public function integrityHash( $input )
+    public static function integrityHash( $input )
     {
         $grav = Grav::instance();
 

--- a/system/src/Grav/Common/Assets/BaseAsset.php
+++ b/system/src/Grav/Common/Assets/BaseAsset.php
@@ -10,6 +10,7 @@
 namespace Grav\Common\Assets;
 
 use Grav\Common\Assets\Traits\AssetUtilsTrait;
+use Grav\Common\Config\Config;
 use Grav\Common\Grav;
 use Grav\Common\Uri;
 use Grav\Common\Utils;
@@ -170,6 +171,31 @@ abstract class BaseAsset extends PropertyObject
         $this->position = $position;
 
         return $this;
+    }
+    
+    /**
+     * Receive asset location and return the SRI integrity hash
+     * 
+     * @param $input
+     *
+     * @return string
+     */
+    protected function integrityHash( $input )
+    {
+        $grav = Grav::instance();
+
+        $assetsConfig = $grav['config']->get('system.assets');
+
+        if ( !empty($assetsConfig['enable_asset_sri']) && $assetsConfig['enable_asset_sri'] )
+        {
+            $dataToHash = file_get_contents( GRAV_ROOT . $input);
+
+            $hash = hash('sha256', $dataToHash, true);
+            $hash_base64 = base64_encode($hash);
+            return ' integrity="sha256-' . $hash_base64 . '"';
+        }
+
+        return '';
     }
 
 

--- a/system/src/Grav/Common/Assets/BaseAsset.php
+++ b/system/src/Grav/Common/Assets/BaseAsset.php
@@ -180,7 +180,7 @@ abstract class BaseAsset extends PropertyObject
      *
      * @return string
      */
-    protected function integrityHash( $input )
+    public function integrityHash( $input )
     {
         $grav = Grav::instance();
 

--- a/system/src/Grav/Common/Assets/Css.php
+++ b/system/src/Grav/Common/Assets/Css.php
@@ -47,6 +47,6 @@ class Css extends BaseAsset
             return "<style>\n" . trim($buffer) . "\n</style>\n";
         }
 
-        return '<link href="' . trim($this->asset) . $this->renderQueryString() . '"' . $this->renderAttributes() . ">\n";
+        return '<link href="' . trim($this->asset) . $this->renderQueryString() . '"' . $this->renderAttributes() . $this->integrityHash($this->asset) . ">\n";
     }
 }

--- a/system/src/Grav/Common/Assets/Js.php
+++ b/system/src/Grav/Common/Assets/Js.php
@@ -43,6 +43,6 @@ class Js extends BaseAsset
             return '<script' . $this->renderAttributes() . ">\n" . trim($buffer) . "\n</script>\n";
         }
 
-        return '<script src="' . trim($this->asset) . $this->renderQueryString() . '"' . $this->renderAttributes() . "></script>\n";
+        return '<script src="' . trim($this->asset) . $this->renderQueryString() . '"' . $this->renderAttributes() . $this->integrityHash($this->asset) . "></script>\n";
     }
 }

--- a/system/src/Grav/Common/Assets/Pipeline.php
+++ b/system/src/Grav/Common/Assets/Pipeline.php
@@ -9,6 +9,7 @@
 
 namespace Grav\Common\Assets;
 
+use Grav\Common\Assets\BaseAsset;
 use Grav\Common\Assets\Traits\AssetUtilsTrait;
 use Grav\Common\Config\Config;
 use Grav\Common\Grav;
@@ -148,7 +149,7 @@ class Pipeline extends PropertyObject
             $output = "<style>\n" . $buffer . "\n</style>\n";
         } else {
             $this->asset = $relative_path;
-            $output = '<link href="' . $relative_path . $this->renderQueryString() . '"' . $this->renderAttributes() . ">\n";
+            $output = '<link href="' . $relative_path . $this->renderQueryString() . '"' . $this->renderAttributes() . BaseAsset::integrityHash($this->asset) . ">\n";
         }
 
         return $output;
@@ -211,7 +212,7 @@ class Pipeline extends PropertyObject
             $output = '<script' . $this->renderAttributes(). ">\n" . $buffer . "\n</script>\n";
         } else {
             $this->asset = $relative_path;
-            $output = '<script src="' . $relative_path . $this->renderQueryString() . '"' . $this->renderAttributes() . "></script>\n";
+            $output = '<script src="' . $relative_path . $this->renderQueryString() . '"' . $this->renderAttributes() . BaseAsset::integrityHash($this->asset) . "></script>\n";
         }
 
         return $output;


### PR DESCRIPTION
Having the website pre-generated and hosted on a CDN, I would like to have integrity hashes included in CSS and JS assets.

This PR will allow:
* User to set if wants the integrity hash to be generated and added to their <script> and <link> elements
    *  controlled via new `system.assets.enable_asset_sri` config option
* When true, this option will generate the integrity hash and add it to both pipelined and not pipelined assets