### PR TITLE
Keep format setting for image derivatives

### DIFF
--- a/system/src/Grav/Common/Media/Traits/ImageMediaTrait.php
+++ b/system/src/Grav/Common/Media/Traits/ImageMediaTrait.php
@@ -183,6 +183,9 @@ trait ImageMediaTrait
                 $derivative->resize($width, $height);
                 $derivative->set('width', $width);
                 $derivative->set('height', $height);
+                if ($base->format !== 'guess') {
+                    $derivative->format($base->format);
+                }
 
                 $this->addAlternative($ratio, $derivative);
             }


### PR DESCRIPTION
This makes sure if you:
image.format('webp').derivatives(400,3000,300).sizes('100vw')

the derivatives are also webp files