### PR TITLE
Fix for wrong LogViewer date output

### DIFF
--- a/system/src/Grav/Common/Helpers/LogViewer.php
+++ b/system/src/Grav/Common/Helpers/LogViewer.php
@@ -10,6 +10,8 @@
 namespace Grav\Common\Helpers;
 
 use DateTime;
+use DateMalformedStringException;
+
 use function array_slice;
 use function is_array;
 use function is_string;
@@ -140,8 +142,14 @@ class LogViewer
             $data['trace'] = trim($matches[2]);
         }
 
+        try {
+            $date = new DateTime($data['date']);
+        } catch (DateMalformedStringException $e) {
+            $date = null;
+        }
+
         return [
-            'date' => DateTime::createFromFormat('Y-m-d H:i:s', $data['date']),
+            'date' => $date,
             'logger' => $data['logger'],
             'level' => $data['level'],
             'message' => $data['message'],


### PR DESCRIPTION
The description of the changes: https://github.com/getgrav/grav-plugin-admin/issues/2468#issuecomment-3633233604
This pull request fixes getgrav/grav-plugin-admin#2468
The fix requires PHP 8 >= 8.3.0 because [DateMalformedStringException](https://www.php.net/manual/de/class.datemalformedstringexception.php) was used.