### PR TITLE
[security] Restrict classes when unserializing lazy-index store rows

### DIFF
--- a/system/src/Grav/Common/Page/PageIndexStore.php
+++ b/system/src/Grav/Common/Page/PageIndexStore.php
@@ -289,7 +289,11 @@ final class PageIndexStore
                 return null;
             }
 
-            $value = @unserialize($payload);
+            // Rows in this table are plain arrays by construction. Refuse object
+            // instantiation outright so a tampered store file cannot be turned into
+            // a gadget-chain entry point; every other store Grav unserializes is
+            // gated the same way (FileCache HMAC, session flash v2 envelope).
+            $value = @unserialize($payload, ['allowed_classes' => false]);
 
             return is_array($value) ? $value : null;
         } catch (Throwable $e) {
@@ -313,7 +317,7 @@ final class PageIndexStore
 
             $result = [];
             foreach ($stmt->fetchAll(\PDO::FETCH_NUM) as [$path, $payload]) {
-                $info = @unserialize((string)$payload);
+                $info = @unserialize((string)$payload, ['allowed_classes' => false]);
                 $result[$path] = is_array($info) ? $info : [];
             }
 
@@ -335,7 +339,7 @@ final class PageIndexStore
 
             $map = [];
             foreach ($rows as [$type, $value, $path, $payload]) {
-                $info = @unserialize((string)$payload);
+                $info = @unserialize((string)$payload, ['allowed_classes' => false]);
                 $map[$type][$value][$path] = is_array($info) ? $info : [];
             }
 

--- a/system/src/Grav/Common/Page/Pages.php
+++ b/system/src/Grav/Common/Page/Pages.php
@@ -442,7 +442,13 @@ class Pages
             if ($instance === true && !array_key_exists($path, $this->instances)) {
                 $payloads ??= $this->index_store->readAll();
 
-                $page = isset($payloads[$path]) ? @unserialize($payloads[$path]) : null;
+                // Store rows only ever contain Page objects (plus plain stdClass
+                // data). Name them explicitly so a tampered store file cannot
+                // instantiate arbitrary classes — same posture as FileCache's
+                // HMAC gate on the blob cache.
+                $page = isset($payloads[$path])
+                    ? @unserialize($payloads[$path], ['allowed_classes' => [Page::class, \stdClass::class]])
+                    : null;
                 if ($page instanceof PageInterface) {
                     $this->instances[$path] = $page;
                 }
@@ -1058,7 +1064,9 @@ class Pages
     protected function loadIndexedPage(string $path): ?PageInterface
     {
         $payload = $this->index_store ? $this->index_store->read($path) : null;
-        $instance = is_string($payload) ? @unserialize($payload) : null;
+        $instance = is_string($payload)
+            ? @unserialize($payload, ['allowed_classes' => [Page::class, \stdClass::class]])
+            : null;
         if ($instance instanceof PageInterface) {
             return $instance;
         }


### PR DESCRIPTION
## Summary

The per-page index store (`PageIndexStore`, backing the experimental `system.pages.lazy_index` mode) reads its SQLite rows back with bare `unserialize()` — no `allowed_classes` restriction. Every other store Grav unserializes is gated: the blob pages cache verifies an HMAC before unserializing, and session flash objects carry a signed envelope. A tampered `cache://compiled/pages/*.sqlite` file can therefore instantiate arbitrary classes — a POP-chain entry point those other gates exist to deny.

This change:

- **`children` / `sorts` / `taxonomy` rows** are plain arrays by construction → unserialize with `['allowed_classes' => false]`, refusing object instantiation outright.
- **Page payloads** only ever contain `Grav\Common\Page\Page` objects plus plain `stdClass` data (verified by scanning every payload in a built store) → unserialize with those two classes named explicitly.

A corrupted or foreign-class row now falls through to the existing index-rebuild path instead of running code. Behavior for legitimate stores is unchanged; hydration was verified end-to-end (`Pages::get()` through `loadIndexedPage()`) with the allowlist active.
