### PR TITLE
Allow read_file() to read .css files by default (#4215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.12
+## 07/20/2026
+
+1. [](#improved)
+    * The `read_file()` Twig function can now read `.css` files by default, so inline stylesheets can be embedded in a template without adjusting the security config ([#4215](https://github.com/getgrav/grav/issues/4215)).
+
 # v2.0.11
 ## 07/13/2026
 

--- a/system/config/security.yaml
+++ b/system/config/security.yaml
@@ -474,6 +474,7 @@ read_file:
     - txt
     - html
     - htm
+    - css
     - json
     - csv
     - xml

--- a/system/defines.php
+++ b/system/defines.php
@@ -9,7 +9,7 @@
 
 // Some standard defines
 define("GRAV", true);
-define("GRAV_VERSION", "2.0.11");
+define("GRAV_VERSION", "2.0.12");
 define("GRAV_SCHEMA", "1.8.0_2026-06-09_0");
 define("GRAV_TESTING", false);
 

--- a/system/src/Grav/Common/Helpers/FileReader.php
+++ b/system/src/Grav/Common/Helpers/FileReader.php
@@ -114,7 +114,7 @@ final class FileReader
         // (3) Extension allow-list. Default set is text/content formats only.
         $extension = strtolower((string) pathinfo($streamPath, PATHINFO_EXTENSION));
         $allowedExtensions = (array) $config->get('security.read_file.allowed_extensions', [
-            'md', 'markdown', 'txt', 'html', 'htm', 'json', 'csv', 'xml', 'svg'
+            'md', 'markdown', 'txt', 'html', 'htm', 'css', 'json', 'csv', 'xml', 'svg'
         ]);
         if ($extension === '' || !in_array($extension, $allowedExtensions, true)) {
             return false;


### PR DESCRIPTION
`css` was missing from `security.read_file.allowed_extensions`, so embedding an inline stylesheet via `read_file()` in a `{% style %}` block was blocked out of the box. CSS is inert text — the same threat class as the already-allowed `html`/`txt` and strictly safer than `svg` — so it's added to both the config default and the hardcoded fallback. Docs updated in a paired grav-learn PR.

Fixes #4215