### PR TITLE
Fix custom_base_url matching pages by literal prefix instead of path segment

### DIFF
--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -193,7 +193,13 @@ class Uri implements \Stringable
 
         $this->url = $this->base . $this->uri;
 
-        $uri = Utils::replaceFirstOccurrence(static::filterPath($this->root), '', $this->url);
+        $root = static::filterPath($this->root);
+        $root_prefix = Utils::endsWith($root, '/') ? $root : $root . '/';
+        if ($this->url === $root || Utils::startsWith($this->url, $root_prefix)) {
+            $uri = Utils::replaceFirstOccurrence($root, '', $this->url);
+        } else {
+            $uri = Utils::replaceFirstOccurrence($this->base, '', $this->url);
+        }
 
         // remove the setup.php based base if set:
         $setup_base = $grav['pages']->base();

--- a/system/src/Grav/Common/Uri.php
+++ b/system/src/Grav/Common/Uri.php
@@ -193,10 +193,14 @@ class Uri implements \Stringable
 
         $this->url = $this->base . $this->uri;
 
-        $root = static::filterPath($this->root);
-        $root_prefix = Utils::endsWith($root, '/') ? $root : $root . '/';
-        if ($this->url === $root || Utils::startsWith($this->url, $root_prefix)) {
-            $uri = Utils::replaceFirstOccurrence($root, '', $this->url);
+        // Strip the root only where it ends a path segment. A raw prefix match made a
+        // custom base of `/act` also match `/action-bar`, leaving `ion-bar` (#3057). The
+        // query string is part of $this->url, so `?` ends the root too, and a request
+        // that is not under the root at all keeps its path relative to the site's base.
+        $root = rtrim(static::filterPath($this->root), '/');
+        $next = substr($this->url, strlen($root), 1);
+        if (str_starts_with($this->url, $root) && ($next === '' || strpbrk($next, '/?#') !== false)) {
+            $uri = substr($this->url, strlen($root));
         } else {
             $uri = Utils::replaceFirstOccurrence($this->base, '', $this->url);
         }

--- a/tests/unit/Grav/Common/UriTest.php
+++ b/tests/unit/Grav/Common/UriTest.php
@@ -1255,4 +1255,42 @@ class UriTest extends \PHPUnit\Framework\TestCase
 
         $this->config->set('system.custom_base_url', $current_base);
     }
+
+    /**
+     * @dataProvider customBaseBoundaryProvider
+     */
+    public function testCustomBaseBoundary(string $custom_base, string $root_path, string $url, string $path, string $query, string $route): void
+    {
+        $current_base = $this->config->get('system.custom_base_url');
+        $this->config->set('system.custom_base_url', $custom_base);
+        $this->uri->initializeWithUrlAndRootPath($url, $root_path)->init();
+
+        $this->assertSame($path, $this->uri->path());
+        $this->assertSame($query, $this->uri->query());
+        $this->assertSame($route, $this->uri->route());
+
+        $this->config->set('system.custom_base_url', $current_base);
+    }
+
+    public static function customBaseBoundaryProvider(): array
+    {
+        return [
+            // the home page with a query string stays the home page
+            'custom base home with query' => ['/act', '', 'https://example.com/act?page=2', '', 'page=2', '/'],
+            'custom base home, slash and query' => ['/act', '', 'https://example.com/act/?page=2', '/', 'page=2', '/'],
+            'full custom base home with query' => ['https://public.example.org/act', '', 'https://example.com/act?page=2', '', 'page=2', '/'],
+            'subfolder home with query' => ['', '/sub', 'https://example.com/sub?x=1', '', 'x=1', '/'],
+            'subfolder and custom base home with query' => ['/act', '/grav', 'https://example.com/grav?x=1', '', 'x=1', '/'],
+            // pages under the base lose the base
+            'custom base page' => ['/act', '', 'https://example.com/act/foo?x=1', '/foo', 'x=1', '/foo'],
+            'subfolder page' => ['', '/sub', 'https://example.com/sub/foo', '/foo', '', '/foo'],
+            // a page that only starts with the same letters keeps its name
+            'custom base prefix collision' => ['/act', '', 'https://example.com/action-bar', '/action-bar', '', '/action-bar'],
+            'custom base prefix collision with query' => ['/act', '', 'https://example.com/action-bar?x=1', '/action-bar', 'x=1', '/action-bar'],
+            'custom base with trailing slash' => ['/act/', '', 'https://example.com/action-bar', '/action-bar', '', '/action-bar'],
+            'full custom base prefix collision' => ['https://public.example.org/act', '', 'https://example.com/action-bar', '/action-bar', '', '/action-bar'],
+            // a proxy that already removed the base
+            'custom base already stripped' => ['/act', '', 'https://example.com/foo', '/foo', '', '/foo'],
+        ];
+    }
 }

--- a/tests/unit/Grav/Common/UriTest.php
+++ b/tests/unit/Grav/Common/UriTest.php
@@ -1244,4 +1244,15 @@ class UriTest extends \PHPUnit\Framework\TestCase
 
         $this->config->set('system.custom_base_url', $current_base);
     }
+
+    public function testCustomBasePrefixCollision(): void
+    {
+        $current_base = $this->config->get('system.custom_base_url');
+        $this->config->set('system.custom_base_url', '/test');
+        $this->uri->initializeWithURL('https://mydomain.example.com:8090/testing/foo')->init();
+
+        $this->assertSame('/testing/foo', $this->uri->toArray()['path']);
+
+        $this->config->set('system.custom_base_url', $current_base);
+    }
 }


### PR DESCRIPTION
`Uri::init()` strips the custom base from the request URL with a raw substring search (`Utils::replaceFirstOccurrence`), no path-segment boundary check. So a `custom_base_url` of `/act` matches the start of `/action-bar` as plain text, and the strip turns it into `ion-bar` — any page whose name happens to start with the same letters as the base 404s.

`InitializeProcessor::pathHasBase()` already does the correct, boundary-aware comparison for a related case (added for #3822), with a docblock calling out this exact failure mode by name — this is the surviving instance of the same bug in `Uri::init()`.

Fix checks that the root is followed by `/` (or matches exactly) before stripping it. When a request doesn't genuinely fall under the custom base, it falls back to stripping just the site's own base instead — the same result as if no custom_base_url were configured for that request, which is what makes the page findable again rather than leaving the host/port in the path.

Added a regression test alongside the existing `testCustomBase()` in `UriTest.php`.

Fixes #3057
