### PR TITLE
Fix LogViewer regex to reduce greediness, closes #3683

### DIFF
--- a/system/src/Grav/Common/Helpers/LogViewer.php
+++ b/system/src/Grav/Common/Helpers/LogViewer.php
@@ -21,7 +21,7 @@ use function is_string;
 class LogViewer
 {
     /** @var string */
-    protected $pattern = '/\[(?P<date>.*)\] (?P<logger>\w+).(?P<level>\w+): (?P<message>.*[^ ]+) (?P<context>[^ ]+) (?P<extra>[^ ]+)/';
+    protected $pattern = '/\[(?P<date>.*?)\] (?P<logger>\w+)\.(?P<level>\w+): (?P<message>.*[^ ]+) (?P<context>[^ ]+) (?P<extra>[^ ]+)/';
 
     /**
      * Get the objects of a tailed file


### PR DESCRIPTION
By making the date match group non-greedy, and escaping the dot between the logger and level match groups, the regex behaves better for log entries that contain square brackets and colons.

See #3683 for full bug report.