### PR TITLE
Allow documented media chain methods in Twig sandbox by default

### DIFF
--- a/system/config/security.yaml
+++ b/system/config/security.yaml
@@ -368,8 +368,16 @@ twig_sandbox:
     # sandbox (e.g. `{{ page.media['x.png'].url }}`). __tostring lives here too
     # so printing a medium keeps working when config_access is off (which
     # strips the Data fallback below).
+    #
+    # The action methods after the read accessors mirror Medium::ALLOWED_ACTIONS
+    # (the documented media chain on learn.getgrav.org /content/media — resize,
+    # cropResize, lightbox, link, format, the player attributes, etc.). These
+    # are the same actions already trusted from editor-authored URLs, so the
+    # standard `{{ page.media['x.jpg'].cropResize(..).lightbox(..).html() }}`
+    # idiom works under the sandbox without per-site allowlist edits. Keep this
+    # list in sync with Medium::ALLOWED_ACTIONS when new actions are documented.
     - class: 'Grav\Common\Page\Medium\Medium'
-      methods: 'url, html, filepath, filename, metadata, thumbnail, parsedownelement, __tostring'
+      methods: 'url, html, filepath, filename, metadata, thumbnail, parsedownelement, __tostring, resize, forceresize, cropresize, crop, zoomcrop, cropzoom, negate, brightness, contrast, grayscale, emboss, smooth, sharp, edge, colorize, sepia, enableprogressive, rotate, flip, fixorientation, gaussianblur, format, quality, watermark, derivatives, cache, lightbox, link, classes, style, id, attribute, width, height, sizes, autosizes, aspectratio, retinascale, loading, decoding, fetchpriority, display, reset, controls, controlslist, loop, autoplay, muted, preload, playsinline, poster'
     - class: 'Grav\Common\User\Interfaces\UserInterface'
       methods: 'authorize, authorized, authenticated, username, fullname, email, language, offsetget, offsetexists'
     - class: 'Grav\Common\Taxonomy'


### PR DESCRIPTION
## What

Widen the `Grav\Common\Page\Medium\Medium` entry in the default `security.twig_sandbox.allowed_methods` to mirror `Medium::ALLOWED_ACTIONS` — the documented media chain on learn.getgrav.org `/content/media` (`resize`, `cropResize`, `lightbox`, `link`, `format`, the player attributes, etc.).

## Why

With the content Twig sandbox enabled, the default allowlist included only the read accessors (`url`, `html`, `metadata`, ...) on the base `Medium` class, but **no** entry for the image-manipulation methods — those resolve on `ImageMedium` via `__call()` and were allow-listed nowhere. So the standard, documented idiom

```twig
{{ page.media['x.jpg'].cropResize(200,200).lightbox(1024,768).html() }}
```

was blocked out of the box (`[TwigSandbox] blocked rule=method token=lightbox ...`), forcing site owners to hand-edit `security.yaml` or disable the sandbox entirely. Reported in #4154 by a migrated 1.7 site.

## Safety

These actions are the same set already trusted from editor-authored URLs via `Medium::ALLOWED_ACTIONS`, so allowing them in sandboxed content Twig carries no new executable exposure. Keying on the base `Medium` class covers `ImageMedium` / `StaticImageMedium` / `AudioMedium` / `VideoMedium` (all extend it) in one entry. A comment ties the list back to `ALLOWED_ACTIONS` so the two stay in sync as new actions are documented.

## Notes

- Defaults-only change; no behavior change for sites that already customized the allowlist (per-class lists merge by position, and this writes the full list).
- Part of a broader "Twig in Content" streamlining effort (also refs getgrav/grav-plugin-migrate-grav#11).

Refs #4154.