### PR TITLE
CI: manual (label-triggered) Claude code review, skip forks automatically

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,35 +1,47 @@
 name: Claude Code Review
 
 on:
+  # Auto-review internal PRs (branches pushed to this repo, not forks).
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Manual review of any PR (including forks): add the "claude-review" label.
+  pull_request_target:
+    types: [labeled]
+  # Manual review from the Actions tab: enter a PR number and click "Run workflow".
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Run when:
+    #  - it's an internal (non-fork) pull_request, OR
+    #  - the "claude-review" label was just added to a PR, OR
+    #  - it was started manually from the Actions tab.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'claude-review') ||
+      (github.event_name == 'workflow_dispatch')
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Determine PR number
+        id: pr
+        run: echo "number=${{ github.event.inputs.pr_number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
         id: claude-review
@@ -38,7 +50,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## What

Reworks `.github/workflows/claude-code-review.yml` so the Claude code review no longer fails on community PRs and can be started on demand.

### Why

Fork PRs ([#4157](https://github.com/getgrav/grav/pull/4157) was the trigger) run `pull_request` workflows in the fork context, where GitHub withholds repo secrets and OIDC. With no `CLAUDE_CODE_OAUTH_TOKEN`, the action fell back to fetching an OIDC token and died with `Could not fetch an OIDC token` on every fork PR.

### Triggers now

| Trigger | When | Forks |
|---|---|---|
| `pull_request` | Auto, internal (non-fork) branches only | skipped |
| `pull_request_target` (labeled) | A maintainer adds the **`claude-review`** label | ✅ |
| `workflow_dispatch` | Run from the Actions tab with a PR number | ✅ |

Both manual paths run in the base-repo context, so secrets/OIDC are present.

### Notes

- `pull-requests`/`issues` bumped to `write` so Claude can post the review (old config was read-only, which would have blocked commenting).
- The label path uses `pull_request_target` but only checks out the base branch — no fork code is executed; the label is gated to write-access users.
- The `claude-review` label and the `pull_request_target`/`workflow_dispatch` triggers only take effect once this is merged to `develop` (GitHub reads those from the default branch).

### Follow-up after merge

Create a label named exactly `claude-review`.