### PR TITLE
fix typo mime type of `.aif`

### DIFF
--- a/system/config/media.yaml
+++ b/system/config/media.yaml
@@ -91,7 +91,7 @@ types:
   aif:
     type: audio
     thumb: media/thumb-aif.png
-    mime: audio/aif
+    mime: audio/aiff
   txt:
     type: file
     thumb: media/thumb-txt.png


### PR DESCRIPTION
mime type should be `audio/aiff`
reference: https://en.wikipedia.org/wiki/Audio_Interchange_File_Format