### PR TITLE
Adds mime type for vCards (.vcf files)

### DIFF
--- a/system/config/media.yaml
+++ b/system/config/media.yaml
@@ -216,3 +216,8 @@ types:
     type: file
     thumb: media/thumb-json.png
     mime: application/json
+  vcf:
+    type: file
+    thumb: media/thumb-vcf.png
+    mime: text/x-vcard
+


### PR DESCRIPTION
Adds support for vCards (.vcf files) in case of e.g. scanning a qr-code with the direct url to the file, so that it can be downloaded. 

Only a thumb-vcf.png should be added then too.