### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,13 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: write # for release creation (svenstaro/upload-release-action)
+
     if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
 
@@ -52,6 +57,9 @@ jobs:
           file_glob: true
 
   slack:
+    permissions:
+      actions: read # to list jobs for workflow run (technote-space/workflow-conclusion-action)
+
     name: Slack
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
 
   unit-tests:

--- a/.github/workflows/trigger-skeletons.yml
+++ b/.github/workflows/trigger-skeletons.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: true
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.