### PR TITLE
Stop gitignoring user/config/security.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ user/plugins/*
 !user/plugins/.*
 user/themes/*
 !user/themes/.*
-user/**/config/security.yaml
+# security.yaml holds only policy now (twig_content, twig_sandbox, xss rules) —
+# the per-site secret moved to security-private.php in 2.0.0-beta.2
+# (GHSA-3f29-pqwf-v4j4), so the policy file is safe (and useful) to commit.
 user/**/config/security-private.php
 user/**/config/security-private.php.tmp
 


### PR DESCRIPTION
`security.yaml` no longer holds a secret — the per-site salt moved to `security-private.php` in 2.0.0-beta.2 (GHSA-3f29-pqwf-v4j4), with auto-migration scrubbing any legacy `salt:`. The file now holds only deployment policy (`twig_content`, `twig_sandbox`, `xss_*`, `uploads_dangerous_extensions`), which git-based deploys reasonably want under version control. The actual secret (`security-private.php`) stays ignored.

Closes #4135. Reported in getgrav/grav-plugin-error#47.