### PR TITLE
Stop the page Content tab from shadowing the content field (#4271)

### DIFF
--- a/system/blueprints/pages/default.yaml
+++ b/system/blueprints/pages/default.yaml
@@ -16,7 +16,7 @@ form:
       active: 1
 
       fields:
-        content:
+        content_tab:
           type: tab
           title: PLUGIN_ADMIN.CONTENT
 

--- a/system/blueprints/pages/external.yaml
+++ b/system/blueprints/pages/external.yaml
@@ -13,7 +13,7 @@ form:
 
       fields:
 
-        content:
+        content_tab:
           fields:
 
             header.title:

--- a/system/blueprints/pages/modular.yaml
+++ b/system/blueprints/pages/modular.yaml
@@ -8,7 +8,7 @@ form:
       active: 1
 
       fields:
-        content:
+        content_tab:
           fields:
 
             modular_title:

--- a/tests/unit/Grav/Common/Data/PageBlueprintContentTest.php
+++ b/tests/unit/Grav/Common/Data/PageBlueprintContentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Codeception\Util\Fixtures;
+use Grav\Common\Data\Blueprint;
+
+/**
+ * Regression test for #4271: the Content tab and the markdown `content` field
+ * in the default page blueprint were both keyed `content`, so BlueprintSchema
+ * flattened them into the same slot and the tab (added after its own fields
+ * during parsing) always won, leaving the field's `validate` config
+ * unreachable.
+ */
+class PageBlueprintContentTest extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $grav = Fixtures::get('grav');
+        $grav();
+    }
+
+    public function testContentFieldIsNotShadowedByTab(): void
+    {
+        $blueprint = new Blueprint('default');
+        $blueprint->setContext('blueprints://pages');
+        $blueprint->load()->init();
+
+        $items = $blueprint->schema()->getState()['items'];
+
+        self::assertArrayHasKey('content', $items);
+        self::assertSame('markdown', $items['content']['type']);
+        self::assertSame('textarea', $items['content']['validate']['type'] ?? null);
+
+        self::assertArrayHasKey('content_tab', $items);
+        self::assertSame('tab', $items['content_tab']['type']);
+    }
+}


### PR DESCRIPTION
Fixes #4271

In `system/blueprints/pages/default.yaml`, the Content tab and the markdown content field are both keyed `content`. BlueprintSchema flattens every field into one map keyed by name, containers included, and it does this by writing the field's own entry after recursing into its children, so the tab's entry gets written last and wins. The markdown field's `validate` config sits in that map under `content` too, but it's never the one that gets read back, so it never actually runs.

I renamed the tab's key to `content_tab` and left the field's key alone, since `content` is the actual page body key used throughout Grav and themes and isn't safe to touch. `modular.yaml` and `external.yaml` both extend `default.yaml` and override that same tab by key, so I updated them to `content_tab` too. Otherwise their overrides would stop merging into the tab and would themselves collide with the content field the same way.

I checked how much this actually changes at runtime before assuming a rename alone was safe. `checkSafety()` (the XSS scan) already runs on this field today regardless of which rule wins, since it only skips fields typed `unset`, so no new XSS behavior gets switched on here. Type validation is the part that starts working, and the field already has `max: 0` set from #3643 to opt out of the length cap, so in practice this now only requires content to be a string, which is what a textarea always posts anyway.

Added a test that loads the real `pages/default.yaml` blueprint and asserts the flattened `content` item resolves to the markdown field's type and validate config rather than the tab's.

Ran the existing blueprint/data tests plus the full page test suite locally, all green, and confirmed the new test fails against the old blueprint (resolves to type `tab`) and passes with the fix.
