### PR TITLE
add mime for `.avif` image format

### DIFF
--- a/system/config/media.yaml
+++ b/system/config/media.yaml
@@ -28,6 +28,10 @@ types:
     type: image
     thumb: media/thumb-webp.png
     mime: image/webp
+  avif:
+    type: image
+    thumb: media/thumb.png
+    mime: image/avif
   gif:
     type: animated
     thumb: media/thumb-gif.png


### PR DESCRIPTION
new image format developed by google

references:
https://codelabs.developers.google.com/codelabs/avif#0
https://caniuse.com/avif

@rhukster Is `type: image` automatically processed? If yes and there is no additional check for supported image formats it may cause issues. The support for `avif` by `gd` is not yet available. Maybe with php8.1.