### PR TITLE
[Draft] [Scheduler] Added 'outdated' option to scheduler command

### DIFF
--- a/system/src/Grav/Common/Scheduler/Job.php
+++ b/system/src/Grav/Common/Scheduler/Job.php
@@ -201,6 +201,28 @@ class Job
     }
 
     /**
+     * Check if the Job should have run previously.
+     *
+     * @param  DateTime|null $date
+     * @return bool
+     */
+    public function isOverdue(?DateTime $date = null, ?DateTime $lastRun = null)
+    {
+        // If the time elapsed since the creation is inferior to the interval, it's not overdue
+        if ($this->creationTime > $this->executionTime->getPreviousRunDate($date)) {
+            return false;
+        }
+        // Else, if the job has never run, it's overdue
+        if (null === $lastRun) {
+            return true;
+        }
+        $date = $date ?? new DateTime('now');
+
+        // Else if the last run time is inferior to the previous scheduled time, it's overdue
+        return $lastRun < $this->executionTime->getPreviousRunDate($date);
+    }
+
+    /**
      * Check if the Job is overlapping.
      *
      * @return bool

--- a/system/src/Grav/Common/Scheduler/Scheduler.php
+++ b/system/src/Grav/Common/Scheduler/Scheduler.php
@@ -188,7 +188,7 @@ class Scheduler
      * @param DateTime|null $runTime Optional, run at specific moment
      * @param bool $force force run even if not due
      */
-    public function run(DateTime $runTime = null, $force = false)
+    public function run(DateTime $runTime = null, $force = false, $overdue = false)
     {
         $this->loadSavedJobs();
 
@@ -199,9 +199,17 @@ class Scheduler
             $runTime = new DateTime('now');
         }
 
+        if ($overdue) {
+            $lastRuns = [];
+            foreach ($this->getJobStates()->content() as $id => $state) {
+                $timestamp = $state['last-run'] ?? time();
+                $lastRuns[$id] = DateTime::createFromFormat('U',$timestamp);
+            }
+        }
+
         // Star processing jobs
         foreach ($alljobs as $job) {
-            if ($job->isDue($runTime) || $force) {
+            if ($job->isDue($runTime) || $force || ($overdue && $job->isOverdue($runTime, $lastRuns[$job->getId()] ?? null))) {
                 $job->run();
                 $this->jobs_run[] = $job;
             }

--- a/tests/unit/Grav/Common/Scheduler/JobTest.php
+++ b/tests/unit/Grav/Common/Scheduler/JobTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace unit\Grav\Common\Scheduler;
+
+use Grav\Common\Scheduler\Job;
+
+class JobTest extends \Codeception\Test\Unit
+{
+    /**
+     * @dataProvider dataProviderForTestIsOverdue
+     */
+    public function testIsOverdue($job, $date, $lastRun, $expected)
+    {
+        $this->assertEquals($expected, $job->isOverdue($date, $lastRun));
+    }
+
+    public function dataProviderForTestIsOverdue()
+    {
+        return [
+            'New Job' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => null,
+                'lastRun' => null,
+                'expected' => false
+            ],
+            'New Job created 1 hour ago' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => new \DateTime('+1 hour'),
+                'lastRun' => null,
+                'expected' => true
+            ],
+            'New Job created 1 minute ago' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => new \DateTime('+1 minute'),
+                'lastRun' => null,
+                'expected' => false
+            ],
+            'New Job created 2 minutes ago' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => new \DateTime('+2 minutes'),
+                'lastRun' => null,
+                'expected' => true
+            ],
+            'Job created 1 hour ago and last run 1 mn ago' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => new \DateTime('+1 hour'),
+                'lastRun' => new \DateTime('+1 minutes'),
+                'expected' => true
+            ],
+            'Job created 1 hour ago and last run 30 mn ago' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => new \DateTime('+1 hour'),
+                'lastRun' => new \DateTime('+30 minutes'),
+                'expected' => true
+            ],
+            'Job created 30 minutes ago and last run 1 hour ago' => [
+                'job' => (new Job('ls'))->at('* * * * *'),
+                'date' => new \DateTime('+30 minutes'),
+                'lastRun' => new \DateTime('+1 hour'),
+                'expected' => false
+            ],
+            'New hourly Job' => [
+                'job' => (new Job('ls'))->at('0 * * * *'),
+                'date' => null,
+                'lastRun' => null,
+                'expected' => false
+            ],
+            'New hourly Job created at 2 hours ago' => [
+                'job' => (new Job('ls'))->at('0 * * * *'),
+                'date' => new \DateTime('+2 hours'),
+                'lastRun' => null,
+                'expected' => true
+            ],
+            'Hourly Job created 1 hour ago and last run 30 mn ago' => [
+                'job' => (new Job('ls'))->at('0 * * * *'),
+                'date' => new \DateTime('+1 hour'),
+                'lastRun' => new \DateTime('+30 minutes'),
+                'expected' => true
+            ],
+        ];
+    }
+}

