### PR TITLE
Fix markdown image embed failing on filenames with a colon (#3933)

### DIFF
--- a/system/src/Grav/Common/Grav.php
+++ b/system/src/Grav/Common/Grav.php
@@ -859,6 +859,17 @@ class Grav extends Container
         $supported_types = $config->get('media.types');
 
         $parsed_url = parse_url(rawurldecode($uri->basename()));
+        if (isset($parsed_url['scheme']) && !preg_match('/^[a-zA-Z][a-zA-Z0-9+.-]*$/', $parsed_url['scheme'])) {
+            // getgrav/grav#3933: parse_url() misreads a basename that merely
+            // contains a literal ':' (e.g. a timestamp such as
+            // "2025-06-29T13:36:56.png") as a scheme:path split, because
+            // unlike RFC 3986 it allows a "scheme" to start with a digit.
+            // A real scheme never does, so rebuild the original basename as
+            // a plain path in that case (see Excerpts::parseUrl() for the
+            // same fix applied to markdown image/link resolution).
+            $parsed_url['path'] = $parsed_url['scheme'] . ':' . ($parsed_url['host'] ?? '') . ($parsed_url['path'] ?? '');
+            unset($parsed_url['scheme'], $parsed_url['host'], $parsed_url['port'], $parsed_url['user'], $parsed_url['pass']);
+        }
         $media_file = isset($parsed_url['path']) ? $parsed_url['path'] : '';
 
         $event = new Event([

--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -338,9 +338,24 @@ class Excerpts
         if (isset($url_parts['scheme'])) {
             /** @var UniformResourceLocator $locator */
             $locator = Grav::instance()['locator'];
+            $is_registered_stream = $locator->schemeExists($url_parts['scheme']);
 
-            // Special handling for the streams.
-            if ($locator->schemeExists($url_parts['scheme'])) {
+            if (
+                !$is_registered_stream
+                && strpos($url, '://') === false
+                && !preg_match('/^[a-zA-Z][a-zA-Z0-9+.-]*$/', $url_parts['scheme'])
+            ) {
+                // parse_url() misreads a relative filename that merely contains a
+                // literal ':' (e.g. "2025-06-29T13:36:56.png") as a scheme:path
+                // split, because unlike RFC 3986 it allows a "scheme" to start
+                // with a digit. A real scheme never does (mailto:, tel:, xmpp:,
+                // ...), so only a scheme failing that grammar - and matching no
+                // registered stream - is untrusted and rebuilt as a plain path
+                // (getgrav/grav#3933).
+                $url_parts['path'] = $url_parts['scheme'] . ':' . ($url_parts['host'] ?? '') . ($url_parts['path'] ?? '');
+                unset($url_parts['scheme'], $url_parts['host'], $url_parts['port'], $url_parts['user'], $url_parts['pass']);
+            } elseif ($is_registered_stream) {
+                // Special handling for the streams.
                 if (isset($url_parts['host'])) {
                     // Merge host and path into a path.
                     $url_parts['path'] = $url_parts['host'] . (isset($url_parts['path']) ? '/' . $url_parts['path'] : '');

--- a/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
+++ b/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
@@ -7,6 +7,7 @@ use Grav\Common\Page\Interfaces\PageInterface;
 use Grav\Common\Uri;
 use Grav\Common\Config\Config;
 use Grav\Common\Page\Pages;
+use Grav\Common\Page\Media;
 use Grav\Common\Language\Language;
 use RocketTheme\Toolbox\ResourceLocator\UniformResourceLocator;
 
@@ -116,6 +117,66 @@ class ExcerptsTest extends \PHPUnit\Framework\TestCase
         self::assertStringStartsWith(
             '<a href="https://meet.weikamp.biz/Support" rel="nofollow" target="_blank"',
             Excerpts::processLinkHtml('<a href="https://meet.weikamp.biz/Support?rel=nofollow&target=_blank">target and rel</a>')
+        );
+    }
+
+    public function testImageFilenameWithColonIsResolvedAsLocalMedia(): void
+    {
+        // getgrav/grav#3933: a bare relative filename containing a literal ':'
+        // (e.g. a timestamp) must still resolve to the page's own media, not be
+        // misread by parse_url() as a scheme:path split.
+        //
+        // The fixture is generated here at runtime rather than committed to
+        // git: ':' is a reserved character on NTFS, so a statically committed
+        // file with this name would make `git clone`/checkout of the whole
+        // repo fail on Windows. Page media loads lazily on first access, so
+        // it's enough for the file to exist before processImageHtml() runs.
+        $fixturePath = 'tests/fake/nested-site/user/pages/02.item2/02.item2-2/2025-06-29T13:36:56.png';
+        $image = imagecreatetruecolor(10, 10);
+        imagepng($image, $fixturePath);
+        imagedestroy($image);
+
+        // The page's media collection was already built (by Pages::init())
+        // before this fixture existed on disk, so force a fresh scan of the
+        // folder now that the file is there.
+        $this->page->media(new Media($this->page->getMediaFolder(), $this->page->getMediaOrder()));
+
+        try {
+            self::assertMatchesRegularExpression(
+                '|<img alt="Timestamped" src="\/images\/.*-2025-06-29t133656\.png" data-src="2025-06-29T13:36:56\.png\?cropZoom=300,300" \/>|',
+                Excerpts::processImageHtml('<img src="2025-06-29T13:36:56.png?cropZoom=300,300" alt="Timestamped" />', $this->page)
+            );
+        } finally {
+            @unlink($fixturePath);
+        }
+    }
+
+    public function testMailtoAndTelLinksAreNotBrokenByColonFix(): void
+    {
+        // Non-regression: any scheme without "://" that still has valid,
+        // letter-led URI scheme grammar (RFC 3986) must pass through
+        // untouched, whether or not Grav has special-case handling for it.
+        self::assertStringStartsWith(
+            '<a href="mailto:bob@example.com"',
+            Excerpts::processLinkHtml('<a href="mailto:bob@example.com">email</a>')
+        );
+        self::assertStringStartsWith(
+            '<a href="tel:+123456789"',
+            Excerpts::processLinkHtml('<a href="tel:+123456789">call</a>')
+        );
+        self::assertStringStartsWith(
+            '<a href="xmpp:xyx@domain.com"',
+            Excerpts::processLinkHtml('<a href="xmpp:xyx@domain.com">xmpp</a>')
+        );
+    }
+
+    public function testStreamImageIsNotBrokenByColonFix(): void
+    {
+        // Non-regression: registered Grav streams (image://, user://, ...) must
+        // keep resolving via the locator exactly as before.
+        self::assertStringStartsWith(
+            '<img alt="Stream" src="/system/images/watermark.png"',
+            Excerpts::processImageHtml('<img src="image://watermark.png" alt="Stream" />', $this->page)
         );
     }
 }


### PR DESCRIPTION
## What changed

`Excerpts::parseUrl()` uses `Utils::multibyteParseUrl()` (a wrapper around `parse_url()`). Unlike RFC 3986, PHP's `parse_url()` allows a "scheme" to start with a digit, so a relative filename that merely contains a literal `:` — e.g. a timestamp like `2025-06-29T13:36:56.png` — gets misread as a `scheme:path` split (`scheme = "2025-06-29t13"`). Excerpts then treats the reference as an external/stream URL instead of resolving it against the page's own media, so the image fails to render.

The fix rebuilds the original path whenever the parsed `scheme`:
- has no `://` in the source string, **and**
- fails RFC 3986 scheme grammar (doesn't start with a letter), **and**
- isn't a name registered with Grav's `UniformResourceLocator` (`schemeExists()`)

Genuine schemes (`mailto:`, `tel:`, `xmpp:`, any other real protocol — these always start with a letter) and registered Grav streams (`image://`, `user://`, ...) are untouched, since they either contain `://` or start with a letter.

Closes #3933

## Test plan

Added to `tests/unit/Grav/Common/Helpers/ExcerptsTest.php` and ran via `codecept run unit` (PHP 8.3, gd extension):

- **Bug case**: `testImageFilenameWithColonIsResolvedAsLocalMedia` — an `<img>` referencing the colon-bearing fixture `tests/fake/nested-site/user/pages/02.item2/02.item2-2/2025-06-29T13:36:56.png` now resolves to the page's own media and renders a proper cache-derivative URL, instead of failing to resolve.
- **Non-regression — real schemes without `://`**: `testMailtoAndTelLinksAreNotBrokenByColonFix` — `mailto:`, `tel:`, and `xmpp:` links still pass through untouched (this last case caught a bug in an earlier iteration of the fix that used a hardcoded external-scheme allowlist instead of RFC scheme grammar, which broke `xmpp:` — an existing `ParsedownTest::testSpecialProtocols` regression, now fixed and passing).
- **Non-regression — registered streams**: `testStreamImageIsNotBrokenByColonFix` — `image://watermark.png` still resolves through the locator exactly as before.

Full run: `php vendor/bin/codecept run unit` — 974 tests, 3108 assertions. All pass except 8 pre-existing errors (`ZipArchive` class not available in the bare `php:8.3-cli` test image — unrelated to this change) and 1 pre-existing failure (`ComposerTest::testGetComposerLocation`, an absolute-path assumption unrelated to this change) — both reproduce identically on `develop` without this patch.
