### PR TITLE
Fix redirect_trailing_slash dropping custom_base_url path (#3822)

### DIFF
--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -424,6 +424,15 @@ class InitializeProcessor extends ProcessorBase
         $path = $uri->getPath() ?: '/';
         $root = $this->container['uri']->rootUrl();
 
+        // When system.custom_base_url is set behind a proxy that strips the custom
+        // path segment before it reaches PHP, the raw request path won't include it,
+        // even though external URLs (and the redirect target) must. Restore it so the
+        // redirect doesn't drop the custom base path.
+        if ($root !== '' && $root !== '/' && !Utils::startsWith($path, $root)) {
+            $path = $root . $path;
+            $uri = $uri->withPath($path);
+        }
+
         if ($path !== $root && $path !== $root . '/' && Utils::endsWith($path, '/')) {
             // Use permanent redirect for SEO reasons.
             return $this->container->getRedirectResponse((string)$uri->withPath(rtrim($path, '/')), $code);

--- a/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
+++ b/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use Grav\Common\Processors\InitializeProcessor;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+/**
+ * Class InitializeProcessorTest
+ */
+class InitializeProcessorTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+    }
+
+    protected function tearDown(): void
+    {
+    }
+
+    protected function handleRedirectRequest(string $requestPath): ?\Psr\Http\Message\ResponseInterface
+    {
+        $factory = new Psr17Factory();
+        $uri = $factory->createUri('http://localhost:8080' . $requestPath);
+        $request = $factory->createServerRequest('GET', $uri);
+
+        $processor = new InitializeProcessor($this->grav);
+        $method = new ReflectionMethod(InitializeProcessor::class, 'handleRedirectRequest');
+        $method->setAccessible(true);
+
+        return $method->invoke($processor, $request);
+    }
+
+    public function testRedirectTrailingSlashKeepsCustomBaseUrlWhenPhysicalPathIncludesIt(): void
+    {
+        $config = $this->grav['config'];
+        $currentBase = $config->get('system.custom_base_url');
+        $config->set('system.custom_base_url', 'http://localhost:8080/custombaseurl');
+
+        /** @var \Grav\Common\Uri $uri */
+        $uri = $this->grav['uri'];
+        $uri->initializeWithUrlAndRootPath('http://localhost:8080/custombaseurl/page1/', '')->init();
+
+        $response = $this->handleRedirectRequest('/custombaseurl/page1/');
+
+        $this->assertNotNull($response);
+        $this->assertSame(
+            'http://localhost:8080/custombaseurl/page1',
+            $response->getHeaderLine('Location')
+        );
+
+        $config->set('system.custom_base_url', $currentBase);
+    }
+
+    public function testRedirectTrailingSlashRestoresCustomBaseUrlWhenPhysicalPathIsStripped(): void
+    {
+        $config = $this->grav['config'];
+        $currentBase = $config->get('system.custom_base_url');
+        $config->set('system.custom_base_url', 'http://localhost:8080/custombaseurl');
+
+        /** @var \Grav\Common\Uri $uri */
+        $uri = $this->grav['uri'];
+        // The reverse proxy strips the custom base path before it reaches PHP.
+        $uri->initializeWithUrlAndRootPath('http://localhost:8080/page1/', '')->init();
+
+        $response = $this->handleRedirectRequest('/page1/');
+
+        $this->assertNotNull($response);
+        $this->assertSame(
+            'http://localhost:8080/custombaseurl/page1',
+            $response->getHeaderLine('Location')
+        );
+
+        $config->set('system.custom_base_url', $currentBase);
+    }
+}


### PR DESCRIPTION
## Summary

`InitializeProcessor::handleRedirectRequest()` builds the trailing-slash
redirect target from the raw PSR-7 request URI path. When
`system.custom_base_url` is configured and the physical request reaching
PHP does not include that custom path segment (e.g. behind a reverse
proxy/router that strips the external prefix before forwarding to Grav),
the redirect dropped the custom base path entirely — reproducing exactly
the symptom in #3822 (`.../custombaseurl/page1/` redirecting to
`.../page1` instead of `.../custombaseurl/page1`).

The fix restores the custom base path onto the redirect target when the
raw request path doesn't already start with it, using the same
`Uri::rootUrl()` that already correctly resolves `custom_base_url`
elsewhere in Grav. When there's no custom base (or the physical path
already includes it, e.g. a front-controller setup where `REQUEST_URI`
carries the full external path), behavior is unchanged.

## Test plan

- Added `tests/unit/Grav/Common/Processors/InitializeProcessorTest.php`
  covering both the "physical path already includes the custom base"
  and the "physical path has the custom base stripped" scenarios.
- Verified the new stripped-path test fails against the pre-fix code
  (`Location: http://localhost:8080/page1` instead of
  `.../custombaseurl/page1`) and passes after the fix.
- `vendor/bin/codecept run unit --filter '/Uri|InitializeProcessor/'` —
  31 tests, 860 assertions, all passing (no regressions to existing
  `UriTest` custom-base-url coverage).
- Manually reproduced end-to-end with a live PHP built-in server
  (`system/router.php`) and `system.custom_base_url` configured,
  confirming the redirect `Location` header now preserves the custom
  base path in both scenarios.

Fixes #3822