### PR TITLE
Fix GRAV_CONFIG env override gate to also check $_SERVER/$_ENV

### DIFF
--- a/system/src/Grav/Common/Config/Setup.php
+++ b/system/src/Grav/Common/Config/Setup.php
@@ -167,6 +167,29 @@ class Setup extends Data
     ];
 
     /**
+     * Read a bootstrap variable from wherever the SAPI put it.
+     *
+     * $_SERVER is the only source PHP guarantees for server-set variables, but
+     * a present-but-empty entry (an unset nginx variable used in a
+     * `fastcgi_param`, an empty `SetEnv`) must not shadow a working getenv(),
+     * or the fix breaks the hosts where the old code worked. Mirrors Env.php
+     * and Uri::ip(). (#4279)
+     *
+     * @param string $name
+     * @return string|null
+     */
+    private static function envVar(string $name): ?string
+    {
+        foreach ([$_SERVER[$name] ?? null, $_ENV[$name] ?? null, getenv($name)] as $value) {
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param Container|array $container
      */
     public function __construct($container)
@@ -182,7 +205,7 @@ class Setup extends Data
 
         // If environment is not set, look for the environment variable and then the constant.
         $environment = static::$environment ??
-            (defined('GRAV_ENVIRONMENT') ? GRAV_ENVIRONMENT : ($_SERVER['GRAV_ENVIRONMENT'] ?? $_ENV['GRAV_ENVIRONMENT'] ?? (getenv('GRAV_ENVIRONMENT') ?: null)));
+            (defined('GRAV_ENVIRONMENT') ? GRAV_ENVIRONMENT : static::envVar('GRAV_ENVIRONMENT'));
 
         // If no environment is set, make sure we get one (CLI or hostname).
         if (null === $environment) {
@@ -204,7 +227,7 @@ class Setup extends Data
         // Pre-load setup.php which contains our initial configuration.
         // Configuration may contain dynamic parts, which is why we need to always load it.
         // If GRAV_SETUP_PATH has been defined, use it, otherwise use defaults.
-        $setupFile = defined('GRAV_SETUP_PATH') ? GRAV_SETUP_PATH : ($_SERVER['GRAV_SETUP_PATH'] ?? $_ENV['GRAV_SETUP_PATH'] ?? (getenv('GRAV_SETUP_PATH') ?: null));
+        $setupFile = defined('GRAV_SETUP_PATH') ? GRAV_SETUP_PATH : static::envVar('GRAV_SETUP_PATH');
         if (null !== $setupFile) {
             // Make sure that the custom setup file exists. Terminates the script if not.
             if (!str_starts_with((string) $setupFile, '/')) {
@@ -237,10 +260,10 @@ class Setup extends Data
         $this->def('environment', static::$environment);
 
         // Figure out path for the current environment.
-        $envPath = defined('GRAV_ENVIRONMENT_PATH') ? GRAV_ENVIRONMENT_PATH : ($_SERVER['GRAV_ENVIRONMENT_PATH'] ?? $_ENV['GRAV_ENVIRONMENT_PATH'] ?? (getenv('GRAV_ENVIRONMENT_PATH') ?: null));
+        $envPath = defined('GRAV_ENVIRONMENT_PATH') ? GRAV_ENVIRONMENT_PATH : static::envVar('GRAV_ENVIRONMENT_PATH');
         if (null === $envPath) {
             // Find common path for all environments and append current environment into it.
-            $envPath = defined('GRAV_ENVIRONMENTS_PATH') ? GRAV_ENVIRONMENTS_PATH : ($_SERVER['GRAV_ENVIRONMENTS_PATH'] ?? $_ENV['GRAV_ENVIRONMENTS_PATH'] ?? (getenv('GRAV_ENVIRONMENTS_PATH') ?: null));
+            $envPath = defined('GRAV_ENVIRONMENTS_PATH') ? GRAV_ENVIRONMENTS_PATH : static::envVar('GRAV_ENVIRONMENTS_PATH');
             if (null !== $envPath) {
                 $envPath .= '/';
             } else {

--- a/system/src/Grav/Common/Config/Setup.php
+++ b/system/src/Grav/Common/Config/Setup.php
@@ -182,7 +182,7 @@ class Setup extends Data
 
         // If environment is not set, look for the environment variable and then the constant.
         $environment = static::$environment ??
-            (defined('GRAV_ENVIRONMENT') ? GRAV_ENVIRONMENT : (getenv('GRAV_ENVIRONMENT') ?: null));
+            (defined('GRAV_ENVIRONMENT') ? GRAV_ENVIRONMENT : ($_SERVER['GRAV_ENVIRONMENT'] ?? $_ENV['GRAV_ENVIRONMENT'] ?? (getenv('GRAV_ENVIRONMENT') ?: null)));
 
         // If no environment is set, make sure we get one (CLI or hostname).
         if (null === $environment) {
@@ -204,7 +204,7 @@ class Setup extends Data
         // Pre-load setup.php which contains our initial configuration.
         // Configuration may contain dynamic parts, which is why we need to always load it.
         // If GRAV_SETUP_PATH has been defined, use it, otherwise use defaults.
-        $setupFile = defined('GRAV_SETUP_PATH') ? GRAV_SETUP_PATH : (getenv('GRAV_SETUP_PATH') ?: null);
+        $setupFile = defined('GRAV_SETUP_PATH') ? GRAV_SETUP_PATH : ($_SERVER['GRAV_SETUP_PATH'] ?? $_ENV['GRAV_SETUP_PATH'] ?? (getenv('GRAV_SETUP_PATH') ?: null));
         if (null !== $setupFile) {
             // Make sure that the custom setup file exists. Terminates the script if not.
             if (!str_starts_with((string) $setupFile, '/')) {
@@ -237,10 +237,10 @@ class Setup extends Data
         $this->def('environment', static::$environment);
 
         // Figure out path for the current environment.
-        $envPath = defined('GRAV_ENVIRONMENT_PATH') ? GRAV_ENVIRONMENT_PATH : (getenv('GRAV_ENVIRONMENT_PATH') ?: null);
+        $envPath = defined('GRAV_ENVIRONMENT_PATH') ? GRAV_ENVIRONMENT_PATH : ($_SERVER['GRAV_ENVIRONMENT_PATH'] ?? $_ENV['GRAV_ENVIRONMENT_PATH'] ?? (getenv('GRAV_ENVIRONMENT_PATH') ?: null));
         if (null === $envPath) {
             // Find common path for all environments and append current environment into it.
-            $envPath = defined('GRAV_ENVIRONMENTS_PATH') ? GRAV_ENVIRONMENTS_PATH : (getenv('GRAV_ENVIRONMENTS_PATH') ?: null);
+            $envPath = defined('GRAV_ENVIRONMENTS_PATH') ? GRAV_ENVIRONMENTS_PATH : ($_SERVER['GRAV_ENVIRONMENTS_PATH'] ?? $_ENV['GRAV_ENVIRONMENTS_PATH'] ?? (getenv('GRAV_ENVIRONMENTS_PATH') ?: null));
             if (null !== $envPath) {
                 $envPath .= '/';
             } else {

--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -204,17 +204,21 @@ class InitializeProcessor extends ProcessorBase
             }
         }
 
-        // Override configuration using the environment.
+        // Override configuration using the environment. The gate has to read
+        // exactly what the loop below reads: a SAPI that populates only
+        // $_SERVER (Apache SetEnv, nginx fastcgi_param) would otherwise skip
+        // the whole feature with nothing logged, and an empty value must fall
+        // through rather than shadow a working getenv(). (#4279)
         $prefix = 'GRAV_CONFIG';
-        $env = $_SERVER[$prefix] ?? $_ENV[$prefix] ?? (getenv($prefix) ?: null);
-        if ($env) {
+        $vars = $_ENV + $_SERVER;
+        if (!empty($vars[$prefix]) || getenv($prefix)) {
             $cPrefix = $prefix . '__';
             $aPrefix = $prefix . '_ALIAS__';
             $cLen = strlen($cPrefix);
             $aLen = strlen($aPrefix);
 
             $keys = $aliases = [];
-            $env = $_ENV + $_SERVER;
+            $env = $vars;
             foreach ($env as $key => $value) {
                 if (!str_starts_with((string) $key, $prefix)) {
                     continue;

--- a/system/src/Grav/Common/Processors/InitializeProcessor.php
+++ b/system/src/Grav/Common/Processors/InitializeProcessor.php
@@ -206,7 +206,7 @@ class InitializeProcessor extends ProcessorBase
 
         // Override configuration using the environment.
         $prefix = 'GRAV_CONFIG';
-        $env = getenv($prefix);
+        $env = $_SERVER[$prefix] ?? $_ENV[$prefix] ?? (getenv($prefix) ?: null);
         if ($env) {
             $cPrefix = $prefix . '__';
             $aPrefix = $prefix . '_ALIAS__';

--- a/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
+++ b/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
@@ -369,6 +369,7 @@ class InitializeProcessorTest extends \PHPUnit\Framework\TestCase
     public function testConfigOverrideAppliesWhenGravConfigIsOnlyInServer(): void
     {
         $original = $this->config->get('test.grav_config_4279');
+        $restoreServer = $this->stashServerVars(['GRAV_CONFIG', 'GRAV_CONFIG__test__grav_config_4279']);
 
         $_SERVER['GRAV_CONFIG'] = '1';
         $_SERVER['GRAV_CONFIG__test__grav_config_4279'] = 'from-server-only';
@@ -381,8 +382,64 @@ class InitializeProcessorTest extends \PHPUnit\Framework\TestCase
 
             self::assertSame('from-server-only', $this->config->get('test.grav_config_4279'));
         } finally {
-            unset($_SERVER['GRAV_CONFIG'], $_SERVER['GRAV_CONFIG__test__grav_config_4279']);
+            $restoreServer();
             $this->config->set('test.grav_config_4279', $original);
         }
+    }
+
+    /**
+     * A present-but-empty `$_SERVER['GRAV_CONFIG']` is what an unset nginx
+     * `fastcgi_param` or an empty Apache `SetEnv` leaves behind. The gate
+     * must fall through to `getenv()` in that case rather than treating the
+     * empty value as "GRAV_CONFIG is off".
+     */
+    public function testConfigOverrideFallsBackToGetenvWhenServerValueIsEmpty(): void
+    {
+        $original = $this->config->get('test.grav_config_4279');
+        $restoreServer = $this->stashServerVars(['GRAV_CONFIG', 'GRAV_CONFIG__test__grav_config_4279']);
+        $hadGetenv = getenv('GRAV_CONFIG');
+
+        $_SERVER['GRAV_CONFIG'] = '';
+        $_SERVER['GRAV_CONFIG__test__grav_config_4279'] = 'from-getenv-fallback';
+        putenv('GRAV_CONFIG=1');
+
+        try {
+            $processor = new InitializeProcessor($this->grav);
+            $method = new ReflectionMethod($processor, 'initializeConfig');
+            $method->setAccessible(true);
+            $method->invoke($processor);
+
+            self::assertSame('from-getenv-fallback', $this->config->get('test.grav_config_4279'));
+        } finally {
+            putenv($hadGetenv === false ? 'GRAV_CONFIG' : "GRAV_CONFIG={$hadGetenv}");
+            $restoreServer();
+            $this->config->set('test.grav_config_4279', $original);
+        }
+    }
+
+    /**
+     * Stashes the current value (or absence) of each `$_SERVER` key and
+     * returns a closure that restores exactly that state, instead of
+     * blindly unsetting keys a real request may already carry.
+     *
+     * @param list<string> $keys
+     * @return callable(): void
+     */
+    private function stashServerVars(array $keys): callable
+    {
+        $stash = [];
+        foreach ($keys as $key) {
+            $stash[$key] = [array_key_exists($key, $_SERVER), $_SERVER[$key] ?? null];
+        }
+
+        return static function () use ($stash): void {
+            foreach ($stash as $key => [$existed, $value]) {
+                if ($existed) {
+                    $_SERVER[$key] = $value;
+                } else {
+                    unset($_SERVER[$key]);
+                }
+            }
+        };
     }
 }

--- a/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
+++ b/tests/unit/Grav/Common/Processors/InitializeProcessorTest.php
@@ -355,4 +355,34 @@ class InitializeProcessorTest extends \PHPUnit\Framework\TestCase
             'an int is returned as-is' => [0, 0],
         ];
     }
+
+    /* ------------------------------------------------------------------ *
+     * The GRAV_CONFIG gate itself must not require getenv() (#4279).
+     *
+     * SAPIs such as Apache's SetEnv or nginx's fastcgi_param only populate
+     * $_SERVER, never the process environment getenv() reads, so a gate
+     * that checks getenv() alone silently drops every GRAV_CONFIG__*
+     * override for those setups even though the body one line below it
+     * already reads $_ENV + $_SERVER.
+     * ------------------------------------------------------------------ */
+
+    public function testConfigOverrideAppliesWhenGravConfigIsOnlyInServer(): void
+    {
+        $original = $this->config->get('test.grav_config_4279');
+
+        $_SERVER['GRAV_CONFIG'] = '1';
+        $_SERVER['GRAV_CONFIG__test__grav_config_4279'] = 'from-server-only';
+
+        try {
+            $processor = new InitializeProcessor($this->grav);
+            $method = new ReflectionMethod($processor, 'initializeConfig');
+            $method->setAccessible(true);
+            $method->invoke($processor);
+
+            self::assertSame('from-server-only', $this->config->get('test.grav_config_4279'));
+        } finally {
+            unset($_SERVER['GRAV_CONFIG'], $_SERVER['GRAV_CONFIG__test__grav_config_4279']);
+            $this->config->set('test.grav_config_4279', $original);
+        }
+    }
 }


### PR DESCRIPTION
The `GRAV_CONFIG` override gate in `InitializeProcessor::initializeConfig()` checks `getenv($prefix)`, but the body one line below already reads `$_ENV + $_SERVER`. On Apache with `SetEnv` or nginx with `fastcgi_param`, the variable lands in `$_SERVER` but never in the process environment `getenv()` reads, so the gate is false and the whole `GRAV_CONFIG__*` override feature does nothing — same failure mode as #4260/#4275.

`Setup.php` has the identical pattern for `GRAV_ENVIRONMENT`, `GRAV_SETUP_PATH`, `GRAV_ENVIRONMENT_PATH` and `GRAV_ENVIRONMENTS_PATH`.

`Env.php` already solves this correctly (`$_SERVER[$key] ?? $_ENV[$key] ?? (getenv($key) ?: null)`) and has its own test coverage proving the precedence. This PR applies the same fallback at all five call sites instead of inventing a new pattern.

Added a test that sets the override only in `$_SERVER` and drives the real `initializeConfig()` — confirmed it fails against the old code and passes against the fix. Ran the full `InitializeProcessorTest` and `EnvTest` suites after, both green (59 tests).

(Replaces #4285, which had the wrong commit author — closing that one.)

Fixes #4279
