### PR TITLE
Bump symfony/polyfill versions for grav 1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-gd": "*",
-        "symfony/polyfill-mbstring": "^1.24",
-        "symfony/polyfill-iconv": "^1.24",
-        "symfony/polyfill-php80": "^1.24",
-        "symfony/polyfill-php81": "^1.24",
+        "symfony/polyfill-mbstring": "^1.33",
+        "symfony/polyfill-iconv": "^1.33",
+        "symfony/polyfill-php84": "^1.33",
+        "symfony/polyfill-php85": "^1.33",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-middleware": "^1.0",
@@ -89,9 +89,10 @@
         }
     ],
     "replace": {
-        "symfony/polyfill-php72": "*",
-        "symfony/polyfill-php73": "*",
-        "symfony/polyfill-php74": "*"
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*",
+        "symfony/polyfill-php83": "*"
     },
     "suggest": {
         "ext-mbstring": "Recommended for better performance",


### PR DESCRIPTION
## Changes

- install newer polyfills
- do not install old polyfills
- remove unnecessary polyfills

## Todo

Update composer.lock (should be done by maintainer because it is hard to review a lock file)

## Reference

Mentioned in #4031
