### PR TITLE
Block Makefiles in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -61,9 +61,9 @@ RewriteRule ^(\.git|cache|bin|logs|backup|webserver-configs|tests)/(.*) error [F
 # Block all direct access to these sensitive user folders, whatever the file type
 RewriteRule ^(user)/(accounts|config|data|env)/(.*) error [F]
 # Block access to specific file types for these system folders
-RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(system|vendor)/(.*)\.(txt|xml|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat|Makefile)$ error [F]
 # Block access to specific file types for these user folders
-RewriteRule ^(user)/(.*)\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ error [F]
+RewriteRule ^(user)/(.*)\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat|Makefile)$ error [F]
 # Block all direct access to .md files:
 RewriteRule \.md$ error [F]
 # Block all direct access to files and folders beginning with a dot


### PR DESCRIPTION
I'm using a Makefile in my own theme building, and had to add my own .htaccess to block it, but it would be better to add it to the global .htaccess which already includes other common scripting filetypes such as py, sh and bat. This change simply adds Makefile to that list.