### PR TITLE
feat(ci): add dependabot to keep GH Actions up to date

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "quarterly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Limit bot to update only quarterly to avoid spam and save resources. Also group to one PR to limit PR spam.

## Reference

Was already merged with #3866 but lost due restructuring branch `develop`.

fixes #3865