### PR TITLE
Allow empty and malformed links in markdown

### DIFF
--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -1835,7 +1835,7 @@ abstract class Utils
         $parts = parse_url($enc_url);
 
         if ($parts === false) {
-            throw new InvalidArgumentException('Malformed URL: ' . $url);
+            $parts = [];
         }
 
         foreach ($parts as $name => $value) {


### PR DESCRIPTION
When a user adds an empty or otherwise invalid link in a page in markdown for example [](https://) and that page is parsed to be shown in a blog listing page that blog listing page crashes with a CRITICAL error. Instead of throwing an error the URL is now ignored. See also https://discord.com/channels/501836936584101899/506916956637495306/1185616779486167141