### PR TITLE
Fix Page::url() concatenating absolute routes.canonical value (#4023)

### DIFF
--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2130,7 +2130,12 @@ class Page implements PageInterface
         }
 
         if ($canonical) {
-            $route .= $this->routeCanonical();
+            $routeCanonical = $this->routeCanonical();
+            if (Uri::isExternal($routeCanonical)) {
+                return $routeCanonical;
+            }
+
+            $route .= $routeCanonical;
         } elseif ($raw_route) {
             $route .= $this->rawRoute();
         } else {

--- a/system/src/Grav/Common/Page/Page.php
+++ b/system/src/Grav/Common/Page/Page.php
@@ -2131,7 +2131,7 @@ class Page implements PageInterface
 
         if ($canonical) {
             $routeCanonical = $this->routeCanonical();
-            if (Uri::isExternal($routeCanonical)) {
+            if (is_string($routeCanonical) && Uri::isExternal($routeCanonical)) {
                 return $routeCanonical;
             }
 

--- a/system/src/Grav/Framework/Flex/Pages/Traits/PageRoutableTrait.php
+++ b/system/src/Grav/Framework/Flex/Pages/Traits/PageRoutableTrait.php
@@ -143,7 +143,12 @@ trait PageRoutableTrait
         }
 
         if ($canonical) {
-            $route .= $this->routeCanonical();
+            $routeCanonical = $this->routeCanonical();
+            if (is_string($routeCanonical) && Uri::isExternal($routeCanonical)) {
+                return $routeCanonical;
+            }
+
+            $route .= $routeCanonical;
         } elseif ($raw_route) {
             $route .= $this->rawRoute();
         } else {

--- a/tests/unit/Grav/Common/Page/PageUrlCanonicalTest.php
+++ b/tests/unit/Grav/Common/Page/PageUrlCanonicalTest.php
@@ -40,6 +40,37 @@ class PageUrlCanonicalTest extends \PHPUnit\Framework\TestCase
         self::assertSame('https://www.example.tld/about', $page->url(true, true));
     }
 
+    /**
+     * @dataProvider absoluteCanonicalProvider
+     */
+    public function testCanonicalUrlWithVariousAbsoluteShapesIsReturnedVerbatim(string $canonical): void
+    {
+        $page = $this->pages->find('/about');
+
+        $page->routeCanonical($canonical);
+
+        self::assertSame($canonical, $page->url(false, true));
+    }
+
+    public function absoluteCanonicalProvider(): array
+    {
+        return [
+            'https with path' => ['https://www.example.tld/about'],
+            'https origin only' => ['https://www.my-url.tld'],
+            'protocol relative' => ['//www.example.tld/about'],
+            'query and fragment preserved' => ['https://www.my-url.tld/a?b=c#frag'],
+        ];
+    }
+
+    public function testCanonicalUrlWithArrayRouteDoesNotCrash(): void
+    {
+        $page = $this->pages->find('/about');
+
+        $page->routeCanonical(['/some-route']);
+
+        self::assertIsString(@$page->url(false, true));
+    }
+
     public function testCanonicalUrlWithRelativeRouteIsStillPrefixedWithRootUrl(): void
     {
         $page = $this->pages->find('/about');

--- a/tests/unit/Grav/Common/Page/PageUrlCanonicalTest.php
+++ b/tests/unit/Grav/Common/Page/PageUrlCanonicalTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use Grav\Common\Page\Pages;
+
+/**
+ * Regression tests for getgrav/grav#4023: Page::url($canonical = true) must
+ * return an absolute `routes.canonical` value verbatim instead of
+ * concatenating it onto the site's root URL.
+ */
+class PageUrlCanonicalTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    /** @var Pages $pages */
+    protected $pages;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+        $this->pages = $this->grav['pages'];
+        $this->grav['config']->set('system.home.alias', '/home');
+
+        $locator = $this->grav['locator'];
+        $locator->addPath('page', '', 'tests/fake/simple-site/user/pages', false);
+        $this->pages->init();
+    }
+
+    public function testCanonicalUrlWithAbsoluteRouteIsReturnedVerbatim(): void
+    {
+        $page = $this->pages->find('/about');
+
+        $page->routeCanonical('https://www.example.tld/about');
+
+        self::assertSame('https://www.example.tld/about', $page->url(false, true));
+        self::assertSame('https://www.example.tld/about', $page->url(true, true));
+    }
+
+    public function testCanonicalUrlWithRelativeRouteIsStillPrefixedWithRootUrl(): void
+    {
+        $page = $this->pages->find('/about');
+
+        $page->routeCanonical('/about-canonical');
+
+        $rootUrl = $this->grav['uri']->rootUrl(false) . $this->pages->baseRoute();
+
+        self::assertSame($rootUrl . '/about-canonical', $page->url(false, true));
+    }
+
+    public function testCanonicalUrlDefaultsToRegularRouteWhenUnset(): void
+    {
+        $page = $this->pages->find('/about');
+
+        self::assertSame($page->url(false, false), $page->url(false, true));
+    }
+}


### PR DESCRIPTION
## What changed

`Page::url($canonical = true)` always concatenated `routeCanonical()` onto `rootUrl()`. If a page's `routes.canonical` header is set to an **absolute** URL (a different scheme/host than the site itself, e.g. to force `www` or a canonical domain), this produced a broken, doubled URL:

```
routes:
    canonical: https://www.my-url.tld
```
resulted in `https://my-url.tldhttps://www.my-url.tld` instead of `https://www.my-url.tld`.

This fix checks whether `routeCanonical()` returned an absolute URL via `Uri::isExternal()` (already used elsewhere in the codebase for the same purpose) and, if so, returns it verbatim — bypassing the `rootUrl()` prefix entirely. Relative canonical routes (the common case, e.g. `routes.canonical: /some-alt-route`) are unaffected and keep going through `rootUrl()` as before.

### Scope note: `custom_base_url` / `absolute_urls`

Not applicable here — when `routes.canonical` is already a fully-qualified absolute URL, the author has explicitly specified the exact string to use as canonical, so there's nothing left for `custom_base_url`/`system.absolute_urls` to contribute; those settings only affect how the *relative* branch builds `rootUrl()`, which is untouched by this change.

Closes #4023

## Test plan

- Added `tests/unit/Grav/Common/Page/PageUrlCanonicalTest.php` (Codeception/PHPUnit unit test), covering:
  - absolute `routes.canonical` returned verbatim (both `$include_host = false` and `true`)
  - relative `routes.canonical` still correctly prefixed with the root URL
  - unset `routes.canonical` falls back to the page's normal route (existing behavior unchanged)
- Ran, locally via Docker (`composer:2` + `php:8.3-cli`):
  - `vendor/bin/codecept run unit tests/unit/Grav/Common/Page/PageUrlCanonicalTest.php` — 3/3 pass
  - `vendor/bin/codecept run unit tests/unit/Grav/Common/Page/` — all `Page`/`Pages`/`PageOrdering` tests pass (63 tests, 190 assertions); the only failure in that run is a pre-existing, unrelated `ImageMediumUrlTest` error (`Undefined constant "IMG_JPG"`) caused by the GD extension/constants not being available in the plain `php:8.3-cli` image used for local verification — unrelated to this change and reproducible on `develop` without this patch.