### PR TITLE
Add new Twig filter/function array_group_by for grouping arrays

### DIFF
--- a/system/src/Grav/Common/Twig/Extension/GravExtension.php
+++ b/system/src/Grav/Common/Twig/Extension/GravExtension.php
@@ -145,6 +145,7 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('wordcount', [$this, 'wordCountFilter']),
             new TwigFilter('json_decode', $this->jsonDecodeFilter(...)),
             new TwigFilter('array_unique', 'array_unique'),
+            new TwigFilter('array_group_by', [$this, 'arrayGroupByFilter'], ['needs_environment' => true]),
             new TwigFilter('basename', 'basename'),
             new TwigFilter('dirname', 'dirname'),
             new TwigFilter('print_r', $this->printRGuarded(...), ['needs_environment' => true]),
@@ -1463,6 +1464,68 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
      * @param string $key     The cookie name to retrieve
      * @return string
      */
+
+    /**
+     * Group items in an array by the results of a callback function
+     *
+     * @param Environment $env The Twig environment
+     * @param array|\Traversable $array The array or collection to group
+     * @param string|callable $callback Property name or callable to determine group key
+     * @return array Grouped array with keys as group identifiers and values as arrays of items
+     */
+    public function arrayGroupByFilter(Environment $env, $array, $callback): array
+    {
+        $groups = [];
+        
+        // Convert to array if it's a Traversable object (like Grav Collections)
+        if ($array instanceof \Traversable) {
+            $array = iterator_to_array($array);
+        }
+        
+        if (!is_array($array)) {
+            return [];
+        }
+        
+        foreach ($array as $key => $item) {
+            // If callback is a string, treat it as a property/method name
+            if (is_string($callback)) {
+                // Try to get the value using different methods
+                if (is_array($item) && isset($item[$callback])) {
+                    $groupKey = $item[$callback];
+                } elseif (is_object($item)) {
+                    if (method_exists($item, $callback)) {
+                        $groupKey = $item->$callback();
+                    } elseif (property_exists($item, $callback)) {
+                        $groupKey = $item->$callback;
+                    } elseif (method_exists($item, '__get')) {
+                        $groupKey = $item->$callback;
+                    } else {
+                        $groupKey = 'undefined';
+                    }
+                } else {
+                    $groupKey = 'undefined';
+                }
+            } else {
+                // Execute the callback function
+                try {
+                    $groupKey = call_user_func($callback, $item, $key, $env);
+                } catch (\Exception $e) {
+                    $groupKey = 'undefined';
+                }
+            }
+            
+            // Initialize group array if it doesn't exist
+            if (!isset($groups[$groupKey])) {
+                $groups[$groupKey] = [];
+            }
+            
+            // Add item to its group
+            $groups[$groupKey][] = $item;
+        }
+        
+        return $groups;
+    }
+
     public function getCookie($key)
     {
         $cookie_value = filter_input(INPUT_COOKIE, $key);

--- a/system/src/Grav/Common/Twig/Extension/GravExtension.php
+++ b/system/src/Grav/Common/Twig/Extension/GravExtension.php
@@ -145,7 +145,7 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('wordcount', [$this, 'wordCountFilter']),
             new TwigFilter('json_decode', $this->jsonDecodeFilter(...)),
             new TwigFilter('array_unique', 'array_unique'),
-            new TwigFilter('array_group_by', [$this, 'arrayGroupByFilter'], ['needs_environment' => true]),
+            new TwigFilter('array_group_by', $this->arrayGroupByFilter(...), ['needs_environment' => true, 'needs_is_sandboxed' => true]),
             new TwigFilter('basename', 'basename'),
             new TwigFilter('dirname', 'dirname'),
             new TwigFilter('print_r', $this->printRGuarded(...), ['needs_environment' => true]),
@@ -198,6 +198,7 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('array_key_value', $this->arrayKeyValueFunc(...)),
             new TwigFunction('array_key_exists', 'array_key_exists'),
             new TwigFunction('array_unique', 'array_unique'),
+            new TwigFunction('array_group_by', $this->arrayGroupByFilter(...), ['needs_environment' => true, 'needs_is_sandboxed' => true]),
             new TwigFunction('array_intersect', $this->arrayIntersectFunc(...)),
             new TwigFunction('array_diff', 'array_diff'),
             new TwigFunction('authorize', $this->authorize(...)),
@@ -762,10 +763,10 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
 
         // Strip HTML tags and decode entities
         $cleanText = html_entity_decode(strip_tags($text), ENT_QUOTES, 'UTF-8');
-        
+
         // Remove extra whitespace and normalize
         $cleanText = trim(preg_replace('/\s+/', ' ', $cleanText));
-        
+
         if (empty($cleanText)) {
             return 0;
         }
@@ -778,27 +779,27 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
             case 'chinese':
                 // Chinese: count characters (excluding spaces and punctuation)
                 return mb_strlen(preg_replace('/[\s\p{P}]/u', '', $cleanText), 'UTF-8');
-                
+
             case 'ja':
             case 'japanese':
                 // Japanese: count characters (excluding spaces)
                 return mb_strlen(preg_replace('/\s/', '', $cleanText), 'UTF-8');
-                
+
             case 'ko':
             case 'korean':
                 // Korean: count characters (excluding spaces)
                 return mb_strlen(preg_replace('/\s/', '', $cleanText), 'UTF-8');
-                
+
             default:
                 // Western languages: use improved word counting
                 // Handle contractions, hyphenated words, and numbers better
                 $words = preg_split('/\s+/', $cleanText, -1, PREG_SPLIT_NO_EMPTY);
-                
+
                 // Filter out pure punctuation
                 $words = array_filter($words, function($word) {
                     return preg_match('/\w/', $word);
                 });
-                
+
                 return count($words);
         }
     }
