### PR TITLE
Uri::ip(): read request variables from $_SERVER, not only getenv()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     * `composer.json` now declares the `ctype` and `session` extensions it has always used, and suggests `fileinfo` and `simplexml`. Installing with `composer create-project` on a machine missing one of these no longer quietly walks back to a years-old release of Grav instead of failing [#4273](https://github.com/getgrav/grav/discussions/4273)
 1. [](#bugfix)
     * Reading the browser name, platform or version no longer raises a PHP deprecation notice when a request arrives with no user agent, which is every request from a bare script or a health check
+    * `Uri::ip()` reads the client address from `$_SERVER` (falling back to `getenv()`), so it no longer reports `UNKNOWN` on hosts whose PHP does not export request variables to the environment: CGI/FastCGI setups such as NearlyFreeSpeech, and PHP's built-in server. Everything keyed on it there, such as the Login plugin's failed-login lockout and per-IP rate limiting, had been sharing one `UNKNOWN` bucket [#2507](https://github.com/getgrav/grav/issues/2507)
 
 # v2.0.22
 ## 08/31/2026

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -698,6 +698,17 @@ class Uri implements \Stringable
     {
         $forwarded = (array)Grav::instance()['config']->get('system.http_x_forwarded', []);
 
+        // Request variables come from $_SERVER, which every SAPI populates.
+        // getenv() only sees them where the SAPI also exports them to the
+        // process environment (mod_php, most php-fpm setups); under CGI/FastCGI
+        // hosts and PHP's built-in server it is empty and every caller used to
+        // come back as UNKNOWN. getenv() stays as the fallback.
+        $server = static function (string $name): string {
+            $value = $_SERVER[$name] ?? getenv($name);
+
+            return is_string($value) ? $value : '';
+        };
+
         // Each forwarded header is opt-in. Defaults ship as false in Grav 2.0:
         // only enable for a header when the request genuinely comes through a
         // proxy that sets and overwrites it (e.g. cf_connecting_ip behind
@@ -706,25 +717,25 @@ class Uri implements \Stringable
         // throttling, banning, or audit logging.
         $candidates = [];
 
-        if (!empty($forwarded['client_ip']) && getenv('HTTP_CLIENT_IP')) {
-            $candidates[] = getenv('HTTP_CLIENT_IP');
+        if (!empty($forwarded['client_ip']) && $server('HTTP_CLIENT_IP')) {
+            $candidates[] = $server('HTTP_CLIENT_IP');
         }
-        if (!empty($forwarded['cf_connecting_ip']) && getenv('HTTP_CF_CONNECTING_IP')) {
-            $candidates[] = getenv('HTTP_CF_CONNECTING_IP');
+        if (!empty($forwarded['cf_connecting_ip']) && $server('HTTP_CF_CONNECTING_IP')) {
+            $candidates[] = $server('HTTP_CF_CONNECTING_IP');
         }
         if (!empty($forwarded['ip'])) {
-            if (getenv('HTTP_X_FORWARDED_FOR')) {
-                $ips = array_map('trim', explode(',', getenv('HTTP_X_FORWARDED_FOR')));
+            if ($server('HTTP_X_FORWARDED_FOR')) {
+                $ips = array_map('trim', explode(',', $server('HTTP_X_FORWARDED_FOR')));
                 $candidates[] = array_shift($ips);
             }
-            if (getenv('HTTP_X_FORWARDED')) {
-                $candidates[] = getenv('HTTP_X_FORWARDED');
+            if ($server('HTTP_X_FORWARDED')) {
+                $candidates[] = $server('HTTP_X_FORWARDED');
             }
-            if (getenv('HTTP_FORWARDED_FOR')) {
-                $candidates[] = getenv('HTTP_FORWARDED_FOR');
+            if ($server('HTTP_FORWARDED_FOR')) {
+                $candidates[] = $server('HTTP_FORWARDED_FOR');
             }
-            if (getenv('HTTP_FORWARDED')) {
-                $candidates[] = getenv('HTTP_FORWARDED');
+            if ($server('HTTP_FORWARDED')) {
+                $candidates[] = $server('HTTP_FORWARDED');
             }
         }
 
@@ -734,7 +745,7 @@ class Uri implements \Stringable
             }
         }
 
-        $remote = getenv('REMOTE_ADDR');
+        $remote = $server('REMOTE_ADDR');
 
         return $remote && filter_var($remote, FILTER_VALIDATE_IP) ? $remote : 'UNKNOWN';
     }

--- a/tests/unit/Grav/Common/UriTest.php
+++ b/tests/unit/Grav/Common/UriTest.php
@@ -1134,6 +1134,7 @@ class UriTest extends \PHPUnit\Framework\TestCase
         // Request variables are read from $_SERVER, not only getenv(): CGI/FastCGI
         // hosts and PHP's built-in server never export them to the environment.
         $previous = $this->config->get('system.http_x_forwarded');
+        $previousServer = array_intersect_key($_SERVER, ['REMOTE_ADDR' => 1, 'HTTP_X_FORWARDED_FOR' => 1]);
         $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.9, 203.0.113.7';
         try {
@@ -1148,6 +1149,7 @@ class UriTest extends \PHPUnit\Framework\TestCase
             self::assertSame('UNKNOWN', Uri::ip(), 'an invalid address is not reported');
         } finally {
             unset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR']);
+            $_SERVER += $previousServer;
             $this->config->set('system.http_x_forwarded', $previous);
         }
     }

--- a/tests/unit/Grav/Common/UriTest.php
+++ b/tests/unit/Grav/Common/UriTest.php
@@ -1130,6 +1130,26 @@ class UriTest extends \PHPUnit\Framework\TestCase
     {
         $this->uri->initializeWithURL('http://localhost/foo/page:test')->init();
         self::assertSame('UNKNOWN', Uri::ip());
+
+        // Request variables are read from $_SERVER, not only getenv(): CGI/FastCGI
+        // hosts and PHP's built-in server never export them to the environment.
+        $previous = $this->config->get('system.http_x_forwarded');
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.9, 203.0.113.7';
+        try {
+            $this->config->set('system.http_x_forwarded', ['ip' => false]);
+            self::assertSame('203.0.113.7', Uri::ip(), 'forwarded headers stay ignored until opted in');
+
+            $this->config->set('system.http_x_forwarded', ['ip' => true]);
+            self::assertSame('198.51.100.9', Uri::ip(), 'opted-in forwarded header wins over REMOTE_ADDR');
+
+            unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+            $_SERVER['REMOTE_ADDR'] = 'not-an-ip';
+            self::assertSame('UNKNOWN', Uri::ip(), 'an invalid address is not reported');
+        } finally {
+            unset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR']);
+            $this->config->set('system.http_x_forwarded', $previous);
+        }
     }
 
     public function testIsExternal(): void


### PR DESCRIPTION
## Problem

`Uri::ip()` has resolved the client address through `getenv()` since its first commit in 2014. PHP only guarantees request variables in `$_SERVER`; `getenv()` sees them where the SAPI also exports them to the process environment (mod_php, most php-fpm setups) and comes back empty under CGI/FastCGI hosts and PHP's built-in server. On such hosts every caller is reported as `UNKNOWN`, so everything keyed on the address shares one bucket: the Login plugin's failed-login lockout (`Utils::getSubnet(Uri::ip())`), per-IP rate limiting, popularity tracking, and audit logging.

#2507 (2019, built-in server) was this symptom. Its fix made `Utils::getSubnet()` return the bad string instead of throwing, which removed the exception but left the lookup unchanged.

`Uri::ip()` is the only place in core that reads request variables through `getenv()`; every other read in `Uri.php` already uses `$_SERVER`.

## How it was found

While building a plugin whose OAuth throttle keys use `Uri::ip()`, every log line on a site hosted at **NearlyFreeSpeech** (Apache + FastCGI PHP) reported the caller as `UNKNOWN`, which collapsed the per-IP registration throttle and login lockout into a single shared bucket. The API plugin's audit trail on the same host records real addresses because it reads `$_SERVER['REMOTE_ADDR']`. Reading `$_SERVER` in the plugin, on the same request path, was confirmed live on that host: the log lines then carry the real address.

## Change

Each read in `Uri::ip()` now prefers `$_SERVER[$name]` and falls back to `getenv($name)`, so behaviour is unchanged wherever `getenv()` already worked. The opt-in `system.http_x_forwarded` gates are untouched, and candidates are still validated with `FILTER_VALIDATE_IP`.

## Testing

- `testIp` extended: `$_SERVER['REMOTE_ADDR']` is honoured with `getenv()` empty; an `X-Forwarded-For` in `$_SERVER` stays ignored until `http_x_forwarded.ip` is enabled and then wins; an invalid `REMOTE_ADDR` still yields `UNKNOWN`. Config and `$_SERVER` are restored afterwards.
- `UriTest` passes (29 tests, 859 assertions) on PHP 8.3.
- Full `codecept run unit` on PHP 8.3 in a slim Docker container: the same 19 tests fail with and without this patch (they need the `gd` and `zip` extensions the container lacks, plus a composer-path check); nothing else changes.
- The patched core itself was not run on the NearlyFreeSpeech host; what was verified there is the underlying `getenv()` versus `$_SERVER` behaviour that the patch relies on.

A changelog line is added under the unreleased v2.0.23 section; happy to drop or reword it if you prefer to manage that yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
