### PR TITLE
Fix date2timestamp() misparsing non-string dates (#3812)

### DIFF
--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -10,6 +10,7 @@
 namespace Grav\Common;
 
 use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use Grav\Common\Flex\Types\Pages\PageObject;
@@ -1465,13 +1466,24 @@ abstract class Utils
     /**
      * Get the timestamp of a date
      *
-     * @param string $date a String expressed in the system.pages.dateformat.default format, with fallback to a
-     *                     strtotime argument
+     * @param string|int|DateTimeInterface $date a String expressed in the system.pages.dateformat.default format,
+     *                     with fallback to a strtotime argument. An unquoted YAML date header (e.g. `date: 2022-01-06`)
+     *                     is parsed by the YAML component into an int timestamp or a DateTimeInterface rather than a
+     *                     string, so those are accepted directly instead of being coerced into strtotime(), which
+     *                     misparses a bare numeric string into a bogus date.
      * @param string|null $format a date format to use if possible
      * @return int the timestamp
      */
     public static function date2timestamp($date, $format = null)
     {
+        if ($date instanceof DateTimeInterface) {
+            return $date->getTimestamp();
+        }
+
+        if (is_int($date) || is_float($date)) {
+            return (int) $date;
+        }
+
         $config = Grav::instance()['config'];
         $dateformat = $format ?: $config->get('system.pages.dateformat.default');
 

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -1466,11 +1466,10 @@ abstract class Utils
     /**
      * Get the timestamp of a date
      *
-     * @param string|int|DateTimeInterface $date a String expressed in the system.pages.dateformat.default format,
-     *                     with fallback to a strtotime argument. An unquoted YAML date header (e.g. `date: 2022-01-06`)
-     *                     is parsed by the YAML component into an int timestamp or a DateTimeInterface rather than a
-     *                     string, so those are accepted directly instead of being coerced into strtotime(), which
-     *                     misparses a bare numeric string into a bogus date.
+     * @param string|int|float|DateTimeInterface $date a String expressed in the system.pages.dateformat.default
+     *                     format, with fallback to a strtotime argument. An unquoted YAML date header such as
+     *                     `date: 2022-01-06` never reaches us as a string: the YAML parser reads it as a date and
+     *                     hands over a Unix timestamp, which strtotime() then misreads as a year in the far future.
      * @param string|null $format a date format to use if possible
      * @return int the timestamp
      */
@@ -1481,7 +1480,15 @@ abstract class Utils
         }
 
         if (is_int($date) || is_float($date)) {
-            return (int) $date;
+            $date = (string) (int) $date;
+
+            // `date: 20220106` arrives as the number the author typed, and the
+            // parsing below already reads it correctly as a date, so only a
+            // number that cannot be one is treated as a timestamp.
+            $ymd = DateTime::createFromFormat('!Ymd', $date);
+            if ($ymd === false || $ymd->format('Ymd') !== $date) {
+                return (int) $date;
+            }
         }
 
         $config = Grav::instance()['config'];

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -320,15 +320,28 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
 
     public function testDate2timestampWithNonStringDate(): void
     {
-        // An unquoted YAML date header (e.g. `date: 2000-09-10`) is parsed by the YAML
-        // component into an int timestamp or a DateTimeInterface rather than a string.
-        // Passing that straight into strtotime() misparses it into a bogus date, so
-        // these need to be accepted directly instead.
+        // An unquoted YAML date header such as `date: 2000-09-10` never reaches
+        // us as a string: the YAML parser reads it as a date and hands over a
+        // Unix timestamp, which strtotime() then misreads as a year in the far
+        // future. Accept these directly instead. Fixes #3812.
         $timestamp = (new DateTime('2000-09-10 00:00:00'))->getTimestamp();
 
         self::assertSame($timestamp, Utils::date2timestamp($timestamp));
+        self::assertSame($timestamp, Utils::date2timestamp((float) $timestamp));
         self::assertSame($timestamp, Utils::date2timestamp(new DateTime('2000-09-10 00:00:00')));
         self::assertSame($timestamp, Utils::date2timestamp(new DateTimeImmutable('2000-09-10 00:00:00')));
+    }
+
+    public function testDate2timestampKeepsReadingBareNumericDates(): void
+    {
+        // `date: 20000910` is also an int by the time it arrives, but it is the
+        // number the author typed rather than a timestamp, and it has always
+        // been read correctly as a date. Treating every int as a timestamp
+        // would silently move these pages to 1970.
+        $timestamp = (new DateTime('2000-09-10 00:00:00'))->getTimestamp();
+
+        self::assertSame($timestamp, Utils::date2timestamp(20000910));
+        self::assertSame($timestamp, Utils::date2timestamp('20000910'));
     }
 
     public function testResolve(): void

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -318,6 +318,19 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         self::assertSame($timestamp, Utils::date2timestamp('2000-09-10 00:00:00'));
     }
 
+    public function testDate2timestampWithNonStringDate(): void
+    {
+        // An unquoted YAML date header (e.g. `date: 2000-09-10`) is parsed by the YAML
+        // component into an int timestamp or a DateTimeInterface rather than a string.
+        // Passing that straight into strtotime() misparses it into a bogus date, so
+        // these need to be accepted directly instead.
+        $timestamp = (new DateTime('2000-09-10 00:00:00'))->getTimestamp();
+
+        self::assertSame($timestamp, Utils::date2timestamp($timestamp));
+        self::assertSame($timestamp, Utils::date2timestamp(new DateTime('2000-09-10 00:00:00')));
+        self::assertSame($timestamp, Utils::date2timestamp(new DateTimeImmutable('2000-09-10 00:00:00')));
+    }
+
     public function testResolve(): void
     {
         $array = [


### PR DESCRIPTION
Fixes #3812.

Turns out the reported behavior is worse than "falls back to today's date". An unquoted YAML date header like `date: 2022-01-06` gets parsed by the YAML component as an int timestamp, not a string, since it looks like an ISO date. `Utils::date2timestamp()` only handled string input: `DateTime::createFromFormat()` fails silently on the int (PHP coerces it to the string `"1641427200"`, which doesn't match the `Y-m-d` format), and the `strtotime()` fallback then misparses that same numeric string into a nonsense timestamp - I checked, it lands on the year 7200, not "now".

Quoting the date in frontmatter (`date: "2022-01-06"`) sidesteps it because then it really is a string, which matches what the two "working" formats in the issue have in common.

Fix is to short-circuit `date2timestamp()` for int/float and `DateTimeInterface` input before it reaches the string-based parsing branches. Added a test alongside the existing `testDate2timestamp()` covering an int timestamp, a `DateTime`, and a `DateTimeImmutable`. Ran the full `UtilsTest` suite locally, all 36 tests green.
