### PR TITLE
Fixed too few arguments exception thrown in the admin with using flex objects

### DIFF
--- a/system/src/Grav/Common/Flex/Types/Pages/PageIndex.php
+++ b/system/src/Grav/Common/Flex/Types/Pages/PageIndex.php
@@ -1141,7 +1141,7 @@ class PageIndex extends FlexPageIndex implements PageCollectionInterface
      */
     public function ofType($type)
     {
-        $collection = $this->__call('ofType', []);
+        $collection = $this->__call('ofType', [$type]);
 
         return $collection;
     }
@@ -1155,7 +1155,7 @@ class PageIndex extends FlexPageIndex implements PageCollectionInterface
      */
     public function ofOneOfTheseTypes($types)
     {
-        $collection = $this->__call('ofOneOfTheseTypes', []);
+        $collection = $this->__call('ofOneOfTheseTypes', [$types]);
 
         return $collection;
     }
@@ -1169,7 +1169,7 @@ class PageIndex extends FlexPageIndex implements PageCollectionInterface
      */
     public function ofOneOfTheseAccessLevels($accessLevels)
     {
-        $collection = $this->__call('ofOneOfTheseAccessLevels', []);
+        $collection = $this->__call('ofOneOfTheseAccessLevels', [$accessLevels]);
 
         return $collection;
     }


### PR DESCRIPTION
https://github.com/getgrav/grav/issues/3657

The following methods from the  Grav\Common\Flex\Types\Pages\PageIndex object do not work as expected in Admin. 
* public function ofType($type)
* public function ofOneOfTheseTypes($types)
* public function ofOneOfTheseAccessLevels($accessLevels)

### Preconditions and environment
1. Grav CMS v1.7.37.1
2. PHP 7.4

### Steps to reproduce
1. Load the Pages Collection of type 'default’ in the admin using the following code `$grav['flex']->getCollection('pages')->ofType('default’)`

### Expected Result
The collection `Grav\Common\Flex\Types\Pages\PageCollection` is loaded with all the pages of a type ‘default’. 

### Actual Result
`Too few arguments to function Grav\Common\Flex\Types\Pages\PageCollection::ofType(), 0 passed in grav-cms/system/src/Grav/Framework/Flex/FlexIndex.php on line 489 and exactly 1 expected`