@@ -1361,6 +1362,99 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
+     * Group items in an array by the results of a callback function
+     *
+     * Registered with 'needs_is_sandboxed' so this follows the same pattern
+     * Twig core uses for its own callback filters (sort/map/filter/column/
+     * reduce/find — see CoreExtension::checkArrow()). In sandbox mode only a
+     * real \Closure — i.e. an arrow function compiled from the sandboxed
+     * template itself — is accepted as $callback. A Closure's own attribute/
+     * property access is already routed through GravSecurityPolicy by Twig's
+     * normal attribute compilation, so nothing extra is needed for that case.
+     *
+     * A string $callback would let sandboxed content call an arbitrary
+     * method on each item by name ($item->$callback()), and any other PHP
+     * callable would let it invoke an arbitrary global function via
+     * call_user_func() — neither goes through the sandbox, so both are
+     * refused while sandboxed. Outside the sandbox both keep working exactly
+     * as before.
+     *
+     * @param Environment $env The Twig environment
+     * @param bool $isSandboxed Whether the current render is sandboxed (injected by Twig)
+     * @param array|\Traversable $array The array or collection to group
+     * @param string|callable $callback Property name or callable to determine group key.
+     *                                  Must be a \Closure when $isSandboxed is true.
+     * @return array Grouped array with keys as group identifiers and values as arrays of items
+     * @throws RuntimeError if $callback is not a Closure while sandboxed
+     */
+    public function arrayGroupByFilter(Environment $env, bool $isSandboxed, $array, $callback): array
+    {
+        if ($isSandboxed && !$callback instanceof \Closure) {
+            throw new RuntimeError('The callable passed to the "array_group_by" filter must be a Closure in sandbox mode.');
+        }
+
+        $groups = [];
+
+        // Convert to array if it's a Traversable object (like Grav Collections)
+        if ($array instanceof \Traversable) {
+            $array = iterator_to_array($array);
+        }
+
+        if (!is_array($array)) {
+            return [];
+        }
+
+        foreach ($array as $key => $item) {
+            if ($callback instanceof \Closure) {
+                // Sandboxed arrow function: attribute access inside it is
+                // already checked by Twig's own attribute compilation.
+                $groupKey = $callback($item, $key);
+            } elseif (is_string($callback)) {
+                // If callback is a string, treat it as a property/method name.
+                // Only reachable outside the sandbox (see the check above).
+                // Try to get the value using different methods
+                if (is_array($item) && array_key_exists($callback, $item)) {
+                    $groupKey = $item[$callback];
+                } elseif (is_object($item)) {
+                    if (method_exists($item, $callback)) {
+                        $groupKey = $item->$callback();
+                    } elseif (property_exists($item, $callback)) {
+                        $groupKey = $item->$callback;
+                    } elseif (method_exists($item, '__get')) {
+                        $groupKey = $item->$callback;
+                    } else {
+                        $groupKey = 'undefined';
+                    }
+                } else {
+                    $groupKey = 'undefined';
+                }
+            } else {
+                // Execute the callback function. Only reachable outside the
+                // sandbox (see the check above). Real errors are allowed to
+                // propagate instead of being silently mapped to 'undefined'.
+                $groupKey = call_user_func($callback, $item, $key, $env);
+            }
+
+            // A group key must be a valid PHP array offset (int|string).
+            // Fall back to 'undefined' for null and for anything else (e.g.
+            // arrays/objects), instead of letting PHP throw "Illegal offset type".
+            if ($groupKey === null || (!is_int($groupKey) && !is_string($groupKey))) {
+                $groupKey = 'undefined';
+            }
+
+            // Initialize group array if it doesn't exist
+            if (!isset($groups[$groupKey])) {
+                $groups[$groupKey] = [];
+            }
+
+            // Add item to its group
+            $groups[$groupKey][] = $item;
+        }
+
+        return $groups;
+    }
+
+    /**
      * Translate a string
      *
      * @return string
@@ -1464,68 +1558,6 @@ class GravExtension extends AbstractExtension implements GlobalsInterface
      * @param string $key     The cookie name to retrieve
      * @return string
      */
