### PR TITLE
Possible fix for inline JS being added out of sequence

### DIFF
--- a/system/src/Grav/Common/Assets/InlineJs.php
+++ b/system/src/Grav/Common/Assets/InlineJs.php
@@ -26,7 +26,6 @@ class InlineJs extends BaseAsset
     {
         $base_options = [
             'asset_type' => 'js',
-            'position' => 'after'
         ];
 
         $merged_attributes = Utils::arrayMergeRecursiveUnique($base_options, $elements);

--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -558,15 +558,21 @@ class AssetsTest extends \Codeception\TestCase\Test
 
         //----------------
         $this->assets->reset();
-        $this->assets->add('file1.js', 90);
-        $this->assets->add('file2.js', 80);
-        $this->assets->add('file3.js', 60);
+        $inline1 = "console.log('position 1');";
+        $inline2 = "console.log('position 4');";
+        $this->assets->addInlineJs($inline1, 100);
+        $this->assets->add('position2.js', 90);
+        $this->assets->add('position3.js', 80);
+        $this->assets->addInlineJs($inline2, 70);
+        $this->assets->add('position5.js', 60);
 
         $js = $this->assets->js();
         $expectedLines = [
-            '<script src="/file1.js"></script>',
-            '<script src="/file2.js"></script>',
-            '<script src="/file3.js"></script>',
+            '<script>', $inline1, '</script>',
+            '<script src="/position2.js"></script>',
+            '<script src="/position3.js"></script>',
+            '<script>', $inline2, '</script>',
+            '<script src="/position5.js"></script>',
             ];
         $expected = implode(PHP_EOL, $expectedLines) . PHP_EOL;
         self::assertSame($expected, $js);

--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -555,6 +555,22 @@ class AssetsTest extends \Codeception\TestCase\Test
         self::assertSame('<link href="/test-before.css" type="text/css" rel="stylesheet">' . PHP_EOL .
             '<link href="/test.css" type="text/css" rel="stylesheet">' . PHP_EOL .
             '<link href="/test-after.css" type="text/css" rel="stylesheet">' . PHP_EOL, $css);
+
+        //----------------
+        $this->assets->reset();
+        $this->assets->add('file1.js', 90);
+        $this->assets->add('file2.js', 80);
+        $this->assets->add('file3.js', 60);
+
+        $js = $this->assets->js();
+        $expectedLines = [
+            '<script src="/file1.js"></script>',
+            '<script src="/file2.js"></script>',
+            '<script src="/file3.js"></script>',
+            ];
+        $expected = implode(PHP_EOL, $expectedLines) . PHP_EOL;
+        self::assertSame($expected, $js);
+
     }
 
     public function testPipeline(): void


### PR DESCRIPTION
Adds a new Assets test assertion to verify order of output per #1893. Fixes asset order by removing default `position=after` property in newly instantiated `inlineJs` objects.

Notes/limitations:

* May be incomplete because there are other asset types where `position=after` is set by default in constructor.
* Not clear if there was a good reason to set `position=after` by default, _or_ unintended consequences not setting it.
* Not actually clear on the intended purpose of asset `position` property vs `priority`.
* Though it's a bug fix restoring expected behaviour, this is a potentially breaking change for existing Grav sites. So might be wise to create a toggle setting in system assets config.
