### PR TITLE
Bundle Shortcode Core with the core package

### DIFF
--- a/.dependencies
+++ b/.dependencies
@@ -11,6 +11,10 @@ git:
         url: https://github.com/trilbymedia/grav-plugin-github-markdown-alerts
         path: user/plugins/github-markdown-alerts
         branch: main
+    shortcode-core:
+        url: https://github.com/getgrav/grav-plugin-shortcode-core
+        path: user/plugins/shortcode-core
+        branch: master
     quark2:
         url: https://github.com/getgrav/grav-theme-quark2
         path: user/themes/quark2
@@ -27,6 +31,10 @@ links:
     github-markdown-alerts:
         src: grav-plugin-github-markdown-alerts
         path: user/plugins/github-markdown-alerts
+        scm: github
+    shortcode-core:
+        src: grav-plugin-shortcode-core
+        path: user/plugins/shortcode-core
         scm: github
     quark2:
         src: grav-theme-quark2


### PR DESCRIPTION
Adds `shortcode-core` to the bundled-plugin manifest (`.dependencies`), enabled by default, so the `[translate]` and `[uri]` shortcodes ship out of the box.

This makes shortcodes the first-class, always-available replacement for Twig in page content (gated by default in 2.0). The error plugin's 404 message already uses `[translate]`, and login's password-reset page uses `[uri]`.

Part of #4133.

Note: the admin package (login/form/email/admin) needs the same addition so login's interim `shortcode-core` dependency is satisfied in a fresh grav-admin install.