### PR TITLE
security: validate ZIP entry paths in ZipArchiver::extract() to prevent Zip Slip

### DIFF
--- a/system/src/Grav/Common/Filesystem/ZipArchiver.php
+++ b/system/src/Grav/Common/Filesystem/ZipArchiver.php
@@ -13,6 +13,8 @@ use InvalidArgumentException;
 use RuntimeException;
 use ZipArchive;
 use function extension_loaded;
+use function realpath;
+use function str_starts_with;
 use function strlen;
 
 /**
@@ -33,6 +35,30 @@ class ZipArchiver extends Archiver
 
         if ($archive === true) {
             Folder::create($destination);
+
+            // Validate every entry path before extracting to prevent Zip Slip
+            // (path traversal via crafted entry names such as "../../evil.php").
+            $destination = rtrim((string) realpath($destination) ?: $destination, '/\\') . DIRECTORY_SEPARATOR;
+            for ($i = 0, $count = $zip->count(); $i < $count; $i++) {
+                $name = $zip->getNameIndex($i);
+                if ($name === false) {
+                    continue;
+                }
+                // Resolve the entry's target path and ensure it stays within $destination.
+                $entryPath = realpath($destination . $name);
+                if ($entryPath === false) {
+                    // realpath() returns false for non-existent paths; build a normalised path instead.
+                    $entryPath = $destination . $name;
+                }
+                // Normalise directory separators before the prefix check.
+                $entryPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $entryPath);
+                if (!str_starts_with($entryPath, $destination)) {
+                    $zip->close();
+                    throw new RuntimeException(
+                        'ZipArchiver: Zip Slip detected — entry "' . $name . '" would extract outside destination directory.'
+                    );
+                }
+            }
 
             if (!$zip->extractTo($destination)) {
                 throw new RuntimeException('ZipArchiver: ZIP failed to extract ' . $this->archive_file . ' to ' . $destination);


### PR DESCRIPTION
## Summary

`ZipArchiver::extract()` calls `$zip->extractTo($destination)` without first validating that every entry path inside the ZIP archive stays within the intended destination directory.

A crafted ZIP file containing entries like:
- `../../config/security.yaml`
- `../../../../etc/cron.d/evil`
- `../user/config/system.yaml` (overwrites Grav configuration)

would be silently extracted outside $destination — a **Zip Slip** vulnerability.

## Attack Vector

Grav's package manager (`InstallCommand`, `SelfupgradeCommand`, `DirectInstallCommand`) uses `ZipArchiver` to extract theme, plugin, and core update packages. An attacker who can supply a malicious ZIP (e.g. via a compromised GPM package, a man-in-the-middle, or the admin panel's direct install) can overwrite arbitrary files on the server — including PHP files, configuration, cron scripts, or SSH authorized_keys.

## Fix

Before calling `extractTo()`, iterate over all entries with `ZipArchive::count()` / `getNameIndex()` and reject any entry whose resolved path does not begin with the canonicalized `$destination` prefix.

This is the same defensive pattern used by:
- **TYPO3** `ZipService::verify()`
- **PrestaShop** (our fix: #41578)
- **Joomla** template installer (our fix: #47859)
- **OWASP** Zip Slip guidance

## Impact

| | |
|---|---|
| **CWE** | CWE-22: Path Traversal |
| **Attack** | Crafted ZIP → arbitrary file write → RCE |
| **Precondition** | Attacker can supply a ZIP to any Grav ZIP-consuming code path |

## No Behaviour Change

All well-formed archives (entries that stay within the destination) are unaffected.