### PR TITLE
Apply force_ssl redirect on 404 fallback page too (#3703)

### DIFF
--- a/system/src/Grav/Common/Service/PagesServiceProvider.php
+++ b/system/src/Grav/Common/Service/PagesServiceProvider.php
@@ -60,19 +60,19 @@ class PagesServiceProvider implements ServiceProviderInterface
             $path = $uri->path() ? urldecode($uri->path()) : '/'; // Don't trim to support trailing slash default routes
             $page = $pages->dispatch($path);
 
+            if ($config->get('system.force_ssl')) {
+                $scheme = $uri->scheme(true);
+                if ($scheme !== 'https') {
+                    $url = 'https://' . $uri->host() . $uri->uri();
+                    $grav->redirect($url);
+                }
+            }
+
             // Redirection tests
             if ($page) {
                 // some debugger override logic
                 if ($page->debugger() === false) {
                     $grav['debugger']->enabled(false);
-                }
-
-                if ($config->get('system.force_ssl')) {
-                    $scheme = $uri->scheme(true);
-                    if ($scheme !== 'https') {
-                        $url = 'https://' . $uri->host() . $uri->uri();
-                        $grav->redirect($url);
-                    }
                 }
 
                 $route = $page->route();

--- a/tests/unit/Grav/Common/Service/PagesServiceProviderTest.php
+++ b/tests/unit/Grav/Common/Service/PagesServiceProviderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Config\Config;
+use Grav\Common\Grav;
+use Grav\Common\Page\Pages;
+use Grav\Common\Uri;
+use RocketTheme\Toolbox\ResourceLocator\UniformResourceLocator;
+
+/**
+ * Class PagesServiceProviderTest
+ *
+ * Covers the `system.force_ssl` redirect performed by the `page` container
+ * service, including on the 404/notfound fallback path (#3703).
+ */
+class PagesServiceProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Grav */
+    protected $grav;
+
+    /** @var Config */
+    protected $config;
+
+    /** @var Uri */
+    protected $uri;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $grav = Fixtures::get('grav');
+        /** @var Grav $grav */
+        $this->grav = $grav();
+        $this->config = $this->grav['config'];
+        $this->uri = $this->grav['uri'];
+
+        /** @var Pages $pages */
+        $pages = $this->grav['pages'];
+
+        /** @var UniformResourceLocator $locator */
+        $locator = $this->grav['locator'];
+        $locator->addPath('page', '', 'tests/fake/simple-site/user/pages', false);
+        $pages->init();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->config->set('system.force_ssl', false);
+        $this->uri->initializeWithUrl('http://localhost/')->init();
+
+        parent::tearDown();
+    }
+
+    public function testForceSslRedirectsOnExistingPage(): void
+    {
+        $this->config->set('system.force_ssl', true);
+        $this->uri->initializeWithUrl('http://testing.dev/blog')->init();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('#redirect to https://testing\.dev/blog#');
+
+        $this->grav['page'];
+    }
+
+    public function testForceSslRedirectsOnNotFoundPage(): void
+    {
+        $this->config->set('system.force_ssl', true);
+        $this->uri->initializeWithUrl('http://testing.dev/this-page-does-not-exist')->init();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('#redirect to https://testing\.dev/this-page-does-not-exist#');
+
+        $this->grav['page'];
+    }
+
+    public function testNoRedirectWhenForceSslDisabledOnNotFoundPage(): void
+    {
+        $this->config->set('system.force_ssl', false);
+        $this->uri->initializeWithUrl('http://testing.dev/this-page-does-not-exist')->init();
+
+        $page = $this->grav['page'];
+
+        self::assertFalse($page->routable());
+    }
+}


### PR DESCRIPTION
Closes #3703.

When `system.force_ssl` is enabled and the requested path doesn't match a real page, the redirect check in `PagesServiceProvider` never runs. It's only inside the `if ($page)` block, and `$page` is null right up until the notfound fallback gets built further down, so a 404 request over plain HTTP just serves the 404 page instead of bouncing to HTTPS first.

I moved the force_ssl check up so it runs right after `$pages->dispatch($path)`, before the found/not-found branch, instead of duplicating it on both paths. That way it applies to every request regardless of whether a page was found.

Added a test in `PagesServiceProviderTest` that drives the actual `page` container service with force_ssl on: one case hitting an existing page (already worked, checked it doesn't regress) and one hitting a path with no matching page. Confirmed the new test fails against the old code (no redirect thrown) and passes with the fix.
