### PR TITLE
Per-file mtime cache-busting for non-pipelined local assets (#4049)

### DIFF
--- a/system/config/system.yaml
+++ b/system/config/system.yaml
@@ -160,7 +160,7 @@ assets:                                          # Configuration for Assets Mana
   js_module_pipeline_include_externals: true     # Include external URLs in the pipeline by default
   js_module_pipeline_before_excludes: true       # Render the pipeline before any excluded files
   js_minify: true                                # Minify the JS during pipelining
-  enable_asset_timestamp: false                  # Enable asset timestamps
+  enable_asset_timestamp: false                  # Enable asset timestamps; non-pipelined local assets get their own filemtime-derived token, everything else (remote/pipelined) keeps the global cache key
   enable_asset_sri: false                        # Enable asset SRI
   collections:
     jquery: system://assets/jquery/jquery-3.x.min.js

--- a/system/src/Grav/Common/Assets/BaseAsset.php
+++ b/system/src/Grav/Common/Assets/BaseAsset.php
@@ -149,14 +149,20 @@ abstract class BaseAsset extends PropertyObject
                 // instead of the global config/version-derived cache key, so
                 // editing one file invalidates only that file's URL.
                 //
-                // Scope: this only affects the query string built for a single,
-                // individually rendered asset (this class's own renderQueryString()).
-                // Pipelined/bundled assets never consult this per-asset timestamp:
-                // Pipeline builds its own uid from a hash of the bundled asset
-                // list and content (see Pipeline::renderCss()/renderJs()), so it
-                // already has its own, finer-grained invalidation and is left
-                // using the global cache key set in Assets::render().
-                if ($this->timestamp && $this->modified) {
+                // Gated on the enable_asset_timestamp config flag itself (not
+                // just on $this->timestamp being truthy), so an explicit,
+                // caller-supplied token set via the public Assets::setTimestamp()
+                // API is never silently discarded when the config flag is off.
+                //
+                // Note: the rendered <link>/<script> tag for a *pipelined* bundle
+                // still uses the global cache key (Pipeline::$timestamp, set from
+                // Assets::render()), so this has no effect on pipelined output
+                // URLs. It does still feed into the pipeline's internal bundle
+                // uid hash (Pipeline::renderCss()/renderJs() hash the serialized
+                // BaseAsset objects, which include $timestamp) — harmless, but
+                // it does mean upgrading can produce one new bundle file instead
+                // of reusing the previous one.
+                if ($this->timestamp && $this->modified && $config->get('system.assets.enable_asset_timestamp')) {
                     $this->timestamp = dechex($this->modified);
                 }
             }

--- a/system/src/Grav/Common/Assets/BaseAsset.php
+++ b/system/src/Grav/Common/Assets/BaseAsset.php
@@ -144,6 +144,21 @@ abstract class BaseAsset extends PropertyObject
                 $asset = $this->buildLocalLink($file->getPathname());
 
                 $this->modified = $file->isFile() ? $file->getMTime() : false;
+
+                // Rewrite the cache-busting token to this asset's own filemtime
+                // instead of the global config/version-derived cache key, so
+                // editing one file invalidates only that file's URL.
+                //
+                // Scope: this only affects the query string built for a single,
+                // individually rendered asset (this class's own renderQueryString()).
+                // Pipelined/bundled assets never consult this per-asset timestamp:
+                // Pipeline builds its own uid from a hash of the bundled asset
+                // list and content (see Pipeline::renderCss()/renderJs()), so it
+                // already has its own, finer-grained invalidation and is left
+                // using the global cache key set in Assets::render().
+                if ($this->timestamp && $this->modified) {
+                    $this->timestamp = dechex($this->modified);
+                }
             }
         }
 

