### PR TITLE
Allow overriding html/json/xml/atom/rss content types via media.types (#3735)

### DIFF
--- a/system/config/media.yaml
+++ b/system/config/media.yaml
@@ -104,6 +104,14 @@ types:
     type: file
     thumb: media/thumb-xml.png
     mime: application/xml
+  atom:
+    type: file
+    thumb: media/thumb-xml.png
+    mime: application/atom+xml
+  rss:
+    type: file
+    thumb: media/thumb-rss.png
+    mime: application/rss+xml
   doc:
     type: file
     thumb: media/thumb-doc.png

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -932,10 +932,19 @@ abstract class Utils
     {
         $extension = strtolower($extension);
 
-        // look for some standard types
+        if ($extension === '') {
+            return $default;
+        }
+
+        // media.types (which a site can override) takes precedence over the built-in defaults
+        $media_types = Grav::instance()['config']->get('media.types');
+        $mime = $media_types[$extension]['mime'] ?? null;
+        if ($mime) {
+            return $mime;
+        }
+
+        // fallback for a few standard types not present in media.types
         switch ($extension) {
-            case null:
-                return $default;
             case 'json':
                 return 'application/json';
             case 'html':
@@ -948,9 +957,7 @@ abstract class Utils
                 return 'application/xml';
         }
 
-        $media_types = Grav::instance()['config']->get('media.types');
-
-        return $media_types[$extension]['mime'] ?? $default;
+        return $default;
     }
 
     /**

--- a/system/src/Grav/Common/Utils.php
+++ b/system/src/Grav/Common/Utils.php
@@ -943,7 +943,8 @@ abstract class Utils
             return $mime;
         }
 
-        // fallback for a few standard types not present in media.types
+        // fallback if media.types is missing one of these standard entries entirely
+        // (e.g. a site config that replaces media.yaml wholesale instead of merging)
         switch ($extension) {
             case 'json':
                 return 'application/json';

--- a/tests/unit/Grav/Common/UtilsTest.php
+++ b/tests/unit/Grav/Common/UtilsTest.php
@@ -221,6 +221,15 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('text/html', Utils::getMimeByExtension('foo', 'text/html'));
     }
 
+    public function testGetMimeByExtensionHonorsMediaTypesOverride(): void
+    {
+        $this->grav['config']->set('media.types.rss.mime', 'application/xml; charset=utf-8');
+
+        self::assertEquals('application/xml; charset=utf-8', Utils::getMimeByExtension('rss'));
+        // untouched types are unaffected
+        self::assertEquals('application/atom+xml', Utils::getMimeByExtension('atom'));
+    }
+
     public function testGetExtensionByMime(): void
     {
         self::assertEquals('html', Utils::getExtensionByMime('*/*'));


### PR DESCRIPTION
Closes #3735.

`Utils::getMimeByExtension()` hardcoded the mime type for `html`, `json`, `xml`, `atom` and `rss` in a switch statement, checked before the `media.types` config was ever consulted. Every other extension already falls through to `media.types`, so a site could override, say, `doc`'s mime type, but not `html`'s or `xml`'s — even though both already exist as regular entries in `media.yaml` with the exact same value the switch hardcoded.

Flipped the order: `media.types` is checked first now, and the switch is just the fallback for `atom`/`rss`, which weren't registered as media types at all before this. Added them to `media.yaml` following the existing `xml`/`json`/`html` pattern (type: file, a thumb icon, the same mime values as before), so they're overridable too.

No behavior change for anyone not overriding these five in `media.types` - the switch's values and the config's values are identical today. Added a test covering the override case (`media.types.rss.mime` in config actually takes effect), alongside the existing `testGetMimeByExtension` which still passes unchanged.
