### PR TITLE
Add `setCurrent()` method to Page Collection

### DIFF
--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -152,7 +152,7 @@ class Collection extends Iterator implements PageCollectionInterface
     {
         reset($this->items);
 
-        while (key($this->items) !== $path && key($this->items) !== null) {
+        while (($key = key($this->items)) !== null && $key !== $path) {
             next($this->items);
         }
     }

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -146,6 +146,18 @@ class Collection extends Iterator implements PageCollectionInterface
     }
 
     /**
+     * Set current page.
+     */
+    public function setCurrent(string $path): void
+    {
+        reset($this->items);
+
+        while (key($this->items) !== $path && key($this->items) !== null) {
+            next($this->items);
+        }
+    }
+
+    /**
      * Returns current page.
      *
      * @return PageInterface


### PR DESCRIPTION
Lets us have a workaround for #531
Also was [a discussion on Discourse](https://discourse.getgrav.org/t/page-prevsibling-nextsibling-inverted/17248/17)

This new method would allow to have expected (not inversed) `prev` and `next` items of the collection in Twig
Eg.:
```twig
    {% set collection = page.parent.collection({items: '@self.children', filter: {published: true, routable: true}}) %}
    {% set isFirst = collection.isFirst(page.path) %}
    {% set isLast = collection.isLast(page.path) %}

    <section>
        {% if not isFirst %}
            {% do collection.setCurrent(page.path) or collection.prev %}
            <a href="{{ collection.current.url }}">Previous page</a>
        {% endif %}

        {% if not isLast %}
            {% do collection.setCurrent(page.path) or collection.next %}
            <a href="{{ collection.current.url }}">Next page</a>
        {% endif %}
    </section>
```