### PR TITLE
Fixing da.yaml

### DIFF
--- a/system/languages/da.yaml
+++ b/system/languages/da.yaml
@@ -1,21 +1,6 @@
 ---
 GRAV:
   FRONTMATTER_ERROR_PAGE: "---\nTitel: %1$s\n---\n\n# Fejl: Ugyldigt frontmatter\n\nSti: `%2$s`\n\n**%3$s**\n\n```\n%4$s\n```"
-  INFLECTOR_UNCOUNTABLE:
-    - 'udstyr'
-    - 'information'
-    - 'ris'
-    - 'penge'
-    - 'arter'
-    - 'Serier'
-    - 'fisk'
-    - 'får'
-  INFLECTOR_IRREGULAR:
-    'person': 'personer'
-    'man': 'mænd'
-    'child': 'børn'
-    'sex': 'køn'
-    'move': 'flyt'
   NICETIME:
     NO_DATE_PROVIDED: Ingen dato angivet
     BAD_DATE: Ugyldig dato
@@ -59,16 +44,16 @@ GRAV:
   MONTHS_OF_THE_YEAR:
     - 'januar'
     - 'februar'
-    - 'mars'
+    - 'marts'
     - 'april'
-    - 'mai'
+    - 'maj'
     - 'juni'
     - 'juli'
     - 'august'
     - 'september'
     - 'oktober'
     - 'november'
-    - 'desember'
+    - 'december'
   DAYS_OF_THE_WEEK:
     - 'mandag'
     - 'tirsdag'


### PR DESCRIPTION
– Fixing months names that were wrong (therefore unusable on a Danish site showing dates)
– Removing INFLECTOR_UNCOUNTABLE and INFLECTOR_IRREGULAR which were just straight translated from English and irrelevant

Not sure how the original file was made? But it seems that there’s a need for fixing these languages files in general with actual grammar/vocabulary from the languages.