### PR TITLE
security: restrict allowed_classes in JobQueue::reconstructJob() to prevent PHP Object Injection

### DIFF
--- a/system/src/Grav/Common/Scheduler/JobQueue.php
+++ b/system/src/Grav/Common/Scheduler/JobQueue.php
@@ -460,9 +460,10 @@ class JobQueue
     protected function reconstructJob(array $item): ?Job
     {
         if (isset($item['serialized_job'])) {
-            // Unserialize the job
+            // Unserialize the job; restrict to Job::class to prevent PHP Object Injection
+            // via a crafted queue backend entry that could trigger a gadget chain.
             try {
-                $job = unserialize(base64_decode($item['serialized_job']));
+                $job = unserialize(base64_decode($item['serialized_job']), ['allowed_classes' => [Job::class]]);
                 if ($job instanceof Job) {
                     return $job;
                 }


### PR DESCRIPTION
## Summary

`JobQueue::reconstructJob()` calls `unserialize(base64_decode($item['serialized_job']))` without an `allowed_classes` restriction. The queue state is stored in a JSON file under the Grav data directory. An attacker who can write to that file (e.g. via a path traversal, insecure file permissions, or an admin-panel upload bypass) can inject a PHP Object Injection payload that instantiates arbitrary classes available in the autoloader during deserialization — potentially leading to Remote Code Execution via a gadget chain.

Note: the existing `if ($job instanceof Job)` check only validates the result **after** deserialization, so the gadget chain fires before the check rejects the payload.

## Fix

Pass `['allowed_classes' => [Job::class]]` to `unserialize()`. The serialized value is always a `Grav\Common\Scheduler\Job` object (serialized on line 95 in the same class), so this restriction is safe and does not change behaviour for legitimate queue entries.

## Impact

| | |
|---|---|
| **CWE** | CWE-502: Deserialization of Untrusted Data |
| **Attack** | Write crafted JSON to queue file → `unserialize()` instantiates gadget → RCE |
| **Precondition** | Write access to the Grav scheduler queue JSON file |

## No Behaviour Change

All legitimate queue entries (serialized `Job` objects) are unaffected. Invalid entries that previously returned `null` continue to return `null`.