-
-    /**
-     * Group items in an array by the results of a callback function
-     *
-     * @param Environment $env The Twig environment
-     * @param array|\Traversable $array The array or collection to group
-     * @param string|callable $callback Property name or callable to determine group key
-     * @return array Grouped array with keys as group identifiers and values as arrays of items
-     */
-    public function arrayGroupByFilter(Environment $env, $array, $callback): array
-    {
-        $groups = [];
-        
-        // Convert to array if it's a Traversable object (like Grav Collections)
-        if ($array instanceof \Traversable) {
-            $array = iterator_to_array($array);
-        }
-        
-        if (!is_array($array)) {
-            return [];
-        }
-        
-        foreach ($array as $key => $item) {
-            // If callback is a string, treat it as a property/method name
-            if (is_string($callback)) {
-                // Try to get the value using different methods
-                if (is_array($item) && isset($item[$callback])) {
-                    $groupKey = $item[$callback];
-                } elseif (is_object($item)) {
-                    if (method_exists($item, $callback)) {
-                        $groupKey = $item->$callback();
-                    } elseif (property_exists($item, $callback)) {
-                        $groupKey = $item->$callback;
-                    } elseif (method_exists($item, '__get')) {
-                        $groupKey = $item->$callback;
-                    } else {
-                        $groupKey = 'undefined';
-                    }
-                } else {
-                    $groupKey = 'undefined';
-                }
-            } else {
-                // Execute the callback function
-                try {
-                    $groupKey = call_user_func($callback, $item, $key, $env);
-                } catch (\Exception $e) {
-                    $groupKey = 'undefined';
-                }
-            }
-            
-            // Initialize group array if it doesn't exist
-            if (!isset($groups[$groupKey])) {
-                $groups[$groupKey] = [];
-            }
-            
-            // Add item to its group
-            $groups[$groupKey][] = $item;
-        }
-        
-        return $groups;
-    }
-
     public function getCookie($key)
     {
         $cookie_value = filter_input(INPUT_COOKIE, $key);

--- a/tests/unit/Grav/Common/Twig/Extensions/GravExtensionTest.php
+++ b/tests/unit/Grav/Common/Twig/Extensions/GravExtensionTest.php
@@ -3,6 +3,9 @@
 use Codeception\Util\Fixtures;
 use Grav\Common\Grav;
 use Grav\Common\Twig\Extension\GravExtension;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Loader\ArrayLoader;
 
 /**
  * Class GravExtensionTest
@@ -15,11 +18,15 @@ class GravExtensionTest extends \PHPUnit\Framework\TestCase
     /** @var  GravExtension $twig_ext */
     protected $twig_ext;
 
+    /** @var Environment $env */
+    protected $env;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->grav = Fixtures::get('grav');
         $this->twig_ext = new GravExtension();
+        $this->env = new Environment(new ArrayLoader());
     }
 
     public function testInflectorFilter(): void
