### PR TITLE
fix `session_store_active` functionality

### DIFF
--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -105,11 +105,11 @@ class InitializeProcessor extends ProcessorBase
         // TODO: remove in 2.0.
         $this->container['accounts'];
 
+        // Initialize session (used by URI, see issue #3269).
+        $this->initializeSession($config);
+
         // Initialize URI (uses session, see issue #3269).
         $this->initializeUri($config);
-
-        // Initialize session.
-        $this->initializeSession($config);
 
         // Grav may return redirect response right away.
         $redirectCode = (int)$config->get('system.pages.redirect_trailing_slash', 1);


### PR DESCRIPTION
At the moment and since 1.7.19, the `system.languages.session_store_active` setting has no effect.

Session must be initialized before URI for `$language->setActiveFromUri($uri)` (called from `$this->initializeUri($config) -> $uri->init()`) to properly retrieve / store `active_language` in Session.

This was previously detected in #3269 as per the code comment, but got reversed in 2e9fe80e33b1f6a80b061239fe2f425aa1f54b06.