### PR TITLE
Add Collection::notOfType() to exclude page templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 1. [](#new)
     * The `url()` Twig function now takes a language, so a link to a route that isn't a page - a search page, a form action - can carry the site's language prefix: `{{ url('/search', lang=true) }}`
+    * Page collections can now exclude one or more template types with `notOfType()`, the counterpart to the existing `ofType()` [#3910](https://github.com/getgrav/grav/issues/3910)
 1. [](#improved)
     * Building a URL is now faster, which adds up over the hundreds of asset and link URLs a single page render produces
 1. [](#bugfix)

--- a/system/src/Grav/Common/Flex/Types/Pages/PageCollection.php
+++ b/system/src/Grav/Common/Flex/Types/Pages/PageCollection.php
@@ -93,6 +93,7 @@ class PageCollection extends FlexPageCollection implements PageCollectionInterfa
                 'nonRoutable' => true,
                 'ofType' => true,
                 'ofOneOfTheseTypes' => true,
+                'notOfType' => true,
                 'ofOneOfTheseAccessLevels' => true,
                 'withOrdered' => true,
                 'withModules' => true,
@@ -670,6 +671,26 @@ class PageCollection extends FlexPageCollection implements PageCollectionInterfa
         $entries = [];
         foreach ($this as $key => $object) {
             if ($object && in_array($object->template(), $types, true)) {
+                $entries[$key] = $object;
+            }
+        }
+
+        return $this->createFrom($entries);
+    }
+
+    /**
+     * Creates new collection excluding pages of the specified type(s)
+     *
+     * @param string|string[] $type
+     * @return static The collection
+     * @phpstan-return static<T>
+     */
+    public function notOfType($type)
+    {
+        $entries = [];
+        $types = (array) $type;
+        foreach ($this as $key => $object) {
+            if ($object && !in_array($object->template(), $types, true)) {
                 $entries[$key] = $object;
             }
         }

--- a/system/src/Grav/Common/Flex/Types/Pages/PageIndex.php
+++ b/system/src/Grav/Common/Flex/Types/Pages/PageIndex.php
@@ -1156,6 +1156,20 @@ class PageIndex extends FlexPageIndex implements PageCollectionInterface
     }
 
     /**
+     * Creates new collection excluding pages of the specified type(s)
+     *
+     * @param string|string[] $type
+     * @return static The collection
+     * @phpstan-return static<T,C>
+     */
+    public function notOfType($type)
+    {
+        $collection = $this->__call('notOfType', [$type]);
+
+        return $collection;
+    }
+
+    /**
      * Creates new collection with only pages of one of the specified access levels
      *
      * @param array $accessLevels

--- a/system/src/Grav/Common/Page/Collection.php
+++ b/system/src/Grav/Common/Page/Collection.php
@@ -634,6 +634,29 @@ class Collection extends Iterator implements PageCollectionInterface
     }
 
     /**
+     * Creates new collection excluding pages of the specified type(s)
+     *
+     * @param string|string[] $type
+     * @return Collection The collection
+     */
+    public function notOfType($type)
+    {
+        $items = [];
+        $types = (array) $type;
+
+        foreach ($this->items as $path => $slug) {
+            $page = $this->pages->get($path);
+            if ($page !== null && !in_array($page->template(), $types, true)) {
+                $items[$path] = $slug;
+            }
+        }
+
+        $this->items = $items;
+
+        return $this;
+    }
+
+    /**
      * Creates new collection with only pages of one of the specified access levels
      *
      * @param array $accessLevels

--- a/system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php
+++ b/system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php
@@ -285,6 +285,15 @@ interface PageCollectionInterface extends Traversable, ArrayAccess, Countable, S
     public function ofOneOfTheseTypes($types);
 
     /**
+     * Creates new collection excluding pages of the specified type(s)
+     *
+     * @param string|string[] $type
+     * @return PageCollectionInterface The collection
+     * @phpstan-return PageCollectionInterface<TKey,T>
+     */
+    public function notOfType($type);
+
+    /**
      * Creates new collection with only pages of one of the specified access levels
      *
      * @param array $accessLevels

--- a/tests/unit/Grav/Common/Page/PagesTest.php
+++ b/tests/unit/Grav/Common/Page/PagesTest.php
@@ -270,6 +270,36 @@ class PagesTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function testOfTypeAndNotOfType(): void
+    {
+        $all = $this->pages->all();
+        $templates = [];
+        foreach ($all as $page) {
+            $templates[$page->template()] = true;
+        }
+        self::assertArrayHasKey('blog', $templates);
+
+        $blogOnly = $this->pages->all()->ofType('blog');
+        foreach ($blogOnly as $page) {
+            self::assertSame('blog', $page->template());
+        }
+        self::assertGreaterThan(0, count($blogOnly->toArray()));
+
+        $withoutBlog = $this->pages->all()->notOfType('blog');
+        foreach ($withoutBlog as $page) {
+            self::assertNotSame('blog', $page->template());
+        }
+        self::assertSame(
+            count($all->toArray()),
+            count($blogOnly->toArray()) + count($withoutBlog->toArray())
+        );
+
+        $withoutBlogOrDefault = $this->pages->all()->notOfType(['blog', 'default']);
+        foreach ($withoutBlogOrDefault as $page) {
+            self::assertNotContains($page->template(), ['blog', 'default']);
+        }
+    }
+
     public function testGetList(): void
     {
         $list = $this->pages->getList();

--- a/tests/unit/Grav/Common/Page/PagesTest.php
+++ b/tests/unit/Grav/Common/Page/PagesTest.php
@@ -298,6 +298,7 @@ class PagesTest extends \PHPUnit\Framework\TestCase
         foreach ($withoutBlogOrDefault as $page) {
             self::assertNotContains($page->template(), ['blog', 'default']);
         }
+        self::assertGreaterThan(0, count($withoutBlogOrDefault->toArray()));
     }
 
     public function testGetList(): void


### PR DESCRIPTION
Fixes #3910

## Summary

Adds `Collection::notOfType($type)`, the inverse of the existing `Collection::ofType()` / `Collection::ofOneOfTheseTypes()`, so a page collection can exclude one or more template types instead of only including them.

`$type` accepts either a single template name (string) or an array of template names, matching the acceptance criteria in the issue ("exclude a single/multiple template types").

Exposed the same way as the existing type filters so it is directly callable from Twig:

```twig
{% for p in page.collection().notOfType('modular/links') %}
    ...
{% endfor %}
```

As @rhukster invited on the issue:

> How about a PR? Seems you have a need, have a solution, just create a PR for this feature, and it could get merged.

## Changes

- `system/src/Grav/Common/Page/Collection.php` — new `notOfType()` method, mirrors `ofType()`/`ofOneOfTheseTypes()` with the match inverted.
- `system/src/Grav/Common/Page/Interfaces/PageCollectionInterface.php` — interface declaration.
- `system/src/Grav/Common/Flex/Types/Pages/PageCollection.php` — Flex collection implementation + registered in `getCachedMethods()` alongside `ofType`/`ofOneOfTheseTypes`.
- `system/src/Grav/Common/Flex/Types/Pages/PageIndex.php` — proxy method delegating to the Flex collection via `__call()`, same pattern as `ofType`/`ofOneOfTheseTypes`.
- `tests/unit/Grav/Common/Page/PagesTest.php` — new `testOfTypeAndNotOfType()` covering single-type and multi-type exclusion, and that `ofType` + `notOfType` partition the full collection.

## Test plan

- [x] `php -l` on all changed files
- [x] Full `composer install` + Codeception unit suite for `tests/unit/Grav/Common/Page` (73 tests, 225 assertions) — all green, including the new test
- [x] Manually verified `notOfType` and `ofType` results are complementary/non-overlapping on the fixture page set