### PR TITLE
CompiledFile: regenerate compiled cache instead of a fatal ParseError on a corrupt compiled file

### DIFF
--- a/system/src/Grav/Common/File/CompiledFile.php
+++ b/system/src/Grav/Common/File/CompiledFile.php
@@ -75,7 +75,17 @@ trait CompiledFile
                 }
 
                 $size = filesize($filename);
-                $cache = $file->exists() ? $file->content() : null;
+                try {
+                    $cache = $file->exists() ? $file->content() : null;
+                } catch (Throwable $e) {
+                    // A corrupt or partially written compiled cache file (e.g. from a
+                    // concurrent regeneration race) can throw while being read/included —
+                    // including ParseError, which is an Error and would otherwise escape
+                    // this method's outer `catch (Exception)` as a fatal. Treat it as a
+                    // cache miss and regenerate from the raw source below, mirroring the
+                    // fast-path `catch (Throwable)` above.
+                    $cache = null;
+                }
 
                 // Load real file if cache isn't up to date (or is invalid).
                 if (!isset($cache['@class'])


### PR DESCRIPTION
Fixes #4239.

### Problem

`CompiledFile::content()` reads a compiled cache file (`cache/compiled/files/*.md.php`) on its slow path via `$file->content()`, which `include`s the file. When that compiled file is corrupt or partially written (e.g. a concurrent regeneration race while the page tree is rebuilt), the `include` throws a **`ParseError`**. `ParseError` extends `Error`, not `Exception`, so it is **not** caught by the method's outer `catch (Exception)` — it escapes as a fatal (a **500** under the API, a white screen on the front end) instead of the compiled cache being regenerated from source.

The fast path a few lines above already handles the exact same situation with `catch (Throwable)`; only the slow-path read was unguarded.

### Fix

Wrap the slow-path read in `catch (Throwable)` and treat a failure as a cache miss (`$cache = null`). The existing "cache isn't up to date (or is invalid)" branch immediately below then regenerates the compiled cache from the raw source — the intended fallback. No behavior change on the happy path.

```php
$size = filesize($filename);
try {
    $cache = $file->exists() ? $file->content() : null;
} catch (Throwable $e) {
    // corrupt/partial compiled cache (incl. ParseError, an Error) -> treat as a
    // cache miss and regenerate from source below, mirroring the fast path.
    $cache = null;
}
```

`Throwable` is already imported in this file.

### Why `Exception` doesn't catch it

```php
file_put_contents('/tmp/corrupt.php', "<?php\nreturn ['data' => 'O **Xen' unexpected];\n");
try { include '/tmp/corrupt.php'; } catch (\Exception $e) { echo "caught\n"; }
// -> PHP Fatal error: Uncaught ParseError (Exception does not catch it)
try { include '/tmp/corrupt.php'; } catch (\Throwable $e) { echo "caught: ".get_class($e); }
// -> caught: ParseError
```

### Observed impact

Renaming a page's folder in Admin2 triggered `PagesController::previewToken()` → `enablePages()` → a full `Pages::recurse()` that read every page's compiled cache; one unrelated page's momentarily-corrupt compiled cache produced an uncaught `ParseError` and a 500 (full stack trace in #4239). The rename itself succeeded, so the folder was renamed but the request errored.
