### PR TITLE
Make Inflector::ordinalize() work

### DIFF
--- a/system/src/Grav/Common/Inflector.php
+++ b/system/src/Grav/Common/Inflector.php
@@ -310,11 +310,11 @@ class Inflector
      */
     public static function ordinalize($number)
     {
+        static::init();
+
         if (!is_array(static::$ordinals)) {
             return (string)$number;
         }
-
-        static::init();
 
         if (in_array($number % 100, range(11, 13), true)) {
             return $number . static::$ordinals['default'];


### PR DESCRIPTION
It's day 2 of learning Grav. I noticed the ordinalize example wasn't working on the docs https://learn.getgrav.org/17/themes/twig-tags-filters-functions/filters#ordinalize 

I almost understand 0.1% of the code, but it feels right.