### PR TITLE
Bypass js_pipeline for the Clockwork debugger script (#3871)

### DIFF
--- a/system/src/Grav/Common/Debugger.php
+++ b/system/src/Grav/Common/Debugger.php
@@ -667,7 +667,8 @@ class Debugger
                 $assets->addCss('/system/assets/debugger/clockwork.css');
                 $assets->addJs('/system/assets/debugger/clockwork.js', [
                     'id' => 'clockwork-script',
-                    'data-route' => $route
+                    'data-route' => $route,
+                    'pipeline' => false
                 ]);
             }
 

--- a/tests/unit/Grav/Common/AssetsTest.php
+++ b/tests/unit/Grav/Common/AssetsTest.php
@@ -3,6 +3,7 @@
 use Codeception\Util\Fixtures;
 use Grav\Common\Grav;
 use Grav\Common\Assets;
+use Grav\Common\Page\Page;
 
 /**
  * Class AssetsTest
@@ -585,6 +586,31 @@ class AssetsTest extends \PHPUnit\Framework\TestCase
         $this->assets->add('/system/assets/debugger/phpdebugbar', null, true);
         $css = $this->assets->css();
         self::assertMatchesRegularExpression('#<link href=\"\/assets\/(.*).css\" type=\"text\/css\" rel=\"stylesheet\">#', $css);
+    }
+
+    public function testClockworkScriptBypassesPipeline(): void
+    {
+        $this->assets->reset();
+        $this->assets->setJsPipeline(true);
+        $this->assets->addJs('/system/assets/jquery/jquery-3.x.min.js');
+
+        $this->grav['config']->set('system.debugger.enabled', true);
+        $this->grav['config']->set('system.debugger.provider', 'clockwork');
+        $page = new Page();
+        $page->templateFormat('html');
+        $this->grav['page'] = $page;
+
+        $debugger = $this->grav['debugger'];
+        $debugger->init();
+        $debugger->addAssets();
+
+        $js = $this->assets->js();
+
+        self::assertMatchesRegularExpression(
+            '#<script\b(?=[^>]*\bsrc="/system/assets/debugger/clockwork\.js")(?=[^>]*\bid="clockwork-script")(?=[^>]*\bdata-route="https://github\.com/getgrav/grav-plugin-clockwork-web")[^>]*></script>#',
+            $js
+        );
+        self::assertMatchesRegularExpression('#<script src="/assets/[a-f0-9]+\.js"></script>#', $js);
     }
 
     public function testPipelineWithTimestamp(): void


### PR DESCRIPTION
When `assets.js_pipeline` is enabled, `clockwork.js` gets swept into the combined pipelined `<script>` tag along with every other JS asset. The pipeline merge only carries over the `loading` attribute across assets, so the `id="clockwork-script"` and `data-route` attributes this particular script depends on get dropped once it's merged. The client script does `document.getElementById('clockwork-script')` and just logs a console error and bails when that id isn't there, so the Clockwork badge silently never shows up with `js_pipeline: true` - reproduces exactly as described in the issue.

The fix is small: pass `'pipeline' => false` alongside the existing `id`/`data-route` options when `Debugger::addAssets()` registers `clockwork.js`, so this one script always renders as its own standalone tag no matter the pipeline setting. Nothing else about pipelining changes.

Added a regression test in `AssetsTest` that turns `js_pipeline` on, adds another JS asset so there's something to actually pipeline, then runs the real `Debugger::addAssets()` + `Assets::js()` path and asserts the clockwork script still comes out as its own tag with `id="clockwork-script"` and the right `data-route`, while the other asset gets pipelined normally. Confirmed it fails against the current code (asset gets merged, no id) and passes after the fix.

Closes #3871