### PR TITLE
Update nginx.conf - anchoring location directives

### DIFF
--- a/webserver-configs/nginx.conf
+++ b/webserver-configs/nginx.conf
@@ -18,29 +18,29 @@ server {
 
     ## Begin - Security
     # deny all direct access for these folders
-    location ~* /(\.git|cache|bin|logs|backup|tests)/.*$ { return 403; }
+    location ~* ^/(\.git|cache|bin|logs|backup|tests)/.*$ { return 403; }
     # deny all direct access to these sensitive user folders, whatever the file type
-    location ~* /user/(config|env)/.*$ { return 403; }
+    location ~* ^/user/(config|env)/.*$ { return 403; }
     # allow avatar images under user/accounts to be served directly, whether stored
     # at user/accounts/avatars/<file> (flatfile accounts) or user/accounts/<username>/
     # <file> (Flex folder storage); this must come before the user/accounts deny so it
     # wins the first-match. SVG is intentionally excluded as a stored-XSS vector.
-    location ~* /user/accounts/[^/]+/[^/]+\.(jpe?g|png|gif|webp|avif|bmp|ico)$ { try_files $uri =404; }
+    location ~* ^/user/accounts/[^/]+/[^/]+\.(jpe?g|png|gif|webp|avif|bmp|ico)$ { try_files $uri =404; }
     # deny everything else under user/accounts, whatever the file type
-    location ~* /user/accounts/.*$ { return 403; }
+    location ~* ^/user/accounts/.*$ { return 403; }
     # allow public media uploads under user/data (e.g. Flex Object images) to be
     # served directly; this must come before the user/data deny so it wins the
     # first-match. SVG is intentionally excluded as a stored-XSS vector.
-    location ~* /user/data/.*\.(jpe?g|png|gif|webp|avif|bmp|ico|mp4|webm|ogg|ogv|mov|mp3|wav|m4a|flac|pdf)$ { try_files $uri =404; }
+    location ~* ^/user/data/.*\.(jpe?g|png|gif|webp|avif|bmp|ico|mp4|webm|ogg|ogv|mov|mp3|wav|m4a|flac|pdf)$ { try_files $uri =404; }
     # deny everything else under user/data, whatever the file type
-    location ~* /user/data/.*$ { return 403; }
+    location ~* ^/user/data/.*$ { return 403; }
     # deny running scripts inside core system folders
-    location ~* /(system|vendor)/.*\.(txt|xml|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ { return 403; }
+    location ~* ^/(system|vendor)/.*\.(txt|xml|md|html|htm|shtml|shtm|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny running scripts inside user folder
-    location ~* /user/.*\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ { return 403; }
+    location ~* ^/user/.*\.(txt|md|json|yaml|yml|php|php2|php3|php4|php5|phar|phtml|pl|py|cgi|twig|sh|bat)$ { return 403; }
     # deny access to specific files in the root folder
-    location ~ /(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) { return 403; }
-    # deny access to .env environment files
+    location ~ ^/(LICENSE\.txt|composer\.lock|composer\.json|nginx\.conf|web\.config|htaccess\.txt|\.htaccess) { return 403; }
+    # deny access to .env environment files (expression purposefully not anchored)
     location ~ /\.env(\.|$) { return 403; }
     ## End - Security
 


### PR DESCRIPTION
Modified 'location' directives in the stanza "## <Begin/End> - Security" to reflect intention captured in 'htaccess.txt': anchoring the start of some regular expressions used in location matching.

For sites served by nginx, this fixes an error message received in Admin2, selecting "Tools -> Logs".  

Worth noting - this behavior (start-anchored regex) existed in earlier versions, but was removed (perhaps inadvertently) in commit 8899b3ebb86ed14e5718178afe922482d9433a0f 

I believe the behavior of non-anchored expressions has been acceptable for quite a long time, since the vast majority of matches would have been equivalent (whether using anchored or non-anchored). However, with the new(ish) reliance on API calls (most notably Admin2), the api call to fetch logs ("/api/v1/system/logs/files") is caught by the non-anchored location check to deny access to certain files/folders: "/(\.git|cache|bin|logs|backup|tests)/.*$"  

Arguably, the case could be made for adding a higher-priority match expression for URLs matching "/api/v1" (or similar), and keeping location expressions as-is (no start anchor), but given that "htaccess", "lighttpd", and "web.config" are all similarly configured (start anchor), it would seem prudent to conform nginx to match. 