### PR TITLE
Fix Twig Sandbox Bypass Due to Improper Regex Handling of Nested Expressions

### DIFF
--- a/system/src/Grav/Common/Security.php
+++ b/system/src/Grav/Common/Security.php
@@ -281,7 +281,13 @@ class Security
             'twig.safe_functions',
             'read_file',
         ];
+
         $string = preg_replace('/(({{\s*|{%\s*)[^}]*?(' . implode('|', $bad_twig) . ')[^}]*?(\s*}}|\s*%}))/i', '{# $1 #}', $string);
+
+        foreach ($bad_twig as $func) {
+            $string = preg_replace('/\b' . preg_quote($func, '/') . '(\s*\([^)]*\))?\b/i', '{# $1 #}', $string);
+        }
+
         return $string;
     }
 }


### PR DESCRIPTION
The current implementation of the `cleanDangerousTwig` in `Security.php` allows for a sandbox bypass which enables Remote Code Execution due to weak handling of nested expressions.

This fix updates the regex pattern to correctly handle nested expressions fixing the bypass.

More details about the vulnerability in the advisory below.

Reference : https://github.com/getgrav/grav/security/advisories/GHSA-662m-56v4-3r8f