### PR TITLE
Add HTTP language fallback mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 1. [](#new)
     * You can now filter, sort, and group a page's media by the values in their `.meta.yaml` metafiles directly in Twig, with new `filterBy`, `where`, `findBy`, `sortBy`, `groupBy`, and `withMeta` methods on `page.media`. Fixes [getgrav/grav#4200](https://github.com/getgrav/grav/issues/4200).
+    * Added per-language fallbacks for unsupported browser languages during `HTTP_ACCEPT_LANGUAGE` negotiation, allowing them to resolve to supported languages without exposing additional language routes.
 1. [](#bugfix)
     * [security] A page editor can no longer read arbitrary files from the server by pointing an image watermark at a traversal path such as `carrier.png?watermark=../secret.png`; an editor-supplied watermark path is now confined to the site's media, while operator-configured watermarks and stream URIs are unaffected ([GHSA-w3f4-8pj2-599w](https://github.com/getgrav/grav/security/advisories/GHSA-w3f4-8pj2-599w)).
     * [security] A page-edit account can no longer reach file-disclosure or secret-read functions by naming an arbitrary `Class::method` as a dynamic field's data provider; qualified providers are now limited to a known-safe allowlist, closing a bypass of the guard added in 2.0.7 and 2.0.9 ([GHSA-7pgq-cr25-xvc8](https://github.com/getgrav/grav/security/advisories/GHSA-7pgq-cr25-xvc8), [GHSA-cxv3-5jj3-cpgr](https://github.com/getgrav/grav/security/advisories/GHSA-cxv3-5jj3-cpgr)).

--- a/system/blueprints/config/system.yaml
+++ b/system/blueprints/config/system.yaml
@@ -454,6 +454,24 @@ form:
               validate:
                 type: bool
 
+            languages.http_accept_language_fallback:
+              type: list
+              label: PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK
+              help: PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK_HELP
+              fields:
+                key:
+                  type: key
+                  label: PLUGIN_ADMIN.LANGUAGE
+                  help: PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK_SOURCE_HELP
+                  placeholder: hr
+                value:
+                  type: selectize
+                  size: large
+                  placeholder: "bs, en"
+                  label: PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK_TARGETS
+                  help: PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK_TARGETS_HELP
+                  classes: fancy
+
             languages.override_locale:
               type: toggle
               label: PLUGIN_ADMIN.OVERRIDE_LOCALE

--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -27,6 +27,7 @@ languages:
   translations_fallback: true                    # Fallback through supported translations if active lang doesn't exist
   session_store_active: false                    # Store active language in session
   http_accept_language: false                    # Attempt to set the language based on http_accept_language header in the browser
+  http_accept_language_fallback: {}               # Map unsupported browser languages to supported languages. eg: {hr: ['bs'], sk: ['cs']}
   override_locale: false                         # Override the default or system locale with language specific one
   content_fallback: {}                           # Custom language fallbacks. eg: {fr: ['fr', 'en']}
   pages_fallback_only: false                     # DEPRECATED: Use `content_fallback` instead

--- a/system/src/Grav/Common/Language/Language.php
+++ b/system/src/Grav/Common/Language/Language.php
@@ -15,6 +15,7 @@ use Grav\Common\Config\Config;
 use Negotiation\AcceptLanguage;
 use Negotiation\LanguageNegotiator;
 use function array_key_exists;
+use function array_keys;
 use function count;
 use function in_array;
 use function is_array;
@@ -293,10 +294,18 @@ class Language
                     $this->config->get('system.languages.http_accept_language') &&
                     $accept = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? false) {
                     $negotiator = new LanguageNegotiator();
-                    $best_language = $negotiator->getBest($accept, $this->languages);
+                    $fallbacks = $this->getHttpLanguageFallbacks();
+                    $languages = $this->languages;
+
+                    foreach (array_keys($fallbacks) as $language) {
+                        $languages[] = $language;
+                    }
+
+                    $best_language = $negotiator->getBest($accept, $languages);
 
                     if ($best_language instanceof AcceptLanguage) {
-                        $this->setActive($best_language->getType());
+                        $language = $best_language->getType();
+                        $this->setActive($fallbacks[$language] ?? $language);
                     } else {
                         $this->setActive($this->getDefault());
                     }
@@ -688,5 +697,46 @@ class Language
         $languages[] = 'en';
 
         return array_values(array_unique($languages));
+    }
+
+    /**
+     * Get valid browser language fallbacks.
+     *
+     * @return array<string, string>
+     */
+    protected function getHttpLanguageFallbacks(): array
+    {
+        $fallbacks = $this->config->get('system.languages.http_accept_language_fallback', []);
+        if (!is_array($fallbacks)) {
+            return [];
+        }
+
+        $languages = [];
+
+        foreach ($fallbacks as $source => $targets) {
+            $source = (string) $source;
+
+            // Supported languages should always resolve directly.
+            if (!preg_match('/^[a-zA-Z]{2,3}(?:[-_][a-zA-Z0-9]{2,8})?$/', $source)
+                || in_array($source, $this->languages, true)
+            ) {
+                continue;
+            }
+
+            if (!is_array($targets)) {
+                $targets = [$targets];
+            }
+
+            foreach ($targets as $target) {
+                $target = (string) $target;
+
+                if (in_array($target, $this->languages, true)) {
+                    $languages[$source] = $target;
+                    break;
+                }
+            }
+        }
+
+        return $languages;
     }
 }


### PR DESCRIPTION
## Summary

Adds configurable fallbacks for unsupported browser languages during `HTTP_ACCEPT_LANGUAGE` negotiation.

```yaml
languages:
  supported: [en, bs, de, cs]
  http_accept_language: true
  http_accept_language_fallback:
    hr: [bs]
    sr: [bs]
    sk: [cs]
```

For this configuration, Croatian and Serbian browser preferences select Bosnian, while Slovak selects Czech. Only the configured supported languages become active languages and URL prefixes, so the fallback sources do not expose additional routes such as `/hr`, `/sr`, or `/sk`.

## Implementation

- Includes configured fallback sources in browser-language negotiation.
- Resolves the winning fallback source to the first configured target present in `languages.supported`.
- Preserves direct supported-language matches and browser quality ordering.
- Ignores malformed sources, mappings from already-supported sources, and unsupported targets.
- Adds the default configuration, system blueprint field, and changelog entry.

Regional browser tags are handled by the existing negotiation library; for example, `hr-HR` matches the configured `hr` fallback and `sr-Latn-RS` matches `sr`.

This setting applies only to browser negotiation. It does not turn fallback sources into supported URL language prefixes.

## Validation

- `php -l system/src/Grav/Common/Language/Language.php`
- Parsed `system/config/system.yaml` and `system/blueprints/config/system.yaml` with Symfony YAML.
- Checked `hr-HR -> bs`, `sr-Latn-RS -> bs`, and `sk-SK -> cs`.
- Checked browser quality ordering between direct and mapped languages.
- `git diff --check`

## Follow-up

The new `PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK*` blueprint labels need corresponding Admin2 translation strings.
