### PR TITLE
Support to Fediverse Creator meta tag

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -1782,7 +1782,7 @@ class Page implements PageInterface
                                 'content' => $escape ? htmlspecialchars($value, ENT_QUOTES | ENT_HTML5, 'UTF-8') : $value
                             ];
 
-                            if ($hasSeparator && !Utils::startsWith($key, ['twitter', 'flattr'])) {
+                            if ($hasSeparator && !Utils::startsWith($key, ['twitter', 'flattr','fediverse'])) {
                                 $entry['property'] = $key;
                             } else {
                                 $entry['name'] = $key;


### PR DESCRIPTION
Added support to [Fediverse Creator meta tag](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/)