### PR TITLE
Honor runtime page-visibility changes in nav menus (#4201)

### DIFF
--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -386,7 +386,14 @@ class Collection extends Iterator implements PageCollectionInterface
     {
         $filtered = [];
         foreach ($this->items as $path => $info) {
-            if (is_array($info) && array_key_exists($flag, $info)) {
+            // Trust the stored index flag only while the page is still lazy — that
+            // is the point of the index, letting navigation prune a folder without
+            // loading every sibling. Once a page is hydrated its live flags are
+            // authoritative: a plugin may have changed them at runtime (e.g. the
+            // Login plugin's dynamic page visibility toggles visible() per request
+            // based on the current user's access), and the frozen index flag would
+            // otherwise mask that. See getgrav/grav#4201.
+            if (is_array($info) && array_key_exists($flag, $info) && !$this->pages->isInstantiated($path)) {
                 $value = (bool)$info[$flag];
             } else {
                 $page = $this->pages->get($path);

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -967,11 +967,27 @@ class Pages
     }
 
     /**
+     * Check whether a page path has already been hydrated into memory, without
+     * triggering hydration.
+     *
+     * Collection flag filters use this to prefer a page's live flags (which a
+     * plugin may have changed at runtime, e.g. the Login plugin's dynamic page
+     * visibility) over the flags frozen in the children index, while still
+     * avoiding a load for pages that are only lazily indexed. See getgrav/grav#4201.
+     *
+     * @param string $path
+     * @return bool
+     */
+    public function isInstantiated($path): bool
+    {
+        return array_key_exists((string)$path, $this->instances);
+    }
+
+    /**
      * Get a page instance.
      *
      * @param  string $path The filesystem full path of the page
      * @return PageInterface|null
-     * @throws RuntimeException
      */
     public function get($path)
     {


### PR DESCRIPTION
Fixes #4201.

The 2.0 nav optimization (26b33b342) reads each page's visible/routable/published/module state from flags frozen in the children index at build time. That silently ignores plugins that toggle visibility per request — notably the Login plugin's `visibility_requires_access`, whose `visible(false)` on the live page instance was never consulted, so access-restricted pages stayed in the menu for anonymous visitors.

Prefer a page's live flags whenever it's already hydrated (exactly when a plugin has had a chance to change them); keep reading the frozen index flag for pages still lazy, preserving the optimization.

**Verified** on a live site with page caching on: without the fix an access-restricted page appears in the anonymous nav; with it, hidden.