### PR TITLE
Fix running Grav under Load Balancer with custom_base_url

### DIFF
--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -205,8 +205,8 @@ class Uri
         // set active language
         $uri = $language->setActiveFromUri($uri);
 
-        // split the URL and params (and make sure that the path isn't seen as domain)
-        $bits = parse_url('http://domain.com' . $uri);
+        // split the URL and params
+        $bits = parse_url($uri);
 
         //process fragment
         if (isset($bits['fragment'])) {


### PR DESCRIPTION
Previous [change](https://github.com/getgrav/grav/commit/0af33850a68dd2e9d3e3a9e1bd2d25215b958eb5) broke running Grav under load balancer with custom_base_url set. All dynamic urls (pages, admin, etc.), returns 404. All static content is not affected.

dump($bits) just after [this parse_url()](https://github.com/getgrav/grav/blob/ee8d783d050588aaf35261b7d1832e2bdc433fe6/system/src/Grav/Common/Uri.php#L209)
**Original Grav 1.7.45 code accessed directly from http://localhost:8080/korteles/kodai**
```
array:3 [▼
  "scheme" => "http"
  "host" => "domain.com"
  "path" => "/korteles/kodai"
]
```
Result - OK.


**Grav 1.7.45 with this PR applied accessed directly from http://localhost:8080/korteles/kodai**
```
array:1 [▼
  "path" => "/korteles/kodai"
]
```
Result - OK.

**Original Grav 1.7.45 code accessed from load balancer https://mydomain.example.com/test/korteles/kodai (`custom_base_url: /test`)**
```
array:3 [▼
  "scheme" => "http"
  "host" => "domain.comhttps"
  "path" => "//mydomain.example.com/korteles/kodai"
]
```
**Result - 404 or even some nasty httpd cycles, depending on the configuration of load calancer.**

**Grav 1.7.45 with this PR applied accessed from load balancer https://mydomain.example.com/test/korteles/kodai (`custom_base_url: /test`)**
```
array:1 [▼
  "path" => "/korteles/kodai"
]
```
**Result - OK.**

Load balancer is configured to rewrite /test/(.*) to /$1, and I ensured that it is reaching Grav under correct path. The patch probably also fixes https://github.com/getgrav/grav/issues/3511 .

Also, it's not a good idea to add 3rd party domain into host value, which could be accidently reused some time in the future.