--- a/tests/unit/Grav/Common/Scheduler/SchedulerTest.php
+++ b/tests/unit/Grav/Common/Scheduler/SchedulerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace unit\Grav\Common\Scheduler;
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use Grav\Common\Scheduler\Scheduler;
+use Grav\Common\Yaml;
+use RocketTheme\Toolbox\File\File;
+
+class SchedulerTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    protected $grav;
+
+    /**
+     * @var \Grav\Common\Scheduler\Scheduler
+     */
+    protected $scheduler;
+    private $statusFilePath;
+
+    public function dataProviderForTestIsOverdue()
+    {
+        return [
+            [
+                new \DateTime('+2 hours'),
+                [
+                    'aze45aze' => ['args'=>[], 'command'=>'ls', 'at'=>'0 * * * *'],
+                ],
+                [
+                    'aze45aze' => ['last-run' => strtotime('2021-01-01 00:00:00')],
+                ]
+            ],
+            [
+                new \DateTime('+2 hours'),
+                [
+                    'aze45aze' => ['args'=>[], 'command'=>'ls', 'at'=>'0 * * * *'],
+                    'zedz5a4eza' => ['args'=>[], 'command'=>'ls', 'at'=>'*/15 * * * *'],
+                ],
+                [
+                    'aze45aze' => ['last-run' => strtotime('-5 minutes')],
+                ]
+            ],
+        ];
+    }
+
+    protected function _before()
+    {
+        $this->grav = Fixtures::get('grav')();
+        $this->scheduler = new Scheduler();
+        $this->statusFilePath = Grav::instance()['locator']->findResource('user-data://scheduler', true, true).'/status.yaml';
+    }
+
+    protected function _after()
+    {
+        if (file_exists($this->statusFilePath)) {
+            unlink($this->statusFilePath);
+        }
+    }
+
+    /**
+     * @dataProvider dataProviderForTestIsOverdue
+     */
+    public function testIsOverdue($date, $jobs, $status){
+        $file = $this->scheduler->getJobStates();
+        $file->save($status);
+        $this->grav['config']->set('scheduler.custom_jobs', $jobs);
+        $this->scheduler->run($date, false, true);
+        $this->assertFileExists($this->statusFilePath);
+        $this->assertFileIsReadable($this->statusFilePath);
+        dump(file_get_contents($this->statusFilePath));
+        foreach ($jobs as $id => $job) {
+            $this->assertStringContainsString($id, file_get_contents($this->statusFilePath));
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR follows #3770 and adds an `outdated` option to the scheduler command.

This allows the scheduler to run jobs that should have been processed earlier but did not (use cases : server downtime, cron not running every minute).

### Usage

``` bash
php bin/grav scheduler --outdated
```

## Advice wanted

First of all if you have another idea for the option name I'm open to discussion, I don't think `outdated` is really relevant.

Now the main concern :
While working on this feature I realized the Job `creationTime` is not stored in the config, but rather set when instantiating the job. The logic I had in mind involved checking if the job had been created later than the previous scheduled execution, to prevent running a job before its first scheduled run.
https://github.com/getgrav/grav/commit/4bb4069f5f92d1c149356c049673e112d4cce7b3#diff-d62f46dc32787f2a5ecbcca58aa4601fc942e8b293a6cfa7a9c6286475cbac02R212

I see a few options to work around this :
- Removing this test. The downside is that running the scheduler with the 'outdated' option may result in running new jobs to early for their first run. 
- Storing the `creationTime` in the `scheduler.yaml` config. This would work for custom jobs, but the default jobs don't store their config there so I don't think it would be such a good idea.
- Create a new scheduler state in addition to success and error ('new' for example) and for each newly created/modified jobs, add an entry to `data/scheduler/status.yaml` with `state: new` and `last-run: previous-scheduled-time`. This way we can keep track of every change in the scheduler configuration and make sure we don't run the jobs before the next occurrence.

IMO the third option would be the best to cover all cases, but I'd be happy to hear your thoughts about this :)