### PR TITLE
Automatic docker image generation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,4 +33,4 @@ jobs:
           push: true
           context: .
           tags: |
-            ghcr.io/23technologies/grav:latest
+            ghcr.io/${{ github.repository_owner }}/grav:latest


### PR DESCRIPTION
This commit contains the GitHub workflow which is triggered when something is pushed to the master branch. 
It checks out the getgrav/docker-grav repository and builds the docker image. 
Afterwards, the image is uploaded to ghcr.io/getgrav/grav:latest
