### PR TITLE
fix whitespace encoding in urls

### DIFF
--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -244,6 +244,7 @@ class Excerpts
             $id = $element_excerpt['id'] ?? '';
 
             $excerpt['element'] = $medium->parsedownElement($title, $alt, $class, $id, true);
+            $excerpt['element']['attributes']['src'] = str_replace(' ', '%20', $excerpt['element']['attributes']['src']);
         } else {
             // Not a current page media file, see if it needs converting to relative.
             $excerpt['element']['attributes']['src'] = Uri::buildUrl($url_parts);

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -163,7 +163,14 @@ class Excerpts
                 $raw_url_parts['path'] = $grav['base_url_relative'] . '/' . $path;
                 unset($url_parts['stream'], $url_parts['scheme']);
             }
+
+            $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);
+
+            return $excerpt;
         }
+
+        // Handle paths and such.
+        $raw_url_parts = Uri::convertUrl($this->page, $raw_url_parts, $type);
 
         // Build the URL from the component parts and set it on the element.
         $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -98,6 +98,7 @@ class Excerpts
         $grav = Grav::instance();
         $url = htmlspecialchars_decode(rawurldecode($excerpt['element']['attributes']['href']));
         $url_parts = $this->parseUrl($url);
+        $raw_url_parts = $this->parseUrl($excerpt['element']['attributes']['href']);
 
         // If there is a query, then parse it and build action calls.
         if (isset($url_parts['query'])) {
@@ -148,8 +149,8 @@ class Excerpts
         }
 
         // Set path to / if not set.
-        if (empty($url_parts['path'])) {
-            $url_parts['path'] = '';
+        if (empty($raw_url_parts['path'])) {
+            $raw_url_parts['path'] = '';
         }
 
         // If scheme isn't http(s)..
@@ -159,20 +160,20 @@ class Excerpts
             $locator = $grav['locator'];
             if ($type === 'link' && $locator->isStream($url)) {
                 $path = $locator->findResource($url, false) ?: $locator->findResource($url, false, true);
-                $url_parts['path'] = $grav['base_url_relative'] . '/' . $path;
+                $raw_url_parts['path'] = $grav['base_url_relative'] . '/' . $path;
                 unset($url_parts['stream'], $url_parts['scheme']);
             }
 
-            $excerpt['element']['attributes']['href'] = Uri::buildUrl($url_parts);
+            $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);
 
             return $excerpt;
         }
 
         // Handle paths and such.
-        $url_parts = Uri::convertUrl($this->page, $url_parts, $type);
+        $raw_url_parts = Uri::convertUrl($this->page, $raw_url_parts, $type);
 
         // Build the URL from the component parts and set it on the element.
-        $excerpt['element']['attributes']['href'] = Uri::buildUrl($url_parts);
+        $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);
 
         return $excerpt;
     }
@@ -187,6 +188,7 @@ class Excerpts
     {
         $url = htmlspecialchars_decode(urldecode($excerpt['element']['attributes']['src']));
         $url_parts = $this->parseUrl($url);
+        $raw_url_parts = $this->parseUrl($excerpt['element']['attributes']['src']);
 
         $media = null;
         $filename = null;
@@ -246,7 +248,7 @@ class Excerpts
             $excerpt['element'] = $medium->parsedownElement($title, $alt, $class, $id, true);
         } else {
             // Not a current page media file, see if it needs converting to relative.
-            $excerpt['element']['attributes']['src'] = Uri::buildUrl($url_parts);
+            $excerpt['element']['attributes']['src'] = Uri::buildUrl($raw_url_parts);
         }
 
         return $excerpt;

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -163,14 +163,7 @@ class Excerpts
                 $raw_url_parts['path'] = $grav['base_url_relative'] . '/' . $path;
                 unset($url_parts['stream'], $url_parts['scheme']);
             }
-
-            $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);
-
-            return $excerpt;
         }
