### PR TITLE
New Trait for decoding attribute in images

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -1300,6 +1300,17 @@ form:
                 auto: Auto
                 lazy: Lazy
                 eager: Eager
+            
+            images.defaults.decoding:
+              type: select
+              size: small
+              label: PLUGIN_ADMIN.IMAGES_DECODING
+              help: PLUGIN_ADMIN.IMAGES_DECODING_HELP
+              highlight: auto
+              options:
+                auto: Auto
+                sync: Sync
+                async: Async
 
             images.seofriendly:
               type: toggle

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -168,6 +168,7 @@ images:
     retina_scale: 1                              # scale to adjust auto-sizes for better handling of HiDPI resolutions
   defaults:
     loading: auto                                # Let browser pick [auto|lazy|eager]
+    decoding: auto                               # Let browser pick [auto|sync|async]
   watermark:
     image: 'system://images/watermark.png'       # Path to a watermark image
     position_y: 'center'                         # top|center|bottom

--- a/system/src/Grav/Common/Media/Traits/ImageDecodingTrait.php
+++ b/system/src/Grav/Common/Media/Traits/ImageDecodingTrait.php
@@ -2,8 +2,7 @@
 
 /**
  * @package    Grav\Common\Media
- *
- * @copyright  Copyright (c) 2015 - 2024 Trilby Media, LLC. All rights reserved.
+ * @author     Pedro Moreno https://github.com/pmoreno-rodriguez
  * @license    MIT License; see LICENSE file for details.
  */
 
@@ -12,7 +11,7 @@ namespace Grav\Common\Media\Traits;
 use Grav\Common\Grav;
 
 /**
- * Trait ImageLoadingTrait
+ * Trait ImageDecodingTrait
  * @package Grav\Common\Media\Traits
  */
 

--- a/system/src/Grav/Common/Media/Traits/ImageDecodingTrait.php
+++ b/system/src/Grav/Common/Media/Traits/ImageDecodingTrait.php
@@ -25,17 +25,16 @@ trait ImageDecodingTrait
      */
     public function decoding($value = null)
     {
-        $validValues = ['sync', 'async', 'auto'];
-
         if (null === $value) {
             $value = Grav::instance()['config']->get('system.images.defaults.decoding', 'auto');
         }
 
-        // Validate the provided value
-        if ($value && in_array($value, $validValues, true)) {
+        // Validate the provided value (similar to loading)
+        if ($value !== null && $value !== 'auto') {
             $this->attributes['decoding'] = $value;
         }
 
         return $this;
     }
+
 }

--- a/system/src/Grav/Common/Media/Traits/ImageDecodingTrait.php
+++ b/system/src/Grav/Common/Media/Traits/ImageDecodingTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @package    Grav\Common\Media
+ *
+ * @copyright  Copyright (c) 2015 - 2024 Trilby Media, LLC. All rights reserved.
+ * @license    MIT License; see LICENSE file for details.
+ */
+
+namespace Grav\Common\Media\Traits;
+
+use Grav\Common\Grav;
+
+/**
+ * Trait ImageLoadingTrait
+ * @package Grav\Common\Media\Traits
+ */
+
+trait ImageDecodingTrait
+{
+    /**
+     * Allows to set the decoding attribute from Markdown or Twig
+     *
+     * @param string|null $value
+     * @return $this
+     */
+    public function decoding($value = null)
+    {
+        $validValues = ['sync', 'async', 'auto'];
+
+        if (null === $value) {
+            $value = Grav::instance()['config']->get('system.images.defaults.decoding', 'auto');
+        }
+
+        // Validate the provided value
+        if ($value && in_array($value, $validValues, true)) {
+            $this->attributes['decoding'] = $value;
+        }
+
+        return $this;
+    }
+}

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -15,6 +15,7 @@ use Grav\Common\Media\Interfaces\ImageManipulateInterface;
 use Grav\Common\Media\Interfaces\ImageMediaInterface;
 use Grav\Common\Media\Interfaces\MediaLinkInterface;
 use Grav\Common\Media\Traits\ImageLoadingTrait;
+use Grav\Common\Media\Traits\ImageDecodingTrait;
 use Grav\Common\Media\Traits\ImageMediaTrait;
 use Grav\Common\Utils;
 use Gregwar\Image\Image;
@@ -30,6 +31,7 @@ class ImageMedium extends Medium implements ImageMediaInterface, ImageManipulate
 {
     use ImageMediaTrait;
     use ImageLoadingTrait;
+    use ImageDecodingTrait;
 
     /**
      * @var mixed|string


### PR DESCRIPTION
The decoding property of the HTMLImageElement interface provides a hint to the browser as to how it should decode the image. More specifically, whether it should wait for the image to be decoded before presenting other content updates or not.
With this trait you can add the decoding attribute to load images in an easy way. It basically works the same way as the 'loading' attribute (see [Grav Docs](https://learn.getgrav.org/17/content/media#loading)), with `async`, `sync` and `auto ` options. More info in [Mozilla.org](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding)