### PR TITLE
Revert "fix whitespace encoding in urls"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
    * Fixed a math rounding issue with number validation when using floating point steps [#3761](https://github.com/getgrav/grav/issues/3761)
    * Fixed an issue with `Inflector::ordinalize()` not working as expected [#3759](https://github.com/getgrav/grav/pull/3759)
    * Fix for invalid input to foreach in `UserGroupObject` [#3724](https://github.com/getgrav/grav/pull/3724)
-   * Fix whitespace encoding in URLs (#3661)[https://github.com/getgrav/grav/pull/3719]
    * Fixed exception: `Property 'jsmodule_pipeline_include_externals' does not exist in object` (#3661)[https://github.com/getgrav/grav/pull/3661]
    * Fixed `too few arguments exception` in FlexObjects [#3658](https://github.com/getgrav/grav/pull/3658)
 

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -244,7 +244,6 @@ class Excerpts
             $id = $element_excerpt['id'] ?? '';
 
             $excerpt['element'] = $medium->parsedownElement($title, $alt, $class, $id, true);
-            $excerpt['element']['attributes']['src'] = str_replace(' ', '%20', $excerpt['element']['attributes']['src']);
         } else {
             // Not a current page media file, see if it needs converting to relative.
             $excerpt['element']['attributes']['src'] = Uri::buildUrl($url_parts);

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -761,7 +761,7 @@ class Uri
         $pass      = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
         $pass      = ($user || $pass) ? "{$pass}@" : '';
         $path      = $parsed_url['path'] ?? '';
-        $path      = !empty($parsed_url['params']) ? str_replace(' ', '%20', rtrim($path, '/')) . static::buildParams($parsed_url['params']) : str_replace(' ', '%20', $path);
+        $path      = !empty($parsed_url['params']) ? rtrim($path, '/') . static::buildParams($parsed_url['params']) : $path;
         $query     = !empty($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
         $fragment  = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
 


### PR DESCRIPTION
Reverts getgrav/grav#3719

The code change from getgrav/grav#3719 introduces a breaking change (as in, literally breaking) and throws a fatal error.

Culprit code:

```php
$excerpt['element']['attributes']['src'] = str_replace(' ', '%20', $excerpt['element']['attributes']['src']);
```

This lacks sanity checks around the src presence under attributes, which throws a fatal error `Undefined array key "src"`.

/cc @dirkjf - Please recreate the PR with adequate checks and unit testing so we don't run into this again, thanks!