### PR TITLE
New Trait for fetchPriority attribute in images

### DIFF
--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -1311,6 +1311,17 @@ form:
                 auto: Auto
                 sync: Sync
                 async: Async
+            
+            images.defaults.fetchpriority:
+              type: select
+              size: small
+              label: PLUGIN_ADMIN.IMAGES_FETCHPRIORITY
+              help: PLUGIN_ADMIN.IMAGES_FETCHPRIORITY_HELP
+              highlight: auto
+              options:
+                auto: Auto
+                high: High
+                low: Low
 
             images.seofriendly:
               type: toggle

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -169,6 +169,7 @@ images:
   defaults:
     loading: auto                                # Let browser pick [auto|lazy|eager]
     decoding: auto                               # Let browser pick [auto|sync|async]
+    fetchpriority: auto                          # Let browser pick [auto|high|low]
   watermark:
     image: 'system://images/watermark.png'       # Path to a watermark image
     position_y: 'center'                         # top|center|bottom

--- a/system/src/Grav/Common/Media/Traits/ImageFetchPriorityTrait.php
+++ b/system/src/Grav/Common/Media/Traits/ImageFetchPriorityTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @package    Grav\Common\Media
+ * @author     Pedro Moreno https://github.com/pmoreno-rodriguez
+ * @license    MIT License; see LICENSE file for details.
+ */
+
+namespace Grav\Common\Media\Traits;
+
+use Grav\Common\Grav;
+
+/**
+ * Trait ImageFetchPriorityTrait
+ * @package Grav\Common\Media\Traits
+ */
+
+trait ImageFetchPriorityTrait
+{
+    /**
+     * Allows to set the fetchpriority attribute from Markdown or Twig
+     *
+     * @param string|null $value
+     * @return $this
+     */
+    public function fetchpriority($value = null)
+    {
+        if (null === $value) {
+            $value = Grav::instance()['config']->get('system.images.defaults.fetchpriority', 'auto');
+        }
+
+        // Validate the provided value (similar to loading and decoding attributes)
+        if ($value !== null && $value !== 'auto') {
+            $this->attributes['fetchpriority'] = $value;
+        }
+
+        return $this;
+    }
+
+}

--- a/system/src/Grav/Common/Page/Medium/ImageMedium.php
+++ b/system/src/Grav/Common/Page/Medium/ImageMedium.php
@@ -16,6 +16,7 @@ use Grav\Common\Media\Interfaces\ImageMediaInterface;
 use Grav\Common\Media\Interfaces\MediaLinkInterface;
 use Grav\Common\Media\Traits\ImageLoadingTrait;
 use Grav\Common\Media\Traits\ImageDecodingTrait;
+use Grav\Common\Media\Traits\ImageFetchPriorityTrait;
 use Grav\Common\Media\Traits\ImageMediaTrait;
 use Grav\Common\Utils;
 use Gregwar\Image\Image;
@@ -32,6 +33,7 @@ class ImageMedium extends Medium implements ImageMediaInterface, ImageManipulate
     use ImageMediaTrait;
     use ImageLoadingTrait;
     use ImageDecodingTrait;
+    use ImageFetchPriorityTrait;
 
     /**
      * @var mixed|string


### PR DESCRIPTION
The fetchPriority property of the HTMLImageElement interface represents a hint given to the browser on how it should prioritize the fetch of the image relative to other images.

The fetchPriority property allows you to signal high or low priority image fetches. This can be useful when applied to <img> elements to signal images that are "important" to the user experience early in the loading process.