### PR TITLE
Convert true/false in GRAV_CONFIG__ env overrides to real booleans

### DIFF
--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -232,6 +232,7 @@ class InitializeProcessor extends ProcessorBase
                 foreach ($aliases as $alias => $real) {
                     $key = str_replace($alias, $real, $key);
                 }
+                $value = static::castEnvironmentValue($value);
                 $list[$key] = $value;
                 $config->set($key, $value);
             }
@@ -481,6 +482,33 @@ class InitializeProcessor extends ProcessorBase
         $base = rtrim($base, '/');
 
         return $path === $base || str_starts_with($path, $base . '/');
+    }
+
+    /**
+     * Coerce a `GRAV_CONFIG__*` environment override to the type it plainly means.
+     *
+     * Environment variables are always strings, so `GRAV_CONFIG__system__cache__enabled=false`
+     * would otherwise reach the config as the string `"false"` -- and the `(bool)` casts
+     * used throughout core (e.g. `Cache::init()`) treat any non-empty, non-`"0"` string
+     * as true, silently doing the opposite of what was asked. Only the two boolean
+     * literals are coerced, case-insensitively; numbers and every other string are
+     * passed through unchanged, matching the previous behaviour.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    protected static function castEnvironmentValue(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            if (strcasecmp($value, 'true') === 0) {
+                return true;
+            }
+            if (strcasecmp($value, 'false') === 0) {
+                return false;
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
+++ b/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
@@ -316,4 +316,43 @@ class InitializeProcessorTest extends \PHPUnit\Framework\TestCase
             'multi-segment lookalike'    => ['/a/bc/page', '/a/b', false],
         ];
     }
+
+    /* ------------------------------------------------------------------ *
+     * GRAV_CONFIG__* environment overrides: boolean literals must not
+     * arrive as the strings "true"/"false" (#4277).
+     * ------------------------------------------------------------------ */
+
+    /**
+     * @dataProvider environmentValues
+     */
+    public function testCastEnvironmentValue(mixed $input, mixed $expected): void
+    {
+        $method = new ReflectionMethod(InitializeProcessor::class, 'castEnvironmentValue');
+        $method->setAccessible(true);
+
+        self::assertSame($expected, $method->invoke(null, $input));
+    }
+
+    /** @return array<string, array{mixed, mixed}> */
+    public function environmentValues(): array
+    {
+        return [
+            'false literal' => ['false', false],
+            'true literal' => ['true', true],
+            'uppercase FALSE' => ['FALSE', false],
+            'mixed-case True' => ['True', true],
+            '"0" kept as string' => ['0', '0'],
+            '"1" kept as string' => ['1', '1'],
+            'numeric string kept' => ['42', '42'],
+            'arbitrary string kept' => ['production', 'production'],
+            'literal as a substring is not matched' => ['falsey', 'falsey'],
+            'a padded literal is left as text' => [' true ', ' true '],
+            '"yes" is not coerced' => ['yes', 'yes'],
+            'empty string' => ['', ''],
+            'a real bool is returned as-is' => [true, true],
+            'a real false is returned as-is' => [false, false],
+            'null is returned as-is' => [null, null],
+            'an int is returned as-is' => [0, 0],
+        ];
+    }
 }


### PR DESCRIPTION
Fixes #4277.

Env vars are always strings, so setting `GRAV_CONFIG__system__cache__enabled=false` puts the string `"false"` into the config. Core reads that flag (and others like it) with a `(bool)` cast, and `(bool)"false"` is `true`, so the override does the opposite of what you'd expect. Nothing in the logs points at it either.

The env override loop in `initializeConfig()` now passes each value through a small `castEnvironmentValue()` helper before `$config->set()`. It converts the literal strings `true`/`false` (case-insensitive) to booleans and leaves everything else alone - numbers, `"0"`/`"1"`, arbitrary strings all behave exactly as before, so existing setups aren't affected.

Tests are in `InitializeProcessorTest` using the same reflection + data provider approach the file already has for `pathHasBase`. `vendor/bin/codecept run unit` is green.

Left `CHANGELOG.md` alone since there's no unreleased section right now - happy to add a line wherever you want it.