### PR TITLE
query-string redirection, fix #3320

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -320,7 +320,7 @@ class Grav extends Container
         $route = preg_replace("#^\/[\\\/]+\/#", '/', $route);
 
          // Check for code in route
-        $regex = '/.*(\[(30[1-7])\])$/';
+        $regex = '/.*(\[(30[1-7])\])(?:$|\?.*)/';
         preg_match($regex, $route, $matches);
         if ($matches) {
             $route = str_replace($matches[1], '', $matches[0]);


### PR DESCRIPTION
Consider the presence of a query-string in the source URL when looking to extract a redirection code

So that with:

```yaml
redirects:
  /foo-2019: '/foo[301]'
```

`/foo-2019?bar` now redirects to `/foo?bar` instead of `/foo[301]?bar`

fix #3320