### PR TITLE
Update PHP version requirement for grav 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The underlying architecture of Grav is designed to use well-established and _bes
 
 # Requirements
 
-- PHP 7.3.6 or higher. Check the [required modules list](https://learn.getgrav.org/basics/requirements#php-requirements)
+- PHP 7.3.6 to 8.3. Check the [required modules list](https://learn.getgrav.org/basics/requirements#php-requirements)
 - Check the [Apache](https://learn.getgrav.org/basics/requirements#apache-requirements) or [IIS](https://learn.getgrav.org/basics/requirements#iis-requirements) requirements
 
 # Documentation


### PR DESCRIPTION
highest supported php version is 8.3 as mentioned in #3995