### PR TITLE
Fix whoami command usage

### DIFF
--- a/system/src/Grav/Common/Scheduler/Scheduler.php
+++ b/system/src/Grav/Common/Scheduler/Scheduler.php
@@ -357,7 +357,7 @@ class Scheduler
      */
     public function whoami()
     {
-        $process = new Process('whoami');
+        $process = new Process(['whoami']);
         $process->run();
 
         if ($process->isSuccessful()) {


### PR DESCRIPTION
Passing process as a string is deprecated since Symfony 4.2.