### PR TITLE
Update console output formatter style to recognize the `<blue>` tag

### DIFF
--- a/system/src/Grav/Console/Application/Application.php
+++ b/system/src/Grav/Console/Application/Application.php
@@ -132,6 +132,7 @@ class Application extends \Symfony\Component\Console\Application
         $formatter->setStyle('green', new OutputFormatterStyle('green', null, ['bold']));
         $formatter->setStyle('magenta', new OutputFormatterStyle('magenta', null, ['bold']));
         $formatter->setStyle('white', new OutputFormatterStyle('white', null, ['bold']));
+        $formatter->setStyle('blue', new OutputFormatterStyle('blue', null, ['bold']));
 
         parent::configureIO($input, $output);
     }


### PR DESCRIPTION
# Before
<img width="612" height="221" alt="console_blue_text_unfixed" src="https://github.com/user-attachments/assets/6ab846c2-7e80-46ca-bbd0-8ec939f0d1ec" />

---

# After
<img width="590" height="217" alt="console_blue_text_fixed" src="https://github.com/user-attachments/assets/f68035f5-46a6-4f94-91b6-6c9cd3d7ff05" />


