### PR TITLE
Improve security for dangerous extensions

### DIFF
--- a/system/config/security.yaml
+++ b/system/config/security.yaml
@@ -32,9 +32,16 @@ xss_dangerous_tags:
     - base
 uploads_dangerous_extensions:
     - php
+    - php2
+    - php3
+    - php4
+    - php5
     - phar
+    - phtml
     - html
     - htm
+    - shtml
+    - shtm
     - js
     - exe
 sanitize_svg: true

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -977,10 +977,10 @@ abstract class Utils
      * @param string $filename
      * @return bool
      */
-    public static function checkFilename($filename)
+    public static function checkFilename($filename): bool
     {
         $dangerous_extensions = Grav::instance()['config']->get('security.uploads_dangerous_extensions', []);
-        $extension = static::pathinfo($filename, PATHINFO_EXTENSION);
+        $extension = strtolower(static::pathinfo($filename, PATHINFO_EXTENSION));
 
         return !(
             // Empty filenames are not allowed.

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -561,6 +561,7 @@ class UtilsTest extends \Codeception\TestCase\Test
         $config->set('security.uploads_dangerous_extensions', ['php', 'html', 'htm', 'exe', 'js']);
 
         self::assertFalse(Utils::checkFilename('foo.php'));
+        self::assertFalse(Utils::checkFilename('foo.PHP'));
         self::assertFalse(Utils::checkFilename('bar.js'));
 
         self::assertTrue(Utils::checkFilename('foo.json'));

--- a/webserver-configs/Caddyfile
+++ b/webserver-configs/Caddyfile
@@ -16,10 +16,10 @@ php_fastcgi 127.0.0.1:9000
 rewrite /(\.git|cache|bin|logs|backups|tests)/.* /403
 
 # deny running scripts inside core system folders
-rewrite /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ /403
+rewrite /(system|vendor)/.*\.(txt|xml|md|html|htm|shtml|shtm|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ /403
 
 # deny running scripts inside user folder
-rewrite /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ /403
+rewrite /user/.*\.(txt|md|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ /403
 
 # deny access to specific files in the root folder
 rewrite /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) /403

--- a/webserver-configs/Caddyfile-0.8.x
+++ b/webserver-configs/Caddyfile-0.8.x
@@ -12,12 +12,12 @@ rewrite {
 }
 # deny running scripts inside core system folders
 rewrite {
-    r       /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
+    r       /(system|vendor)/.*\.(txt|xml|md|html|htm|shtml|shtm|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$
     status  403
 }
 # deny running scripts inside user folder
 rewrite {
-    r       /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$
+    r       /user/.*\.(txt|md|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$
     status  403
 }
 # deny access to specific files in the root folder

--- a/webserver-configs/htaccess.txt
+++ b/webserver-configs/htaccess.txt
@@ -59,9 +59,9 @@ RewriteRule .* index.php [L]
 # Block all direct access for these folders
 RewriteRule ^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F]
 # Block access to specific file types for these system folders
-RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|json|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block access to specific file types for these user folders
-RewriteRule ^(user)/(.*)\.(txt|md|json|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(user)/(.*)\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ error [F]
 # Block all direct access to .md files:
 RewriteRule \.md$ error [F]
 # Block all direct access to files and folders beginning with a dot

--- a/webserver-configs/lighttpd.conf
+++ b/webserver-configs/lighttpd.conf
@@ -33,7 +33,7 @@ $HTTP["url"] =~ "^/grav_path/(LICENSE\.txt|composer\.json|composer\.lock|nginx\.
 $HTTP["url"] =~ "^/grav_path/(\.git|cache|bin|logs|backup|tests)/(.*)" {
     url.access-deny = ("")
 }
-$HTTP["url"] =~ "^/grav_path/(system|user|vendor)/(.*)\.(txt|md|html|json|yaml|yml|php|twig|sh|bat)$" {
+$HTTP["url"] =~ "^/grav_path/(system|user|vendor)/(.*)\.(txt|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|twig|sh|bat)$" {
     url.access-deny = ("")
 }
 $HTTP["url"] =~ "^/grav_path/(\.(.*))" {

--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -20,9 +20,9 @@ server {
     # deny all direct access for these folders
     location ~* /(\.git|cache|bin|logs|backup|tests)/.*$ { return 403; }
     # deny running scripts inside core system folders
-    location ~* /(system|vendor)/.*\.(txt|xml|md|html|json|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
+    location ~* /(system|vendor)/.*\.(txt|xml|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny running scripts inside user folder
-    location ~* /user/.*\.(txt|md|json|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ { return 403; }
+    location ~* /user/.*\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny access to specific files in the root folder
     location ~ /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) { return 403; }
     ## End - Security

--- a/webserver-configs/web.config
+++ b/webserver-configs/web.config
@@ -18,7 +18,7 @@
                     <action type="Rewrite" url="index.php" />
                 </rule>
                 <rule name="user_error_redirect" stopProcessing="true">
-                    <match url="^(user)/(.*)\.(txt|md|json|yaml|yml|php|pl|py|cgi|twig|sh|bat)$" ignoreCase="false" />
+                    <match url="^(user)/(.*)\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="ignore_folders" stopProcessing="true">
@@ -26,11 +26,11 @@
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="system" stopProcessing="true">
-                    <match url="^system/(.*)\.(txt|md|html|json|yaml|yml|php|twig|sh|bat)$" ignoreCase="false" />
+                    <match url="^system/(.*)\.(txt|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|twig|sh|bat)$" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
                 <rule name="vendor" stopProcessing="true">
-                    <match url="^vendor/(.*)\.(txt|md|html|json|yaml|yml|php|twig|sh|bat)$" ignoreCase="false" />
+                    <match url="^vendor/(.*)\.(txt|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|twig|sh|bat)$" ignoreCase="false" />
                     <action type="Redirect" url="error" redirectType="Permanent" />
                 </rule>
             </rules>


### PR DESCRIPTION
Hi,
here are a few changes to improve the security for dangerous extensions.

- add several new dangerous extensions in `system/config/security.yaml`
The new `ph*` extensions are just a precaution. The `shtm*` extensions are a real thing and prevents that an attacker can upload html files which get rendered by the browser.
- make `Utils::checkFilename()` extension check case insensitive
- update webserver configurations