### PR TITLE
Fix unicode handling issue in inflector method hyphenize

### DIFF
--- a/system/src/Grav/Common/Inflector.php
+++ b/system/src/Grav/Common/Inflector.php
@@ -225,7 +225,7 @@ class Inflector
         $regex1 = preg_replace('/([A-Z]+)([A-Z][a-z])/', '\1-\2', $word);
         $regex2 = preg_replace('/([a-z])([A-Z])/', '\1-\2', $regex1);
         $regex3 = preg_replace('/([0-9])([A-Z])/', '\1-\2', $regex2);
-        $regex4 = preg_replace('/[^\p{L}^0-9]+/', '-', $regex3);
+        $regex4 = preg_replace('/[^\p{L}^0-9]+/u', '-', $regex3);
 
         $regex4 = trim($regex4, '-');
 

--- a/tests/unit/Grav/Common/InflectorTest.php
+++ b/tests/unit/Grav/Common/InflectorTest.php
@@ -85,6 +85,7 @@ class InflectorTest extends \Codeception\TestCase\Test
         self::assertSame('this-string-is-hyphenized', $this->inflector->hyphenize('ThisStringIsHyphenized'));
         self::assertSame('this-string-is-hyphenized', $this->inflector->hyphenize('This-String-Is-Hyphenized'));
         self::assertSame('this-string-is-hyphenized', $this->inflector->hyphenize('This_String_Is_Hyphenized'));
+        self::assertSame('wörter-mit-bindestrich-getrennt', $this->inflector->hyphenize('Wörter_mit_Bindestrich_getrennt'));
     }
 
     public function testHumanize(): void


### PR DESCRIPTION
## Summary

On a modular site the on-page menu anchor links are not shown correctly if they are containing Unicode letters like `ä`, `ü`, `ö` and so on. This does not have a negative effect on the behavior of the links in my tests but looks strange in the addressbar and on mouseover.

## Environment

- Grav v2.0.0-rc.9
- Firefox 151
- PHP 8.5
- Apache Server

## Steps to Reproduce

1. Create a modular site with activated on-page menu and at least one module.
2. Name the module `Käsekuchen`.
3. Go to the frontend and click `Käsekuchen` in the navbar. 
4. Look at the adressbar and see `https://my-grav-page/#k?-sekuchen`

The `?` you're seeing is likely how your system displays the corrupted/replaced character.
The regex isn't recognizing `ä` as a valid letter.

## Reason

The quark2 module template uses the inflector class method hyphenize 
https://github.com/getgrav/grav-theme-quark2/blob/develop/templates/modular.html.twig#L45
and the pattern `/[^\p{L}^0-9]+/` from this method
https://github.com/getgrav/grav/blob/2.0/system/src/Grav/Common/Inflector.php#L223-L233
uses `\p{L}` (Unicode letter property), but **`\p{L}` only works in PHP when the `u` flag is set** to enable PCRE Unicode mode.

Without the `u` flag, `\p{L}` is treated as a literal character class that doesn't match Unicode letters properly, causing `ä` to be replaced  by the corrupted/replaced character. 

## Solution

Add the **`u` flag** at the end of the regex:

```php
$regex4 = preg_replace('/[^\p{L}^0-9]+/u', '-', (string) $regex3);
```
The `u` flag tells PCRE to treat the pattern as UTF-8 and properly interpret Unicode escape sequences like `\p{L}`.

## Testcase

The following assertion was added to https://github.com/getgrav/grav/blob/2.0/tests/unit/Grav/Common/InflectorTest.php#L83-L89 to confirm the changes are working as expected:

```php
self::assertSame('wörter-mit-bindestrich-getrennt', $this->inflector->hyphenize('Wörter_mit_Bindestrich_getrennt'));
```

Without the **`u` flag** at the end of the regex this test fails. 

```diff
There was 1 failure:
1) InflectorTest: Hyphenize
 Test  tests/unit/Grav/Common/InflectorTest.php:testHyphenize
Failed asserting that two strings are identical.
- Expected | + Actual
@@ @@
-'wörter-mit-bindestrich-getrennt>>+'w�-rter-mit-bindestrich-getrennt'
```

With the **`u` flag** at the end of the regex all tests succeeded. 

`OK (748 tests, 2705 assertions)`

## Similar Issue
https://github.com/getgrav/grav/issues/732