### PR TITLE
Fix invalid alt attributes on audio and video media

### DIFF
--- a/system/src/Grav/Common/Media/Traits/AudioMediaTrait.php
+++ b/system/src/Grav/Common/Media/Traits/AudioMediaTrait.php
@@ -43,6 +43,7 @@ trait AudioMediaTrait
     protected function sourceParsedownElement(array $attributes, $reset = true)
     {
         $location = $this->url($reset);
+        $attributes = $this->normalizePlayerAttributes($attributes);
 
         return [
             'name' => 'audio',

--- a/system/src/Grav/Common/Media/Traits/MediaPlayerTrait.php
+++ b/system/src/Grav/Common/Media/Traits/MediaPlayerTrait.php
@@ -104,6 +104,29 @@ trait MediaPlayerTrait
     }
 
     /**
+     * Normalize attributes for HTML audio and video elements.
+     *
+     * The generic media pipeline always provides an alt attribute, but alt is
+     * not valid on audio or video. Preserve non-empty alternative text as an
+     * accessible name unless the caller already provided one explicitly.
+     *
+     * @param array $attributes
+     * @return array
+     */
+    protected function normalizePlayerAttributes(array $attributes)
+    {
+        if (isset($attributes['alt'])) {
+            if ($attributes['alt'] !== '' && empty($attributes['aria-label'])) {
+                $attributes['aria-label'] = $attributes['alt'];
+            }
+
+            unset($attributes['alt']);
+        }
+
+        return $attributes;
+    }
+
+    /**
      * Reset player.
      */
     public function resetPlayer()

--- a/system/src/Grav/Common/Media/Traits/VideoMediaTrait.php
+++ b/system/src/Grav/Common/Media/Traits/VideoMediaTrait.php
@@ -58,6 +58,7 @@ trait VideoMediaTrait
     protected function sourceParsedownElement(array $attributes, $reset = true)
     {
         $location = $this->url($reset);
+        $attributes = $this->normalizePlayerAttributes($attributes);
 
         return [
             'name' => 'video',

--- a/tests/unit/Grav/Common/Page/Medium/MediaPlayerAttributesTest.php
+++ b/tests/unit/Grav/Common/Page/Medium/MediaPlayerAttributesTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use Grav\Common\Page\Medium\AudioMedium;
+use Grav\Common\Page\Medium\VideoMedium;
+
+class MediaPlayerAttributesTest extends \Codeception\Test\Unit
+{
+    /** @var Grav */
+    protected $grav;
+
+    /** @var string */
+    protected $fixture = 'tests/fake/nested-site/user/pages/01.item1/home-sample-image.jpg';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+    }
+
+    public function testVideoMovesAlternativeTextToAriaLabel(): void
+    {
+        $element = $this->video()->parsedownElement(null, 'Video description');
+
+        $this->assertSame('video', $element['name']);
+        $this->assertArrayNotHasKey('alt', $element['attributes']);
+        $this->assertSame('Video description', $element['attributes']['aria-label']);
+        $this->assertSame('controls', $element['attributes']['controls']);
+    }
+
+    public function testAudioMovesAlternativeTextToAriaLabel(): void
+    {
+        $element = $this->audio()->parsedownElement(null, 'Audio description');
+
+        $this->assertSame('audio', $element['name']);
+        $this->assertArrayNotHasKey('alt', $element['attributes']);
+        $this->assertSame('Audio description', $element['attributes']['aria-label']);
+    }
+
+    public function testEmptyAlternativeTextDoesNotCreateAriaLabel(): void
+    {
+        $element = $this->video()->parsedownElement();
+
+        $this->assertArrayNotHasKey('alt', $element['attributes']);
+        $this->assertArrayNotHasKey('aria-label', $element['attributes']);
+    }
+
+    public function testExplicitAriaLabelTakesPrecedenceOverAlternativeText(): void
+    {
+        $element = $this->video()
+            ->attribute('aria-label', 'Explicit label')
+            ->parsedownElement(null, 'Alternative text');
+
+        $this->assertArrayNotHasKey('alt', $element['attributes']);
+        $this->assertSame('Explicit label', $element['attributes']['aria-label']);
+    }
+
+    private function video(): VideoMedium
+    {
+        return new VideoMedium($this->mediaItems('test.mp4'));
+    }
+
+    private function audio(): AudioMedium
+    {
+        return new AudioMedium($this->mediaItems('test.mp3'));
+    }
+
+    private function mediaItems(string $filename): array
+    {
+        return [
+            'filepath' => GRAV_ROOT . '/' . $this->fixture,
+            'filename' => $filename,
+            'basename' => $filename,
+        ];
+    }
+}


### PR DESCRIPTION
## What changed

- remove the invalid `alt` attribute from rendered `<video>` and `<audio>` elements
- preserve non-empty media alternative text as `aria-label`
- keep an explicitly configured `aria-label` unchanged
- add regression coverage for video, audio, empty alt text, and explicit aria labels

The generic media pipeline populates `alt` for every medium. That is valid for images but not for HTML audio/video elements, which is why `media.html()` can emit non-standard markup as reported in #3540.

This keeps the existing media metadata useful for assistive technology while making the generated player markup valid.

Fixes #3540