### PR TITLE
daterange - allow optionnal start date

### DIFF
--- a/system/src/Grav/Common/Flex/Types/Pages/PageCollection.php
+++ b/system/src/Grav/Common/Flex/Types/Pages/PageCollection.php
@@ -438,7 +438,7 @@ class PageCollection extends FlexPageCollection implements PageCollectionInterfa
      */
     public function dateRange($startDate, $endDate = false, $field = null)
     {
-        $start = Utils::date2timestamp($startDate);
+        $start = $startDate ? Utils::date2timestamp($startDate) : false;
         $end = $endDate ? Utils::date2timestamp($endDate) : false;
 
         $entries = [];
@@ -449,7 +449,7 @@ class PageCollection extends FlexPageCollection implements PageCollectionInterfa
 
             $date = $field ? strtotime($object->getNestedProperty($field)) : $object->date();
 
-            if ($date >= $start && (!$end || $date <= $end)) {
+            if ((!$start || $date >= $start) && (!$end || $date <= $end)) {
                 $entries[$key] = $object;
             }
         }

--- a/system/src/Grav/Common/Flex/Types/Pages/PageCollection.php
+++ b/system/src/Grav/Common/Flex/Types/Pages/PageCollection.php
@@ -426,17 +426,17 @@ class PageCollection extends FlexPageCollection implements PageCollectionInterfa
 
     /**
      * Returns the items between a set of date ranges of either the page date field (default) or
-     * an arbitrary datetime page field where end date is optional
-     * Dates can be passed in as text that strtotime() can process
+     * an arbitrary datetime page field where start date and end date are optional
+     * Dates must be passed in as text that strtotime() can process
      * http://php.net/manual/en/function.strtotime.php
      *
-     * @param string $startDate
-     * @param string|false $endDate
+     * @param string|null $startDate
+     * @param string|null $endDate
      * @param string|null $field
-     * @return static
+     * @return PageCollectionInterface
      * @throws Exception
      */
-    public function dateRange($startDate, $endDate = false, $field = null)
+    public function dateRange($startDate = null, $endDate = null, $field = null)
     {
         $start = $startDate ? Utils::date2timestamp($startDate) : false;
         $end = $endDate ? Utils::date2timestamp($endDate) : false;

--- a/system/src/Grav/Common/Flex/Types/Pages/PageIndex.php
+++ b/system/src/Grav/Common/Flex/Types/Pages/PageIndex.php
@@ -949,17 +949,17 @@ class PageIndex extends FlexPageIndex implements PageCollectionInterface
 
     /**
      * Returns the items between a set of date ranges of either the page date field (default) or
-     * an arbitrary datetime page field where end date is optional
-     * Dates can be passed in as text that strtotime() can process
+     * an arbitrary datetime page field where start date and end date are optional
+     * Dates must be passed in as text that strtotime() can process
      * http://php.net/manual/en/function.strtotime.php
      *
-     * @param string $startDate
-     * @param bool $endDate
+     * @param string|null $startDate
+     * @param string|null $endDate
      * @param string|null $field
-     * @return static
+     * @return PageCollectionInterface
      * @throws Exception
      */
-    public function dateRange($startDate, $endDate = false, $field = null)
+    public function dateRange($startDate = null, $endDate = null, $field = null)
     {
         $collection = $this->__call('dateRange', [$startDate, $endDate, $field]);
 

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -331,7 +331,7 @@ class Collection extends Iterator implements PageCollectionInterface
      */
     public function dateRange($startDate, $endDate = false, $field = null)
     {
-        $start = Utils::date2timestamp($startDate);
+        $start = $startDate ? Utils::date2timestamp($startDate) : false;
         $end = $endDate ? Utils::date2timestamp($endDate) : false;
 
         $date_range = [];
@@ -340,7 +340,7 @@ class Collection extends Iterator implements PageCollectionInterface
             if ($page !== null) {
                 $date = $field ? strtotime($page->value($field)) : $page->date();
 
-                if ($date >= $start && (!$end || $date <= $end)) {
+                if ((!$start || $date >= $start) && (!$end || $date <= $end)) {
                     $date_range[$path] = $slug;
                 }
             }

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -319,17 +319,17 @@ class Collection extends Iterator implements PageCollectionInterface
 
     /**
      * Returns the items between a set of date ranges of either the page date field (default) or
-     * an arbitrary datetime page field where end date is optional
-     * Dates can be passed in as text that strtotime() can process
+     * an arbitrary datetime page field where start date and end date are optional
+     * Dates must be passed in as text that strtotime() can process
      * http://php.net/manual/en/function.strtotime.php
      *
-     * @param string $startDate
-     * @param bool $endDate
+     * @param string|null $startDate
+     * @param string|null $endDate
      * @param string|null $field
-     * @return $this
+     * @return PageCollectionInterface
      * @throws Exception
      */
-    public function dateRange($startDate, $endDate = false, $field = null)
+    public function dateRange($startDate = null, $endDate = null, $field = null)
     {
         $start = $startDate ? Utils::date2timestamp($startDate) : false;
         $end = $endDate ? Utils::date2timestamp($endDate) : false;

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -337,12 +337,14 @@ class Collection extends Iterator implements PageCollectionInterface
         $date_range = [];
         foreach ($this->items as $path => $slug) {
             $page = $this->pages->get($path);
-            if ($page !== null) {
-                $date = $field ? strtotime($page->value($field)) : $page->date();
+            if (!$page) {
+                continue ;
+            }
 
-                if ((!$start || $date >= $start) && (!$end || $date <= $end)) {
-                    $date_range[$path] = $slug;
-                }
+            $date = $field ? strtotime($page->value($field)) : $page->date();
+
+            if ((!$start || $date >= $start) && (!$end || $date <= $end)) {
+                $date_range[$path] = $slug;
             }
         }
 

--- a/system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php
+++ b/system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php
@@ -158,17 +158,17 @@ interface PageCollectionInterface extends Traversable, ArrayAccess, Countable, S
 
     /**
      * Returns the items between a set of date ranges of either the page date field (default) or
-     * an arbitrary datetime page field where end date is optional
-     * Dates can be passed in as text that strtotime() can process
+     * an arbitrary datetime page field where start date and end date are optional
+     * Dates must be passed in as text that strtotime() can process
      * http://php.net/manual/en/function.strtotime.php
      *
-     * @param string $startDate
-     * @param bool $endDate
+     * @param string|null $startDate
+     * @param string|null $endDate
      * @param string|null $field
      * @return PageCollectionInterface
      * @throws Exception
      */
-    public function dateRange($startDate, $endDate = false, $field = null);
+    public function dateRange($startDate = null, $endDate = null, $field = null);
 
     /**
      * Creates new collection with only visible pages

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -540,9 +540,9 @@ class Pages
         }
 
         if (isset($params['dateRange'])) {
-            $start = $params['dateRange']['start'] ?? 0;
-            $end = $params['dateRange']['end'] ?? false;
-            $field = $params['dateRange']['field'] ?? false;
+            $start = $params['dateRange']['start'] ?? null;
+            $end = $params['dateRange']['end'] ?? null;
+            $field = $params['dateRange']['field'] ?? null;
             $collection = $collection->dateRange($start, $end, $field);
         }
 


### PR DESCRIPTION
While testing dateRange filtering for collection, I encountered error when the start value is not specified (see #3345 for the issue).

After looking deeper in the source code, I found that the method dateRange() come from an interface and has three implementations and the fix I submited in the issue was not complete. That's why I submit this pull request.

I've divided the fix into three commit so you may discard some of them :
* First commit deal only with the fix of behaviour and touch only minimum lines of codes,
* Second commit simplify a little bit the code,
* Third commit is about the interface (method definition) : using null instead of false (as the behaviour is not specified if you pass true`), updating the documentation of the code (and synchronize the documentation accross all implemtnations) and fixing the only part of the code that call the method (with null instead of a mix of 0, false and null).

As 0, null and false have the same behaviour, the new version is retro-compatible with hypothetical legacy plugins that use the method.

The code have been manually tested on page collection with a fresh install of the fork and default theme :

* Three pages, one in the pase (1800's), one in the present (2000's) and one in the future (2200's),
* Test with start only, end only, both set,
* Same test but with the field attribute specified.