### PR TITLE
Docblock: GlobalMedia's inherited collection queries need media_directory() (#4210)

### DIFF
--- a/system/src/Grav/Common/Page/Medium/GlobalMedia.php
+++ b/system/src/Grav/Common/Page/Medium/GlobalMedia.php
@@ -18,6 +18,15 @@ use function dirname;
 /**
  * Class GlobalMedia
  * @package Grav\Common\Page\Medium
+ *
+ * NOTE: GlobalMedia resolves media lazily, one stream at a time via
+ * {@see offsetGet()}/{@see addMedium()}; it never enumerates `user://media`
+ * into `$items`. Because of that, the collection-level query methods it inherits
+ * from {@see AbstractMedia} — filterBy()/where()/findBy()/sortBy()/groupBy()/
+ * withMeta() — all operate on an empty item set and silently return nothing.
+ * To filter or sort site media as a collection, build a concrete
+ * {@see \Grav\Common\Page\Media} over the folder instead, e.g.
+ * `media_directory('user://media')`, and query that.
  */
 class GlobalMedia extends AbstractMedia
 {


### PR DESCRIPTION
`GlobalMedia` extends `AbstractMedia` and so inherits `filterBy/where/findBy/sortBy/groupBy/withMeta`, but it resolves lazily (`offsetGet`/`addMedium`) and never enumerates `user://media`, so those collection queries silently return nothing. Adds a class docblock note pointing developers to `media_directory('user://media')` for collection queries. Docs-only, no behavior change.

Ref #4210