-
-        // Handle paths and such.
-        $raw_url_parts = Uri::convertUrl($this->page, $raw_url_parts, $type);
 
         // Build the URL from the component parts and set it on the element.
         $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -98,7 +98,6 @@ class Excerpts
         $grav = Grav::instance();
         $url = htmlspecialchars_decode(rawurldecode($excerpt['element']['attributes']['href']));
         $url_parts = $this->parseUrl($url);
-        $raw_url_parts = $this->parseUrl($excerpt['element']['attributes']['href']);
 
         // If there is a query, then parse it and build action calls.
         if (isset($url_parts['query'])) {
@@ -149,8 +148,8 @@ class Excerpts
         }
 
         // Set path to / if not set.
-        if (empty($raw_url_parts['path'])) {
-            $raw_url_parts['path'] = '';
+        if (empty($url_parts['path'])) {
+            $url_parts['path'] = '';
         }
 
         // If scheme isn't http(s)..
@@ -160,20 +159,20 @@ class Excerpts
             $locator = $grav['locator'];
             if ($type === 'link' && $locator->isStream($url)) {
                 $path = $locator->findResource($url, false) ?: $locator->findResource($url, false, true);
-                $raw_url_parts['path'] = $grav['base_url_relative'] . '/' . $path;
+                $url_parts['path'] = $grav['base_url_relative'] . '/' . $path;
                 unset($url_parts['stream'], $url_parts['scheme']);
             }
 
-            $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);
+            $excerpt['element']['attributes']['href'] = Uri::buildUrl($url_parts);
 
             return $excerpt;
         }
 
         // Handle paths and such.
-        $raw_url_parts = Uri::convertUrl($this->page, $raw_url_parts, $type);
+        $url_parts = Uri::convertUrl($this->page, $url_parts, $type);
 
         // Build the URL from the component parts and set it on the element.
-        $excerpt['element']['attributes']['href'] = Uri::buildUrl($raw_url_parts);
+        $excerpt['element']['attributes']['href'] = Uri::buildUrl($url_parts);
 
         return $excerpt;
     }
@@ -188,7 +187,6 @@ class Excerpts
     {
         $url = htmlspecialchars_decode(urldecode($excerpt['element']['attributes']['src']));
         $url_parts = $this->parseUrl($url);
-        $raw_url_parts = $this->parseUrl($excerpt['element']['attributes']['src']);
 
         $media = null;
         $filename = null;
@@ -248,7 +246,7 @@ class Excerpts
             $excerpt['element'] = $medium->parsedownElement($title, $alt, $class, $id, true);
         } else {
             // Not a current page media file, see if it needs converting to relative.
-            $excerpt['element']['attributes']['src'] = Uri::buildUrl($raw_url_parts);
+            $excerpt['element']['attributes']['src'] = Uri::buildUrl($url_parts);
         }
 
         return $excerpt;

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -761,7 +761,7 @@ class Uri
         $pass      = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
         $pass      = ($user || $pass) ? "{$pass}@" : '';
         $path      = $parsed_url['path'] ?? '';
-        $path      = !empty($parsed_url['params']) ? rtrim($path, '/') . static::buildParams($parsed_url['params']) : $path;
+        $path      = !empty($parsed_url['params']) ? str_replace(' ', '%20', rtrim($path, '/')) . static::buildParams($parsed_url['params']) : str_replace(' ', '%20', $path);
         $query     = !empty($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
         $fragment  = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
 


### PR DESCRIPTION
Keep encoded links encoded. With this PR markdown like this: 

```
![internal](image%20wtih%20spaces.jpeg)
![exernal](https://examle.com/image%20wtih%20spaces.jpeg)
```

Will result in:
```
<img src="image%20wtih%20spaces.jpeg" alt="internal">
<img src="https://examle.com/image%20wtih%20spaces.jpeg" alt="exernal">
```

Instead of not: 
```
<img src="image wtih spaces.jpeg" alt="internal">
<img src="https://examle.com/image wtih spaces.jpeg" alt="exernal">
```

See also issue  #1622