### PR TITLE
More readability for the LogViewerCommand time output

### DIFF
--- a/system/src/Grav/Console/Cli/LogViewerCommand.php
+++ b/system/src/Grav/Console/Cli/LogViewerCommand.php
@@ -78,7 +78,7 @@ class LogViewerCommand extends GravCommand
             $level_color = LogViewer::levelColor($log['level']);
 
             if ($date instanceof DateTime) {
-                $output = "<yellow>{$log['date']->format('Y-m-d h:i:s')}</yellow> [<{$level_color}>{$log['level']}</{$level_color}>]";
+                $output = "<yellow>{$log['date']->format('Y-m-d H:i:s')}</yellow> [<{$level_color}>{$log['level']}</{$level_color}>]";
                 if ($log['trace'] && $verbose) {
                     $output .= " <white>{$log['message']}</white>\n";
                     foreach ((array) $log['trace'] as $index => $tracerow) {


### PR DESCRIPTION
The LogViewerCommand.php time output could be confusing because "h" the 12-hour format is used without AM/PM. Switching to "H" the 24-hour format could make the output more readable.