### PR TITLE
Added detection of external triggers of the scheduler

### DIFF
--- a/system/src/Grav/Common/Scheduler/Scheduler.php
+++ b/system/src/Grav/Common/Scheduler/Scheduler.php
@@ -214,6 +214,9 @@ class Scheduler
 
         // Store states
         $this->saveJobStates();
+
+        // Store run date
+        file_put_contents("logs/lastcron.run", (new DateTime("now"))->format("Y-m-d H:i:s"), LOCK_EX);
     }
 
     /**
@@ -291,7 +294,7 @@ class Scheduler
     }
 
     /**
-     * Helper to determine if cron job is setup
+     * Helper to determine if cron-like job is setup
      * 0 - Crontab Not found
      * 1 - Crontab Found
      * 2 - Error
@@ -300,6 +303,13 @@ class Scheduler
      */
     public function isCrontabSetup()
     {
+        // Check for external triggers
+        $last_run = @file_get_contents("logs/lastcron.run");
+        if (time() - strtotime($last_run) < 120){
+            return 1;
+        }
+
+        // No external triggers found, so do legacy cron checks
         $process = new Process(['crontab', '-l']);
         $process->run();
 


### PR DESCRIPTION
Added extension to the isCrontabSetup method to detect external triggers of the scheduler, so that in the admin interface the error message is hidden when the scheduler is called by an external trigger as discussed in #2647 