--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -714,67 +714,143 @@ class AssetsTest extends \PHPUnit\Framework\TestCase
     {
         $fileA = GRAV_ROOT . '/tests/unit/data/assets/timestamp-a.css';
         $fileB = GRAV_ROOT . '/tests/unit/data/assets/timestamp-b.css';
+        $fileJs = GRAV_ROOT . '/tests/unit/data/assets/timestamp-a.js';
 
-        // Distinct, known mtimes for each fixture (not "now") so the assertions
-        // don't depend on filesystem timing/precision.
-        $mtimeA = time() - 3600;
-        $mtimeB = time() - 60;
-        touch($fileA, $mtimeA);
-        touch($fileB, $mtimeB);
-        clearstatcache(true, $fileA);
-        clearstatcache(true, $fileB);
+        $origMtimeA = filemtime($fileA);
+        $origMtimeB = filemtime($fileB);
+        $origMtimeJs = filemtime($fileJs);
 
-        // Local, non-pipelined assets: each gets its own filemtime-derived
-        // token, not the shared global cache key ('foo' here, via setTimestamp()
-        // which stands in for the value enable_asset_timestamp would compute).
+        try {
+            // Distinct, known mtimes for each fixture (not "now") so the assertions
+            // don't depend on filesystem timing/precision.
+            $mtimeA = time() - 3600;
+            $mtimeB = time() - 60;
+            touch($fileA, $mtimeA);
+            touch($fileB, $mtimeB);
+            clearstatcache(true, $fileA);
+            clearstatcache(true, $fileB);
+
+            // Exercise the real enable_asset_timestamp config flag (the actual
+            // trigger for #4049), not just a manually set token.
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            // Pin the resulting global key so remote/pipeline assertions below
+            // (which are unaffected by the per-file override) are deterministic.
+            $this->assets->setTimestamp('foo');
+
+            // Local, non-pipelined assets: each gets its own filemtime-derived
+            // token, not the shared global cache key.
+            $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
+            $css = $this->assets->css();
+            self::assertSame(
+                '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeA) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+                $css
+            );
+
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            $this->assets->setTimestamp('foo');
+            $this->assets->addCss('/tests/unit/data/assets/timestamp-b.css');
+            $css = $this->assets->css();
+            self::assertSame(
+                '<link href="/tests/unit/data/assets/timestamp-b.css?' . dechex($mtimeB) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+                $css
+            );
+
+            // Touching one file changes only its own token.
+            $mtimeANew = $mtimeA + 1800;
+            touch($fileA, $mtimeANew);
+            clearstatcache(true, $fileA);
+
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            $this->assets->setTimestamp('foo');
+            $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
+            $css = $this->assets->css();
+            self::assertSame(
+                '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeANew) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+                $css
+            );
+
+            // Stream-based local asset (e.g. theme://): goes through
+            // $locator->findResource() rather than GRAV_WEBROOT concatenation,
+            // and must be rewritten to its own mtime too.
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            $this->assets->setTimestamp('foo');
+            $this->assets->addCss('tests://unit/data/assets/timestamp-a.css');
+            $css = $this->assets->css();
+            self::assertSame(
+                '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeANew) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+                $css
+            );
+
+            // Local JS asset: addJs() goes through a different concrete asset
+            // class than addCss(), but must be rewritten the same way.
+            $mtimeJs = time() - 120;
+            touch($fileJs, $mtimeJs);
+            clearstatcache(true, $fileJs);
+
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            $this->assets->setTimestamp('foo');
+            $this->assets->addJs('/tests/unit/data/assets/timestamp-a.js');
+            $js = $this->assets->js();
+            self::assertSame(
+                '<script src="/tests/unit/data/assets/timestamp-a.js?' . dechex($mtimeJs) . '"></script>' . PHP_EOL,
+                $js
+            );
+
+            // Remote assets have no local file to stat, so they keep the global
+            // cache key untouched.
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            $this->assets->setTimestamp('foo');
+            $this->assets->addCss('http://somesite.com/test.css');
+            $css = $this->assets->css();
+            self::assertSame('<link href="http://somesite.com/test.css?foo" type="text/css" rel="stylesheet">' . PHP_EOL, $css);
+
+            // Pipelined assets: the *rendered* query string keeps using the
+            // global cache key (Pipeline::$timestamp, set from Assets::render()),
+            // regardless of the per-asset mtime rewrite above.
+            $this->assets->reset();
+            $this->grav['config']->set('system.assets.enable_asset_timestamp', true);
+            $this->assets->config(['enable_asset_timestamp' => true]);
+            $this->assets->setTimestamp('foo');
+            $this->assets->setCssPipeline(true);
+            $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
+            $css = $this->assets->css();
+            self::assertMatchesRegularExpression('#<link href="/assets/(.*)\.css\?foo" type="text/css" rel="stylesheet">#', $css);
+        } finally {
+            touch($fileA, $origMtimeA);
+            touch($fileB, $origMtimeB);
+            touch($fileJs, $origMtimeJs);
+            clearstatcache(true, $fileA);
+            clearstatcache(true, $fileB);
+            clearstatcache(true, $fileJs);
+        }
+    }
+
+    public function testManualTimestampPreservedWithoutConfigFlag(): void
+    {
+        // enable_asset_timestamp defaults to off. A caller-supplied token set
+        // via the public Assets::setTimestamp() API must not be silently
+        // overridden by the per-file mtime rewrite, since that rewrite is only
+        // meant to fire for the enable_asset_timestamp config path.
         $this->assets->reset();
-        $this->assets->setTimestamp('foo');
+        $this->assets->setTimestamp('v1.2.3');
         $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
         $css = $this->assets->css();
         self::assertSame(
-            '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeA) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+            '<link href="/tests/unit/data/assets/timestamp-a.css?v1.2.3" type="text/css" rel="stylesheet">' . PHP_EOL,
             $css
         );
-
-        $this->assets->reset();
-        $this->assets->setTimestamp('foo');
-        $this->assets->addCss('/tests/unit/data/assets/timestamp-b.css');
-        $css = $this->assets->css();
-        self::assertSame(
-            '<link href="/tests/unit/data/assets/timestamp-b.css?' . dechex($mtimeB) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
-            $css
-        );
-
-        // Touching one file changes only its own token.
-        $mtimeANew = $mtimeA + 1800;
-        touch($fileA, $mtimeANew);
-        clearstatcache(true, $fileA);
-
-        $this->assets->reset();
-        $this->assets->setTimestamp('foo');
-        $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
-        $css = $this->assets->css();
-        self::assertSame(
-            '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeANew) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
-            $css
-        );
-
-        // Remote assets have no local file to stat, so they keep the global
-        // cache key untouched.
-        $this->assets->reset();
-        $this->assets->setTimestamp('foo');
-        $this->assets->addCss('http://somesite.com/test.css');
-        $css = $this->assets->css();
-        self::assertSame('<link href="http://somesite.com/test.css?foo" type="text/css" rel="stylesheet">' . PHP_EOL, $css);
-
-        // Pipelined assets keep using the global cache key: Pipeline derives its
-        // bundle filename from a content hash and has its own invalidation.
-        $this->assets->reset();
-        $this->assets->setTimestamp('foo');
-        $this->assets->setCssPipeline(true);
-        $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
-        $css = $this->assets->css();
-        self::assertMatchesRegularExpression('#<link href="/assets/(.*)\.css\?foo" type="text/css" rel="stylesheet">#', $css);
     }
 
     public function testAddInlineCss(): void

