### PR TITLE
Drop the $scanXss param tag left behind when the scan moved to save time

### DIFF
--- a/system/src/Grav/Common/Twig/Twig.php
+++ b/system/src/Grav/Common/Twig/Twig.php
@@ -365,17 +365,6 @@ class Twig
      *
      * @param  PageInterface   $item    The page item to render
      * @param  string|null $content Optional content override
-     * @param  bool $scanXss When true, re-run the XSS detector on the resolved
-     *                       editor-authored content *before* the trusted
-     *                       theme/modular template wraps it. Set only for
-     *                       content whose in-page Twig was processed (the
-     *                       blueprint validator sees the raw source, so a
-     *                       payload assembled at render time — e.g.
-     *                       `{{ "on" ~ "error" }}` — passes validation but
-     *                       resolves to live markup). The scan never inspects
-     *                       the theme/modular template output, so legitimate
-     *                       template markup (embeds, form scripts, JS/CSS) can
-     *                       never trip it. (GHSA-2c4f-86xc-cr74)
      *
      * @return string          The rendered output
      */


### PR DESCRIPTION
`Twig::processPage()` documents a `bool $scanXss` parameter it does not take:

```php
 * @param  bool $scanXss When true, re-run the XSS detector on the resolved
 *                       editor-authored content *before* the trusted
 *                       ... (GHSA-2c4f-86xc-cr74)
 */
public function processPage(PageInterface $item, $content = null)
```

`$scanXss` appears nowhere else in `system/` — not in the signature, not in the body, and none of the three call sites (`Page.php:1164`, `PageContentTrait.php:809`, `Security.php:442`) pass a third argument.

The reason is already written a few lines further down in the same method, and it is why this is a documentation-only change rather than a missing guard:

```php
// That is caught at SAVE time now — Security::detectXssInEditorContent
// renders this same sandboxed pass in isolation and rejects the save —
// so there is no render-time output scan here. (GHSA-2c4f-86xc-cr74)
```

So the protection moved from render time to save time, the parameter went with it, and only its `@param` block stayed behind. Left as is, it describes an opt-in render-time scan that cannot be switched on.

Removed the tag. Nothing else touched — no signature, no call site, no behaviour.
