### PR TITLE
Correcting comment about custom site.yaml value

### DIFF
--- a/system/config/site.yaml
+++ b/system/config/site.yaml
@@ -25,7 +25,7 @@ routes:
 #  '/new/(.*)': '/blog/$1'                  # Regex any /new/my-page URL to /blog/my-page Route
 
 blog:
-  route: '/blog'                            # Custom value added (accessible via system.blog.route)
+  route: '/blog'                            # Custom value added (accessible via site.blog.route)
 
 #menu:                                      # Menu Example
 #    - text: Source


### PR DESCRIPTION
Corrected blog: route: '/blog' comment from system.blog.route to site.blog.route