### PR TITLE
Skip image-only defaults for non-image media (#4264)

### DIFF
--- a/system/src/Grav/Common/Page/Markdown/Excerpts.php
+++ b/system/src/Grav/Common/Page/Markdown/Excerpts.php
@@ -10,6 +10,7 @@
 namespace Grav\Common\Page\Markdown;
 
 use Grav\Common\Grav;
+use Grav\Common\Media\Interfaces\ImageMediaInterface;
 use Grav\Common\Page\Interfaces\PageInterface;
 use Grav\Common\Page\Medium\Link;
 use Grav\Common\Page\Pages;
@@ -295,7 +296,15 @@ class Excerpts
 
         $defaults = $this->config['images']['defaults'] ?? [];
         if (count($defaults)) {
+            $isImage = $medium instanceof ImageMediaInterface;
             foreach ($defaults as $method => $params) {
+                // loading/decoding/fetchpriority are image-only HTML attributes
+                // (backed by traits only ImageMedium/StaticImageMedium use); skip
+                // them for non-image media such as audio/video/documents.
+                if (!$isImage && in_array($method, ['loading', 'decoding', 'fetchpriority'], true)) {
+                    continue;
+                }
+
                 if (array_search($method, array_column($actions, 'method')) === false) {
                     $actions[] = [
                         'method' => $method,

--- a/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
+++ b/tests/unit/Grav/Common/Helpers/ExcerptsTest.php
@@ -211,6 +211,50 @@ class ExcerptsTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    public function testImageDefaultsAreNotAppliedToNonImageMedia(): void
+    {
+        // getgrav/grav#4264: system.images.defaults (loading/decoding/fetchpriority)
+        // must only apply to actual image media, not every medium type embedded
+        // via markdown image syntax (audio, video, documents, ...).
+        $this->config->set('system.images.defaults', [
+            'loading' => 'lazy',
+            'decoding' => 'async',
+            'fetchpriority' => 'high',
+            'link' => true,
+        ]);
+
+        $fixturePath = GRAV_ROOT . '/tests/fake/nested-site/user/pages/02.item2/02.item2-2/sample-audio.mp3';
+        file_put_contents($fixturePath, '');
+
+        $this->page->media(new Media($this->page->getMediaFolder(), $this->page->getMediaOrder()));
+
+        try {
+            $result = Excerpts::processImageHtml('<img src="sample-audio.mp3" alt="Sample Audio" />', $this->page);
+
+            self::assertStringNotContainsString('loading=', $result);
+            self::assertStringNotContainsString('decoding=', $result);
+            self::assertStringNotContainsString('fetchpriority=', $result);
+            // 'link' is a universal action and should still be honoured.
+            self::assertStringContainsString('<a ', $result);
+        } finally {
+            @unlink($fixturePath);
+        }
+    }
+
+    public function testImageDefaultsAreStillAppliedToRealImages(): void
+    {
+        // Non-regression: normal images must keep receiving the configured
+        // image defaults.
+        $this->config->set('system.images.defaults', [
+            'loading' => 'lazy',
+        ]);
+
+        self::assertMatchesRegularExpression(
+            '/loading="lazy"/',
+            Excerpts::processImageHtml('<img src="sample-image.jpg" alt="Sample Image" />', $this->page)
+        );
+    }
+
     public function testMediaExtensionArmDoesNotCaptureRealSchemes(): void
     {
         // The media-extension check must never reinterpret a genuine protocol as


### PR DESCRIPTION
`system.images.defaults` gets applied to every medium that comes through `Excerpts::processMediaActions()`, not just images. If you set `loading: lazy` (or `decoding`/`fetchpriority`) there, it also gets called on audio/video/document media embedded via markdown image syntax, e.g. `![](podcast.mp3)`.

`loading()`/`decoding()`/`fetchpriority()` only exist as real methods on `ImageMedium`/`StaticImageMedium` (via their traits). For anything else, the call falls through to the generic `__call()` on `MediaObjectTrait`, which just appends `loading=lazy` etc. to the medium's querystring — so it leaks into the rendered output for media types where it means nothing.

Fixed by skipping those three default actions in the defaults loop when the medium isn't `ImageMediaInterface`. Left `link` and the other defaults alone since those are legitimate for any media type.

Added a test confirming a non-image medium (mp3) no longer picks up `loading`/`decoding`/`fetchpriority` from `system.images.defaults`, plus a non-regression test that real images still get them.

Closes #4264
