### PR TITLE
GRAV_USER_PATH & USER_PATH may start with '/'

### DIFF
--- a/system/src/Grav/Common/Config/Setup.php
+++ b/system/src/Grav/Common/Config/Setup.php
@@ -208,7 +208,7 @@ class Setup extends Data
         } else {
             $setupFile = GRAV_WEBROOT . '/setup.php';
             if (!is_file($setupFile)) {
-                $setupFile = GRAV_WEBROOT . '/' . GRAV_USER_PATH . '/setup.php';
+                $setupFile = USER_DIR . 'setup.php';
             }
             if (!is_file($setupFile)) {
                 $setupFile = null;
@@ -236,7 +236,7 @@ class Setup extends Data
                 $envPath .= '/';
             } else {
                 // Use default location. Start with Grav 1.7 default.
-                $envPath = GRAV_WEBROOT. '/' . GRAV_USER_PATH . '/env';
+                $envPath = USER_DIR . 'env';
                 if (is_dir($envPath)) {
                     $envPath = 'user://env/';
                 } else {

--- a/system/src/Grav/Console/Cli/InstallCommand.php
+++ b/system/src/Grav/Console/Cli/InstallCommand.php
@@ -77,7 +77,7 @@ class InstallCommand extends GravCommand
 
         // fix trailing slash
         $this->destination = rtrim($this->destination, DS) . DS;
-        $this->user_path = $this->destination . USER_PATH;
+        $this->user_path = (str_starts_with(USER_PATH, DS) ? '' : $this->destination) . USER_PATH;
         if ($local_config_file = $this->loadLocalConfig()) {
             $io->writeln('Read local config from <cyan>' . $local_config_file . '</cyan>');
         }


### PR DESCRIPTION
I'm not 100% sure but maybe I spotted a few locations where the new fact that paths (like e.g. GRAV_USER_PATH) might start with a `/`.

Please mind that I was not able to test these changes. Especially the change in `InstallCommand.php` may have side effects that I cannot foresee.