### PR TITLE
[fix] Multisite issue when using `find` function

### DIFF
--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -957,6 +957,7 @@ class Pages
     public function find($route, $all = false)
     {
         $route = urldecode((string)$route);
+        $route = str_replace($this->base, '', $route);
 
         // Fetch page if there's a defined route to it.
         $path = $this->routes[$route] ?? null;


### PR DESCRIPTION
When running multisite with subfolder, the route includes the subfolder. The `find` function returns `null` since it only needs the page route, without the subfolder.

This commit removes that subfolder as `$this->base`, which fixes the route on multisite with subfolder.

This has been tested on multisite with Grav v1.7.30 and Flex Objects