--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -710,6 +710,73 @@ class AssetsTest extends \PHPUnit\Framework\TestCase
         self::assertSame('<script src="http://somesite.com/test.js?bar&foo"></script>' . PHP_EOL, $css);
     }
 
+    public function testPerFileTimestamps(): void
+    {
+        $fileA = GRAV_ROOT . '/tests/unit/data/assets/timestamp-a.css';
+        $fileB = GRAV_ROOT . '/tests/unit/data/assets/timestamp-b.css';
+
+        // Distinct, known mtimes for each fixture (not "now") so the assertions
+        // don't depend on filesystem timing/precision.
+        $mtimeA = time() - 3600;
+        $mtimeB = time() - 60;
+        touch($fileA, $mtimeA);
+        touch($fileB, $mtimeB);
+        clearstatcache(true, $fileA);
+        clearstatcache(true, $fileB);
+
+        // Local, non-pipelined assets: each gets its own filemtime-derived
+        // token, not the shared global cache key ('foo' here, via setTimestamp()
+        // which stands in for the value enable_asset_timestamp would compute).
+        $this->assets->reset();
+        $this->assets->setTimestamp('foo');
+        $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
+        $css = $this->assets->css();
+        self::assertSame(
+            '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeA) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+            $css
+        );
+
+        $this->assets->reset();
+        $this->assets->setTimestamp('foo');
+        $this->assets->addCss('/tests/unit/data/assets/timestamp-b.css');
+        $css = $this->assets->css();
+        self::assertSame(
+            '<link href="/tests/unit/data/assets/timestamp-b.css?' . dechex($mtimeB) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+            $css
+        );
+
+        // Touching one file changes only its own token.
+        $mtimeANew = $mtimeA + 1800;
+        touch($fileA, $mtimeANew);
+        clearstatcache(true, $fileA);
+
+        $this->assets->reset();
+        $this->assets->setTimestamp('foo');
+        $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
+        $css = $this->assets->css();
+        self::assertSame(
+            '<link href="/tests/unit/data/assets/timestamp-a.css?' . dechex($mtimeANew) . '" type="text/css" rel="stylesheet">' . PHP_EOL,
+            $css
+        );
+
+        // Remote assets have no local file to stat, so they keep the global
+        // cache key untouched.
+        $this->assets->reset();
+        $this->assets->setTimestamp('foo');
+        $this->assets->addCss('http://somesite.com/test.css');
+        $css = $this->assets->css();
+        self::assertSame('<link href="http://somesite.com/test.css?foo" type="text/css" rel="stylesheet">' . PHP_EOL, $css);
+
+        // Pipelined assets keep using the global cache key: Pipeline derives its
+        // bundle filename from a content hash and has its own invalidation.
+        $this->assets->reset();
+        $this->assets->setTimestamp('foo');
+        $this->assets->setCssPipeline(true);
+        $this->assets->addCss('/tests/unit/data/assets/timestamp-a.css');
+        $css = $this->assets->css();
+        self::assertMatchesRegularExpression('#<link href="/assets/(.*)\.css\?foo" type="text/css" rel="stylesheet">#', $css);
+    }
+
     public function testAddInlineCss(): void
     {
         $this->assets->reset();

--- a/tests/unit/data/assets/timestamp-a.css
+++ b/tests/unit/data/assets/timestamp-a.css
@@ -1,0 +1,2 @@
+/* fixture for AssetsTest::testPerFileTimestamps */
+.timestamp-a { color: red; }

--- a/tests/unit/data/assets/timestamp-a.js
+++ b/tests/unit/data/assets/timestamp-a.js
@@ -1,0 +1,1 @@
+console.log('timestamp fixture');

--- a/tests/unit/data/assets/timestamp-b.css
+++ b/tests/unit/data/assets/timestamp-b.css
@@ -1,0 +1,2 @@
+/* fixture for AssetsTest::testPerFileTimestamps */
+.timestamp-b { color: blue; }


### PR DESCRIPTION
## Problem

Closes #4049.

When `enable_asset_timestamp` is on, `Assets` computes one global cache-busting
token (`Grav::instance()['cache']->getKey()`) and stamps it onto every
asset's URL as a `?<token>` query string. That token only changes when the
global config/cache key changes, so editing a single CSS/JS file's contents
does not invalidate that file's cached URL until something unrelated bumps
the global key — the bug reported in #4049.

## Change

For non-pipelined, local (non-remote) assets, `BaseAsset::init()` now
overrides the asset's own `$timestamp` property with `dechex(filemtime())` of
that specific file, right after the file is resolved and stat'd. The rewrite
only fires when `system.assets.enable_asset_timestamp` is actually enabled —
not just whenever a truthy timestamp happens to be present — so an explicit
token set via the public `Assets::setTimestamp()` API (independent of that
config flag) is preserved instead of being silently overridden. Everything
else about the existing timestamp plumbing (`Assets::$timestamp`,
`options['timestamp']`, `renderQueryString()`) is unchanged; this only
swaps the value that ends up in the per-asset property for this one case.

### Why pipelined and remote assets are effectively unaffected

- **Pipelined assets**: the *rendered* `<link>`/`<script>` tag's query string
  for a pipelined bundle comes from `Pipeline::$timestamp`, which is set from
  `Assets::$timestamp` (the global key) when the `Pipeline` object is
  constructed in `Assets::render()` — a separate property from the
  individual `BaseAsset` objects whose `$timestamp` this PR changes. So the
  pipelined *output URL* is unaffected.

  Correction from an earlier version of this description: the pipeline's
  internal bundle uid *does* consult this per-asset timestamp.
  `Pipeline::renderCss()`/`renderJs()` hash `json_encode($assets)`, and
  `BaseAsset::jsonSerialize()` includes the `timestamp` property via
  `getElements()`, so mutating it here does perturb the bundle filename hash.
  This is harmless in practice (bundle mtimes already flow into that same
  hash before this PR, and the effect here is a one-time bundle regeneration
  plus an orphaned old bundle file on upgrade, not a functional bug) — but
  it's not "no effect" as originally claimed here, so I'm correcting the
  record.
- **Remote assets**: `BaseAsset::init()` only enters the "local asset" branch
  when `!$this->remote`; remote URLs have no local file to `stat()`, so they
  keep using the existing global cache key.

## Test plan

`AssetsTest::testPerFileTimestamps()` now exercises the real
`enable_asset_timestamp` config flag (not just a manually set token), and
covers:
- two local CSS fixtures each get a distinct, `filemtime()`-derived query
  string instead of the shared global key
- touching one fixture only changes that fixture's own token
- a stream-based (`tests://`) local asset gets the same per-file rewrite
- a local JS asset gets the same per-file rewrite
- a remote asset keeps the unmodified global cache key
- a pipelined local asset's rendered query string keeps the unmodified
  global cache key

Added `AssetsTest::testManualTimestampPreservedWithoutConfigFlag()`: a token
set via `Assets::setTimestamp()` while `enable_asset_timestamp` is off (its
default) is preserved verbatim, proving the regression flagged in review is
fixed.

Fixture mtimes touched by the test are restored in a `finally` block so
repeated runs stay deterministic.

Ran via Docker (`composer:2` + `php:8.3-cli`, matching `composer.json`'s
`"php": "^8.3"`):

```
docker run --rm -v <worktree>:/app -w /app composer:2 install --no-interaction --ignore-platform-reqs
docker run --rm -v <worktree>:/app -w /app php:8.3-cli vendor/bin/codecept run unit Grav/Common/AssetsTest
docker run --rm -v <worktree>:/app -w /app php:8.3-cli vendor/bin/codecept run unit
```

- `AssetsTest`: 26/26 tests passing, 148 assertions.
- Full unit suite: 973 tests, 3060 assertions, 17 errors / 1 failure — all
  pre-existing and unrelated to this change (`ZipArchive` extension missing
  from the bare `php:8.3-cli` image used for `ZipBombSecurityTest`, and a
  `ComposerTest` path assertion that depends on the host filesystem layout).
  Same baseline as before this branch's changes (972/3057/17/1), plus the
  one new test method and its assertions.

## Scope note

Also updated the `enable_asset_timestamp` comment in
`system/config/system.yaml` to describe the new per-file-mtime behavior.
Not addressed in this PR (raised in review, left out as separable/low-risk
follow-ups): translating the admin-panel help string
(`PLUGIN_ADMIN.ENABLED_TIMESTAMPS_ON_ASSETS_HELP`) lives in the Admin
plugin's own language files, not in this repo.
