### PR TITLE
Update php-fpm socket file to use generic socket file

### DIFF
--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -30,7 +30,7 @@ server {
     ## Begin - PHP
     location ~ \.php$ {
         # Choose either a socket or TCP/IP address
-        fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php-fpm.sock;
         # fastcgi_pass unix:/var/run/php5-fpm.sock; #legacy
         # fastcgi_pass 127.0.0.1:9000;
 


### PR DESCRIPTION
I've had to manually change this on recent installs on Debian Ubuntu and Arch. All php-fpm packages (That I have observed) create a generic php-fpm.sock file which symlinks to the latest installed PHP version. 

PHP 7.X is EOL so I believe this should be a trivial change.