@@ -199,5 +206,68 @@ class GravExtensionTest extends \PHPUnit\Framework\TestCase
         // reversed range
         self::assertSame(array_reverse($hundred), $this->twig_ext->rangeFunc(100, 0));
         self::assertSame([4, 2, 0], $this->twig_ext->rangeFunc(4, 0, 2));
+    }
+
+    public function testArrayGroupByFilterByArrayKey(): void
+    {
+        $items = [
+            ['type' => 'fruit', 'name' => 'apple'],
+            ['type' => 'veg', 'name' => 'carrot'],
+            ['type' => 'fruit', 'name' => 'banana'],
+        ];
+
+        $result = $this->twig_ext->arrayGroupByFilter($this->env, false, $items, 'type');
+
+        self::assertCount(2, $result);
+        self::assertCount(2, $result['fruit']);
+        self::assertCount(1, $result['veg']);
+        self::assertSame('apple', $result['fruit'][0]['name']);
+        self::assertSame('banana', $result['fruit'][1]['name']);
+        self::assertSame('carrot', $result['veg'][0]['name']);
+    }
+
+    public function testArrayGroupByFilterByObjectProperty(): void
+    {
+        $apple = new \stdClass();
+        $apple->type = 'fruit';
+        $apple->name = 'apple';
+
+        $carrot = new \stdClass();
+        $carrot->type = 'veg';
+        $carrot->name = 'carrot';
+
+        $result = $this->twig_ext->arrayGroupByFilter($this->env, false, [$apple, $carrot], 'type');
+
+        self::assertCount(1, $result['fruit']);
+        self::assertSame('apple', $result['fruit'][0]->name);
+        self::assertCount(1, $result['veg']);
+        self::assertSame('carrot', $result['veg'][0]->name);
+    }
+
+    public function testArrayGroupByFilterByClosure(): void
+    {
+        $items = [1, 2, 3, 4, 5];
+
+        $result = $this->twig_ext->arrayGroupByFilter($this->env, false, $items, fn($v) => $v % 2 === 0 ? 'even' : 'odd');
+
+        self::assertSame([1, 3, 5], $result['odd']);
+        self::assertSame([2, 4], $result['even']);
+    }
+
+    public function testArrayGroupByFilterAcceptsClosureInSandbox(): void
+    {
+        $items = [1, 2, 3, 4];
+
+        $result = $this->twig_ext->arrayGroupByFilter($this->env, true, $items, fn($v) => $v % 2 === 0 ? 'even' : 'odd');
+
+        self::assertSame([1, 3], $result['odd']);
+        self::assertSame([2, 4], $result['even']);
+    }
+
+    public function testArrayGroupByFilterRejectsNonClosureInSandbox(): void
+    {
+        $this->expectException(RuntimeError::class);
+
+        $this->twig_ext->arrayGroupByFilter($this->env, true, [1, 2, 3], 'strval');
     }
 }


### PR DESCRIPTION
#### **Description**

This PR introduces a new Twig **filter and function** named `array_group_by` that allows grouping arrays or Grav collections by a property, method, or callback result.

It provides a convenient way to organize content directly in Twig templates — for example, grouping pages by category, year, or author — without writing custom PHP logic.

#### **Usage Example**

```twig
{# Prepare collection with category #}
{% set collection_with_category = [] %}
{% for post in page.collection() %}
    {% set category = post.taxonomy.category|first ?: 'uncategorized' %}
    {% set collection_with_category = collection_with_category|merge([{
        post: post,
        category: category
    }]) %}
{% endfor %}

{# Group by category #}
{% set posts_by_category = collection_with_category|array_group_by('category') %}

{# Display grouped posts #}
{% for category, posts in posts_by_category %}
    <h3>{{ category|capitalize }}</h3>
    {% for item in posts %}
        <div>{{ item.post.title }}</div>
    {% endfor %}
{% endfor %}
```