### PR TITLE
Return false instead of Collection if adjacent item not found

### DIFF
--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -264,7 +264,7 @@ class Collection extends Iterator implements PageCollectionInterface
      *
      * @param  string $path
      *
-     * @return PageInterface  The previous item.
+     * @return PageInterface|false The previous item.
      */
     public function prevSibling($path)
     {
@@ -276,7 +276,7 @@ class Collection extends Iterator implements PageCollectionInterface
      *
      * @param  string $path
      *
-     * @return PageInterface The next item.
+     * @return PageInterface|false The next item.
      */
     public function nextSibling($path)
     {
@@ -288,7 +288,7 @@ class Collection extends Iterator implements PageCollectionInterface
      *
      * @param  string  $path
      * @param  int $direction either -1 or +1
-     * @return PageInterface|Collection    The sibling item.
+     * @return PageInterface|false The sibling item.
      */
     public function adjacentSibling($path, $direction = 1)
     {
@@ -298,10 +298,10 @@ class Collection extends Iterator implements PageCollectionInterface
         if (array_key_exists($path, $keys)) {
             $index = $keys[$path] - $direction;
 
-            return isset($values[$index]) ? $this->offsetGet($values[$index]) : $this;
+            return isset($values[$index]) ? $this->offsetGet($values[$index]) : false;
         }
 
-        return $this;
+        return false;
     }
 
     /**

--- a/system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php
+++ b/system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php
@@ -127,7 +127,7 @@ interface PageCollectionInterface extends Traversable, ArrayAccess, Countable, S
      * Gets the previous sibling based on current position.
      *
      * @param  string $path
-     * @return PageInterface  The previous item.
+     * @return PageInterface|false The previous item.
      */
     public function prevSibling($path);
 
@@ -135,7 +135,7 @@ interface PageCollectionInterface extends Traversable, ArrayAccess, Countable, S
      * Gets the next sibling based on current position.
      *
      * @param  string $path
-     * @return PageInterface The next item.
+     * @return PageInterface|false The next item.
      */
     public function nextSibling($path);
 
@@ -144,7 +144,7 @@ interface PageCollectionInterface extends Traversable, ArrayAccess, Countable, S
      *
      * @param  string  $path
      * @param  int $direction either -1 or +1
-     * @return PageInterface|PageCollectionInterface|false    The sibling item.
+     * @return PageInterface|false The sibling item.
      */
     public function adjacentSibling($path, $direction = 1);
 


### PR DESCRIPTION
_/system/src/Grav/Common/Page/Collection.php::adjacentSibling()_ could return back the whole _Collection_ if previous or next sibling is not found. All other places in such case expect to return `false`. 

Closes #3396