### PR TITLE
Avoid Arbitrary File Deletion abuse via Object Injection

### DIFF
--- a/system/src/Grav/Framework/Cache/Adapter/FileCache.php
+++ b/system/src/Grav/Framework/Cache/Adapter/FileCache.php
@@ -201,7 +201,7 @@ class FileCache extends AbstractCache
 
         try {
             if ($this->tmp === null) {
-                $this->tmp = $this->directory . uniqid('', true);
+                $this->tmp = $this->directory . uniqid(__CLASS__, true);
             }
 
             file_put_contents($this->tmp, $data);
@@ -259,7 +259,7 @@ class FileCache extends AbstractCache
     #[\ReturnTypeWillChange]
     public function __destruct()
     {
-        if ($this->tmp !== null && file_exists($this->tmp)) {
+        if ($this->tmp !== null && (strpos(basename($this->tmp), __CLASS__) === 0) && file_exists($this->tmp)) {
             unlink($this->tmp);
         }
     }


### PR DESCRIPTION
As discussed with @rhukster this simple change should avoid `\Grav\Framework\Cache\Adapter\FileCache::__destruct` being abused via Object Injection to achieve Arbitrary File Deletion.

I've used `strpos` rather than `str_starts_with` as it looks like Grav supports PHP 7.