### PR TITLE
Fix for undefined array key path triggered through url encoded characters

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -769,7 +769,7 @@ class Grav extends Container
         $supported_types = $config->get('media.types');
 
         $parsed_url = parse_url(rawurldecode($uri->basename()));
-        $media_file = $parsed_url['path'];
+        $media_file = isset($parsed_url['path']) ? $parsed_url['path'] : '';
 
         $event = new Event([
             'uri' => $uri,


### PR DESCRIPTION
At random intervals, I found in the log file the error message:

```
grav.CRITICAL: Undefined array key "path" - Trace:
#0 /grav/system/src/Grav/Common/Debugger.php(840): Whoops\Run->handleError(2, 'Undefined array...', '/www/htdocs/...', 746) 
#1 /grav/system/src/Grav/Common/Grav.php(746): Grav\Common\Debugger->deprecatedErrorHandler(2, 'Undefined array...', '/www/htdocs/...', 746) 
#2 /grav/system/src/Grav/Common/Service/PagesServiceProvider.php(125): Grav\Common\Grav->fallbackUrl('/
#footer') 
#3 /grav/system/src/Pimple/Container.php(147): Grav\Common\Service\PagesServiceProvider::{closure:Grav\Common\Service\PagesServiceProvider::register():50}(Object(Grav\Common\Grav)) 
#4 /grav/user/plugins/flex-objects/flex-objects.php(287): Pimple\Container->offsetGet('page') 
#5 /grav/vendor/symfony/event-dispatcher/EventDispatcher.php(206): Grav\Plugin\FlexObjectsPlugin->onPagesInitialized(Object(RocketTheme\Toolbox\Event\Event), 'onPagesInitiali...', Object(Symfony\Component\EventDispatcher\EventDispatcher)) 
#6 /grav/vendor/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'onPagesInitiali...', Object(RocketTheme\Toolbox\Event\Event)) 
#7 /grav/system/src/Grav/Common/Grav.php(571): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(RocketTheme\Toolbox\Event\Event), 'onPagesInitiali...') 
#8 /grav/system/src/Grav/Common/Processors/PagesProcessor.php(49): Grav\Common\Grav->fireEvent('onPagesInitiali...', Object(RocketTheme\Toolbox\Event\Event)) 
#9 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\PagesProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#10 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#11 /grav/system/src/Grav/Common/Processors/TwigProcessor.php(38): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#12 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\TwigProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#13 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#14 /grav/system/src/Grav/Common/Processors/AssetsProcessor.php(39): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#15 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\AssetsProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#16 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#17 /grav/system/src/Grav/Common/Processors/SchedulerProcessor.php(40): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#18 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\SchedulerProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#19 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#20 /grav/system/src/Grav/Common/Processors/BackupsProcessor.php(39): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#21 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\BackupsProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#22 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#23 /grav/system/src/Grav/Common/Processors/TasksProcessor.php(69): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#24 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\TasksProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#25 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#26 /grav/system/src/Grav/Common/Processors/RequestProcessor.php(64): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#27 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\RequestProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#28 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#29 /grav/system/src/Grav/Common/Processors/ThemesProcessor.php(38): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#30 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\ThemesProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#31 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#32 /grav/system/src/Grav/Common/Processors/PluginsProcessor.php(39): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#33 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\PluginsProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#34 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#35 /grav/system/src/Grav/Common/Processors/InitializeProcessor.php(132): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#36 /grav/system/src/Grav/Common/Debugger.php(548): Grav\Common\Processors\InitializeProcessor::{closure:Grav\Common\Processors\InitializeProcessor::process():132}() 
#37 /grav/system/src/Grav/Common/Processors/InitializeProcessor.php(132): Grav\Common\Debugger->profile(Object(Closure)) 
#38 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Common\Processors\InitializeProcessor->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#39 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#40 /grav/system/src/Grav/Framework/RequestHandler/Middlewares/MultipartRequestSupport.php(40): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#41 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(50): Grav\Framework\RequestHandler\Middlewares\MultipartRequestSupport->process(Object(Nyholm\Psr7\ServerRequest), Object(Grav\Framework\RequestHandler\RequestHandler)) 
#42 /grav/system/src/Grav/Framework/RequestHandler/Traits/RequestHandlerTrait.php(62): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#43 /grav/system/src/Grav/Common/Grav.php(286): Grav\Framework\RequestHandler\RequestHandler->handle(Object(Nyholm\Psr7\ServerRequest)) 
#44 /grav/index.php(116): Grav\Common\Grav->process() 
#45 {main} [] []
```
(the `Grav->fallbackUrl `may vary)

Debugging the `fallbackUrl` method from [system/src/Grav/Common/Grav.php](https://github.com/getgrav/grav/blob/1.8/system/src/Grav/Common/Grav.php#L724) brought the result that the critical could be triggered with the url encoded characters:
`%23` = # or `%3F` = ?. 

To verify it I tested it with a fresh installed and unchanged Grav (beta 28) and PHP 8.4.

Examples: 
`https://grav-page.com/%23footer`
`fallbackUrl()` `$parsed_url `result:
```
array (
  'fragment' => 'footer',
)
```
`https://grav-page.com/%3Ftest`
` fallbackUrl()`  `$parsed_url` result:
```
array (
  'query' => 'test',
)
```

Both arrays without path was set.
A declaration check of 'path' can avoid the critical.