### PR TITLE
Preserve __Secure-/__Host- cookie name prefixes in session name

### DIFF
--- a/system/src/Grav/Common/Service/SessionServiceProvider.php
+++ b/system/src/Grav/Common/Service/SessionServiceProvider.php
@@ -11,6 +11,7 @@ namespace Grav\Common\Service;
 
 use Grav\Common\Config\Config;
 use Grav\Common\Debugger;
+use Grav\Common\Inflector;
 use Grav\Common\Security;
 use Grav\Common\Session;
 use Grav\Common\Uri;
@@ -86,7 +87,7 @@ class SessionServiceProvider implements ServiceProviderInterface
                 $cookie_lifetime = 9999999999;
             }
 
-            $session_prefix = $c['inflector']->hyphenize($config->get('system.session.name', 'grav-site'));
+            $session_prefix = static::resolveSessionPrefix($c['inflector'], (string) $config->get('system.session.name', 'grav-site'));
             $session_uniqueness = $config->get('system.session.uniqueness', 'path') === 'path' ?  substr(md5(GRAV_ROOT), 0, 7) :  md5(Security::getNonceKey());
 
             $session_name = $session_prefix . '-' . $session_uniqueness;
@@ -131,5 +132,31 @@ class SessionServiceProvider implements ServiceProviderInterface
 
             return $session->messages;
         };
+    }
+
+    /**
+     * Resolves the configured session name into a session cookie name prefix.
+     *
+     * If the configured name is already a valid cookie name (RFC 6265 / RFC 2616 token), it is
+     * used as-is. This preserves cookie name prefixes such as `__Secure-` and `__Host-`, which
+     * browsers only honor on exact, case-sensitive, unmodified cookie names. Otherwise the name
+     * is hyphenized to strip out invalid characters.
+     *
+     * @param Inflector $inflector
+     * @param string $name
+     * @return string
+     */
+    public static function resolveSessionPrefix(Inflector $inflector, string $name): string
+    {
+        return static::isValidCookieName($name) ? $name : $inflector->hyphenize($name);
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    private static function isValidCookieName(string $name): bool
+    {
+        return $name !== '' && (bool) preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/', $name);
     }
 }

--- a/tests/unit/Grav/Common/Service/SessionServiceProviderTest.php
+++ b/tests/unit/Grav/Common/Service/SessionServiceProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use Grav\Common\Inflector;
+use Grav\Common\Service\SessionServiceProvider;
+
+/**
+ * Class SessionServiceProviderTest
+ */
+class SessionServiceProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Inflector $inflector */
+    protected $inflector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $grav = Fixtures::get('grav');
+        /** @var Grav $grav */
+        $grav = $grav();
+        $this->inflector = $grav['inflector'];
+    }
+
+    public function testSecureCookiePrefixIsPreserved(): void
+    {
+        self::assertSame(
+            '__Secure-session-cookie',
+            SessionServiceProvider::resolveSessionPrefix($this->inflector, '__Secure-session-cookie')
+        );
+    }
+
+    public function testHostCookiePrefixIsPreserved(): void
+    {
+        self::assertSame(
+            '__Host-session-cookie',
+            SessionServiceProvider::resolveSessionPrefix($this->inflector, '__Host-session-cookie')
+        );
+    }
+
+    public function testDefaultSessionNameIsUnchanged(): void
+    {
+        self::assertSame(
+            'grav-site',
+            SessionServiceProvider::resolveSessionPrefix($this->inflector, 'grav-site')
+        );
+    }
+
+    public function testInvalidCharactersAreStillHyphenized(): void
+    {
+        self::assertSame(
+            'my-site-cookie',
+            SessionServiceProvider::resolveSessionPrefix($this->inflector, 'My Site Cookie')
+        );
+    }
+}


### PR DESCRIPTION
Fixes #3773

The session cookie name (`system.session.name`) is always run through `Inflector::hyphenize()` in `SessionServiceProvider`. That helper strips leading underscores and lowercases the string, so a name like `__Secure-session-cookie` silently becomes `secure-session-cookie`.

Browsers only apply the `__Secure-` and `__Host-` cookie prefix protections when the cookie name is an exact, case-sensitive match, so this stripped the security benefit entirely without any error or warning to the site owner.

## Fix

`SessionServiceProvider` now only hyphenizes the configured session name when it isn't already a valid cookie name (RFC 6265 / RFC 2616 token). Names using a recognized cookie prefix (or any other already-valid cookie name) are preserved as-is; anything with characters that wouldn't be valid in a cookie name is still hyphenized exactly as before, so existing sites keep the same session cookie name after upgrading.

## Test plan

- Added `tests/unit/Grav/Common/Service/SessionServiceProviderTest.php` covering:
  - `__Secure-` prefixed names are preserved
  - `__Host-` prefixed names are preserved
  - the default `grav-site` name is unchanged
  - names with invalid characters are still hyphenized (existing behavior)
- `php -l` on both changed/added files
- Ran the full `tests/unit/Grav/Common` Codeception suite in a `php:8.3-cli` container after `composer install`; new tests pass, and the pre-existing `InflectorTest` suite is unaffected. The only failures/errors in that run are pre-existing environment gaps unrelated to this change (missing `gd`/`ZipArchive` extensions in the bare PHP image, and an unrelated `ComposerTest` path assertion).