### PR TITLE
Correct width and height after image manipulation

### DIFF
--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -310,7 +310,7 @@ class ImageMedium extends Medium implements ImageMediaInterface, ImageManipulate
 
             if (isset(static::$magic_resize_actions[$method])) {
                 try {
-                    $image = $this->image->get('guess', $this->default_quality);
+                    $this->image->get('guess', 1);
 
                     $this->set('width', $this->image->width());
                     $this->set('height', $this->image->height());

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -308,10 +308,16 @@ class ImageMedium extends Medium implements ImageMediaInterface, ImageManipulate
             $this->image->{$method}(...$args);
 
             if (isset(static::$magic_resize_actions[$method])) {
-                $this->image->get('guess', $this->default_quality);
+                try {
+                    $image = $this->image->get('guess', $this->default_quality);
 
-                $this->set('width', $this->image->width());
-                $this->set('height', $this->image->height());
+                    $this->set('width', $this->image->width());
+                    $this->set('height', $this->image->height());
+                } catch (ErrorException $exception) {
+                    // Image most likely was deleted from page, but page was not saved
+                    // Lets do nothing about it and just ignore that image
+                    // Once page is saved, everything goes back to normal
+                }
             }
 
             /** @var ImageMediaInterface $medium */

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -307,6 +307,13 @@ class ImageMedium extends Medium implements ImageMediaInterface, ImageManipulate
         try {
             $this->image->{$method}(...$args);
 
+            if (isset(static::$magic_resize_actions[$method])) {
+                $this->image->get('guess', $this->default_quality);
+
+                $this->set('width', $this->image->width());
+                $this->set('height', $this->image->height());
+            }
+
             /** @var ImageMediaInterface $medium */
             foreach ($this->alternatives as $medium) {
                 $args_copy = $args;

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -310,7 +310,7 @@ class ImageMedium extends Medium implements ImageMediaInterface, ImageManipulate
 
             if (isset(static::$magic_resize_actions[$method])) {
                 try {
-                    $this->image->get('guess', 1);
+                    $this->image->get('guess', $this->default_quality);
 
                     $this->set('width', $this->image->width());
                     $this->set('height', $this->image->height());

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -18,6 +18,7 @@ use Grav\Common\Media\Traits\ImageLoadingTrait;
 use Grav\Common\Media\Traits\ImageMediaTrait;
 use Grav\Common\Utils;
 use RocketTheme\Toolbox\ResourceLocator\UniformResourceLocator;
+use Whoops\Exception\ErrorException;
 use function func_get_args;
 use function in_array;
 


### PR DESCRIPTION
I have various size images (both horizontal and vertical). All are at least 1900px on longest side (some 2000px)
```twig
{% set image = item.cropResize(1600, 1600) %}
{{ image.width ~ 'x' ~ image.height }}
```
Result is something like `2000x1350` or `1200x1900`, but it should be 1600 on longest side

Debugged a bit and found the solution, but was afraid, that calling ` $this->image->get()` to actually save the image to get correct dimensions might not be the way. Searched a bit and found [this issue on Gregwar/Image](https://github.com/Gregwar/Image/issues/123) and there's [a fix and a comment](https://github.com/Gregwar/Image/issues/123#ref-commit-948240d) from Gregwar, that this is the way.

This change will cache image with default quality from config and return correct cropped/resized dimensions